### PR TITLE
Fix N_PCI is not assessed on first byte of raw_data

### DIFF
--- a/tests/software_tests/messages/test_uds_packet.py
+++ b/tests/software_tests/messages/test_uds_packet.py
@@ -1,21 +1,8 @@
 import pytest
 from mock import Mock, patch
 
-from uds.messages.uds_packet import AbstractUdsPacket, AbstractUdsPacketType, AbstractUdsPacketRecord, get_raw_packet_type, \
+from uds.messages.uds_packet import AbstractUdsPacket, AbstractUdsPacketType, AbstractUdsPacketRecord, \
     AddressingType, NibbleEnum, ValidatedEnum, ExtendableEnum, TransmissionDirection, ReassignmentError
-
-
-class TestFunctions:
-    """Tests for helper functions in the package."""
-
-    @pytest.mark.parametrize("raw_data, expected_result", [
-        ([0x12], 0x1),
-        ([0x00, 0x11, 0x22, 0x33], 0x0),
-        ((0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10), 0xF),
-        ((0xA5, 0x55, 0x33), 0xA),
-    ])
-    def test_get_raw_packet_type(self, raw_data, expected_result):
-        assert get_raw_packet_type(raw_data) == expected_result
 
 
 class TestAbstractPacketType:
@@ -43,13 +30,10 @@ class TestAbstractUdsPacket:
         self.mock_validate_raw_bytes = self._patcher_validate_raw_bytes.start()
         self._patcher_validate_addressing_type = patch(f"{self.SCRIPT_LOCATION}.AddressingType.validate_member")
         self.mock_validate_addressing_type = self._patcher_validate_addressing_type.start()
-        self._patcher_get_raw_packet_type = patch(f"{self.SCRIPT_LOCATION}.get_raw_packet_type")
-        self.mock_get_raw_packet_type = self._patcher_get_raw_packet_type.start()
 
     def teardown(self):
         self._patcher_validate_raw_bytes.stop()
         self._patcher_validate_addressing_type.stop()
-        self._patcher_get_raw_packet_type.stop()
 
     # __init__
 
@@ -97,15 +81,6 @@ class TestAbstractUdsPacket:
         self.mock_abstract_packet._AbstractUdsPacket__addressing = "some value"
         self.test_addressing__set_instance(example_addressing_type=example_addressing_type)
 
-    # packet_type
-
-    def test_packet_type__get(self, example_raw_bytes):
-        self.mock_abstract_packet.raw_data = example_raw_bytes
-        assert AbstractUdsPacket.packet_type.fget(self=self.mock_abstract_packet) \
-               is self.mock_abstract_packet.packet_type_enum.return_value
-        self.mock_get_raw_packet_type.assert_called_once_with(example_raw_bytes)
-        self.mock_abstract_packet.packet_type_enum.assert_called_once_with(self.mock_get_raw_packet_type.return_value)
-
 
 class TestAbstractUdsPacketRecord:
     """Tests for 'AbstractUdsPacketRecord' class."""
@@ -117,8 +92,6 @@ class TestAbstractUdsPacketRecord:
         # patching
         self._patcher_validate_direction = patch(f"{self.SCRIPT_LOCATION}.TransmissionDirection.validate_member")
         self.mock_validate_direction = self._patcher_validate_direction.start()
-        self._patcher_get_raw_packet_type = patch(f"{self.SCRIPT_LOCATION}.get_raw_packet_type")
-        self.mock_get_raw_packet_type = self._patcher_get_raw_packet_type.start()
 
     def teardown(self):
         self._patcher_validate_direction.stop()
@@ -179,12 +152,3 @@ class TestAbstractUdsPacketRecord:
             AbstractUdsPacketRecord.direction.fset(self=self.mock_packet_record, value=new_value)
         assert self.mock_packet_record._AbstractUdsPacketRecord__direction == old_value
         self.mock_validate_direction.assert_not_called()
-
-    # packet_type
-
-    def test_packet_type__get(self, example_raw_bytes):
-        self.mock_packet_record.raw_data = example_raw_bytes
-        assert AbstractUdsPacketRecord.packet_type.fget(self=self.mock_packet_record) \
-               is self.mock_packet_record.packet_type_enum.return_value
-        self.mock_get_raw_packet_type.assert_called_once_with(example_raw_bytes)
-        self.mock_packet_record.packet_type_enum.assert_called_once_with(self.mock_get_raw_packet_type.return_value)

--- a/uds/messages/__init__.py
+++ b/uds/messages/__init__.py
@@ -11,7 +11,7 @@ It provides tools for:
  - addressing types definition
 """
 
-from .uds_packet import AbstractUdsPacketType, AbstractUdsPacket, AbstractUdsPacketRecord, get_raw_packet_type
+from .uds_packet import AbstractUdsPacketType, AbstractUdsPacket, AbstractUdsPacketRecord
 from .uds_message import UdsMessage, UdsMessageRecord
 from .service_identifiers import RequestSID, ResponseSID, POSSIBLE_REQUEST_SIDS, POSSIBLE_RESPONSE_SIDS, \
     UnrecognizedSIDWarning

--- a/uds/messages/uds_packet.py
+++ b/uds/messages/uds_packet.py
@@ -79,7 +79,7 @@ class AbstractUdsPacket(ABC):
     @property  # noqa: F841
     @abstractmethod
     def packet_type(self) -> AbstractUdsPacketType:
-        """UDS packet type value - N_PCI value."""
+        """UDS packet type value - N_PCI value of this N_PDU."""
 
 
 class AbstractUdsPacketRecord(ABC):
@@ -174,7 +174,7 @@ class AbstractUdsPacketRecord(ABC):
     @property  # noqa: F841
     @abstractmethod
     def packet_type(self) -> AbstractUdsPacketType:
-        """UDS packet type value - N_PCI value."""
+        """UDS packet type value - N_PCI value of this N_PDU."""
 
 
 PacketsRecordsTuple = Tuple[AbstractUdsPacketRecord, ...]

--- a/uds/messages/uds_packet.py
+++ b/uds/messages/uds_packet.py
@@ -5,28 +5,16 @@ UDS Packets are defined on middle layers of UDS OSI Model.
 """
 
 __all__ = ["AbstractUdsPacketType", "AbstractUdsPacket", "AbstractUdsPacketRecord",
-           "PacketsRecordsTuple", "PacketsRecordsSequence",
-           "get_raw_packet_type"]
+           "PacketsRecordsTuple", "PacketsRecordsSequence"]
 
 from abc import ABC, abstractmethod
 from typing import Union, Tuple, List, Any
 
 from uds.utilities import NibbleEnum, ValidatedEnum, ExtendableEnum, \
-    RawByte, RawBytes, RawBytesTuple, validate_raw_bytes,\
+    RawBytes, RawBytesTuple, validate_raw_bytes,\
     ReassignmentError, TimeStamp
 from .transmission_attributes import AddressingMemberTyping, AddressingType, \
     TransmissionDirection, DirectionMemberTyping
-
-
-def get_raw_packet_type(packet_raw_data: RawBytes) -> RawByte:
-    """
-    Get raw value of packet type (N_PCI).
-
-    :param packet_raw_data: Raw data of UDS packet.
-
-    :return: Raw value of packet type (N_PCI).
-    """
-    return (packet_raw_data[0] >> 4) & 0xF  # TODO: make sure that this is valid for all bus types
 
 
 class AbstractUdsPacketType(NibbleEnum, ValidatedEnum, ExtendableEnum):
@@ -83,15 +71,15 @@ class AbstractUdsPacket(ABC):
         AddressingType.validate_member(value)
         self.__addressing = AddressingType(value)
 
-    @property
+    @property  # noqa: F841
     @abstractmethod
     def packet_type_enum(self) -> type:
-        """Get enum with possible UDS packet types."""
+        """Enum with possible UDS packet types."""
 
     @property  # noqa: F841
+    @abstractmethod
     def packet_type(self) -> AbstractUdsPacketType:
-        """Type of UDS packet - N_PCI value of this N_PDU."""
-        return self.packet_type_enum(get_raw_packet_type(self.raw_data))
+        """UDS packet type value - N_PCI value."""
 
 
 class AbstractUdsPacketRecord(ABC):
@@ -178,15 +166,15 @@ class AbstractUdsPacketRecord(ABC):
     def transmission_time(self) -> TimeStamp:
         """Time stamp when this packet was fully transmitted on a bus."""
 
-    @property
+    @property  # noqa: F841
     @abstractmethod
     def packet_type_enum(self) -> type:
-        """Get enum with possible UDS packet types."""
+        """Enum with possible UDS packet types."""
 
     @property  # noqa: F841
+    @abstractmethod
     def packet_type(self) -> AbstractUdsPacketType:
-        """Type of UDS packet - N_PCI value carried by this N_PDU."""
-        return self.packet_type_enum(get_raw_packet_type(self.raw_data))
+        """UDS packet type value - N_PCI value."""
 
 
 PacketsRecordsTuple = Tuple[AbstractUdsPacketRecord, ...]


### PR DESCRIPTION
## Description
- Get rid of `get_raw_packet_type` function.


## How Has This Been Tested?
- unit tests
- static code analysis


## Process
<!--- If you are familiar with the process, leave the line below. If not, please describe what you did, so we could help you deliver your changed according to our quality policies -->
I know the [process](https://github.com/mdabrowski1990/uds/wiki/Software-Development-Life-Cycle) and did my best to follow it
