### PR TITLE
Common abstraction

### DIFF
--- a/tests/software_tests/message/test_uds_message.py
+++ b/tests/software_tests/message/test_uds_message.py
@@ -57,10 +57,10 @@ class TestUdsMessage:
     @pytest.mark.parametrize("value", [None, [0x1, 0x02], "some message"])
     def test_payload__get(self, value):
         self.mock_uds_message._UdsMessage__payload = value
-        assert UdsMessage.payload.fget(self=self.mock_uds_message) is value
+        assert UdsMessage.payload.fget(self.mock_uds_message) is value
 
     def test_payload__set(self, example_raw_bytes):
-        UdsMessage.payload.fset(self=self.mock_uds_message, value=example_raw_bytes)
+        UdsMessage.payload.fset(self.mock_uds_message, value=example_raw_bytes)
         assert self.mock_uds_message._UdsMessage__payload == tuple(example_raw_bytes)
         self.mock_validate_raw_bytes.assert_called_once_with(example_raw_bytes)
 
@@ -73,10 +73,10 @@ class TestUdsMessage:
     @pytest.mark.parametrize("value", [None, AddressingType.PHYSICAL, "some addressing"])
     def test_addressing_type__get(self, value):
         self.mock_uds_message._UdsMessage__addressing_type = value
-        assert UdsMessage.addressing_type.fget(self=self.mock_uds_message) is value
+        assert UdsMessage.addressing_type.fget(self.mock_uds_message) is value
 
     def test_addressing_type__set(self, example_addressing_type):
-        UdsMessage.addressing_type.fset(self=self.mock_uds_message, value=example_addressing_type)
+        UdsMessage.addressing_type.fset(self.mock_uds_message, value=example_addressing_type)
         assert self.mock_uds_message._UdsMessage__addressing_type == example_addressing_type
         self.mock_validate_addressing.assert_called_once_with(example_addressing_type)
 
@@ -162,7 +162,7 @@ class TestUdsMessageRecord:
     ])
     def test_payload__get(self, packets):
         self.mock_uds_message_record.packets_records = packets
-        payload = UdsMessageRecord.payload.fget(self=self.mock_uds_message_record)
+        payload = UdsMessageRecord.payload.fget(self.mock_uds_message_record)
         assert isinstance(payload, tuple)
         assert len(payload) == self.mock_uds_message_record.packets_records[0].data_length
 
@@ -179,7 +179,7 @@ class TestUdsMessageRecord:
         "abcdefg"
     ])
     def test_packets_records__set__first_call(self, packets_records):
-        UdsMessageRecord.packets_records.fset(self=self.mock_uds_message_record, value=packets_records)
+        UdsMessageRecord.packets_records.fset(self.mock_uds_message_record, value=packets_records)
         assert self.mock_uds_message_record._UdsMessageRecord__packets_records == tuple(packets_records)
         self.mock_uds_message_record._UdsMessageRecord__validate_packets_records.assert_called_once_with(packets_records)
 
@@ -188,7 +188,7 @@ class TestUdsMessageRecord:
     def test_packets_records__set__second_call(self, old_value, new_value):
         self.mock_uds_message_record._UdsMessageRecord__packets_records = old_value
         with pytest.raises(ReassignmentError):
-            UdsMessageRecord.packets_records.fset(self=self.mock_uds_message_record, value=new_value)
+            UdsMessageRecord.packets_records.fset(self.mock_uds_message_record, value=new_value)
         assert self.mock_uds_message_record._UdsMessageRecord__packets_records == old_value
         self.mock_uds_message_record._UdsMessageRecord__validate_packets_records.assert_not_called()
 
@@ -201,7 +201,7 @@ class TestUdsMessageRecord:
     ])
     def test_addressing_type__get(self, packets_records):
         self.mock_uds_message_record.packets_records = packets_records
-        assert UdsMessageRecord.addressing_type.fget(self=self.mock_uds_message_record) == packets_records[0].addressing_type
+        assert UdsMessageRecord.addressing_type.fget(self.mock_uds_message_record) == packets_records[0].addressing_type
 
     # direction
 
@@ -212,7 +212,7 @@ class TestUdsMessageRecord:
     ])
     def test_direction__get(self, packets_records):
         self.mock_uds_message_record.packets_records = packets_records
-        assert UdsMessageRecord.direction.fget(self=self.mock_uds_message_record) == packets_records[0].direction
+        assert UdsMessageRecord.direction.fget(self.mock_uds_message_record) == packets_records[0].direction
 
     # transmission_start
 
@@ -224,7 +224,7 @@ class TestUdsMessageRecord:
     ])
     def test_transmission_start__get(self, packets_records):
         self.mock_uds_message_record.packets_records = packets_records
-        assert UdsMessageRecord.transmission_start.fget(self=self.mock_uds_message_record) \
+        assert UdsMessageRecord.transmission_start.fget(self.mock_uds_message_record) \
                == packets_records[0].transmission_time
 
     # transmission_end
@@ -237,5 +237,5 @@ class TestUdsMessageRecord:
     ])
     def test_transmission_end__get(self, packets_records):
         self.mock_uds_message_record.packets_records = packets_records
-        assert UdsMessageRecord.transmission_end.fget(self=self.mock_uds_message_record) \
+        assert UdsMessageRecord.transmission_end.fget(self.mock_uds_message_record) \
                == packets_records[-1].transmission_time

--- a/tests/software_tests/packet/test_abstract_can_packet_container.py
+++ b/tests/software_tests/packet/test_abstract_can_packet_container.py
@@ -1,0 +1,289 @@
+import pytest
+from mock import Mock, patch
+
+from uds.packet.abstract_can_packet_container import AbstractCanPacketContainer, \
+    CanAddressingInformationHandler, CanPacketType
+from uds.transmission_attributes import AddressingType
+
+
+class TestAbstractCanPacketContainer:
+    """Unit tests for 'AbstractCanPacketContainer' class."""
+
+    SCRIPT_LOCATION = "uds.packet.abstract_can_packet_container"
+
+    def setup(self):
+        self.mock_can_packet_container = Mock(spec=AbstractCanPacketContainer)
+        mock_ai_handler_class = Mock(ADDRESSING_TYPE_NAME=CanAddressingInformationHandler.ADDRESSING_TYPE_NAME,
+                                     TARGET_ADDRESS_NAME=CanAddressingInformationHandler.TARGET_ADDRESS_NAME,
+                                     SOURCE_ADDRESS_NAME=CanAddressingInformationHandler.SOURCE_ADDRESS_NAME,
+                                     ADDRESS_EXTENSION_NAME=CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME)
+        mock_can_packet_type_class = Mock(SINGLE_FRAME=CanPacketType.SINGLE_FRAME,
+                                          FIRST_FRAME=CanPacketType.FIRST_FRAME,
+                                          CONSECUTIVE_FRAME=CanPacketType.CONSECUTIVE_FRAME,
+                                          FLOW_CONTROL=CanPacketType.FLOW_CONTROL)
+        # patching
+        self._patcher_ai_handler_class = patch(f"{self.SCRIPT_LOCATION}.CanAddressingInformationHandler",
+                                               mock_ai_handler_class)
+        self.mock_ai_handler_class = self._patcher_ai_handler_class.start()
+        self._patcher_can_dlc_handler_class = patch(f"{self.SCRIPT_LOCATION}.CanDlcHandler")
+        self.mock_can_dlc_handler_class = self._patcher_can_dlc_handler_class.start()
+        self._patcher_single_frame_handler_class = patch(f"{self.SCRIPT_LOCATION}.CanSingleFrameHandler")
+        self.mock_single_frame_handler_class = self._patcher_single_frame_handler_class.start()
+        self._patcher_first_frame_handler_class = patch(f"{self.SCRIPT_LOCATION}.CanFirstFrameHandler")
+        self.mock_first_frame_handler_class = self._patcher_first_frame_handler_class.start()
+        self._patcher_consecutive_frame_handler_class = patch(f"{self.SCRIPT_LOCATION}.CanConsecutiveFrameHandler")
+        self.mock_consecutive_frame_handler_class = self._patcher_consecutive_frame_handler_class.start()
+        self._patcher_flow_control_handler_class = patch(f"{self.SCRIPT_LOCATION}.CanFlowControlHandler")
+        self.mock_flow_control_handler_class = self._patcher_flow_control_handler_class.start()
+        self._patcher_can_packet_type_class = patch(f"{self.SCRIPT_LOCATION}.CanPacketType", mock_can_packet_type_class)
+        self.mock_can_packet_type_class = self._patcher_can_packet_type_class.start()
+
+    def teardown(self):
+        self._patcher_ai_handler_class.stop()
+        self._patcher_can_dlc_handler_class.stop()
+        self._patcher_single_frame_handler_class.stop()
+        self._patcher_first_frame_handler_class.stop()
+        self._patcher_consecutive_frame_handler_class.stop()
+        self._patcher_flow_control_handler_class.stop()
+        self._patcher_can_packet_type_class.stop()
+
+    # dlc
+
+    @pytest.mark.parametrize("raw_frame_data", ["some raw data", list(range(2))])
+    def test_dlc__get(self, raw_frame_data):
+        self.mock_can_packet_container.raw_frame_data = raw_frame_data
+        assert AbstractCanPacketContainer.dlc.fget(self.mock_can_packet_container) \
+               == self.mock_can_dlc_handler_class.encode_dlc.return_value
+        self.mock_can_dlc_handler_class.encode_dlc.assert_called_once_with(len(raw_frame_data))
+
+    # packet_type
+
+    @pytest.mark.parametrize("ai_data_bytes_number, raw_frame_data", [
+        (0, [0x2F]),
+        (1, [0x12, 0x34, 0x45]),
+    ])
+    def test_packet_type__get(self, ai_data_bytes_number, raw_frame_data):
+        self.mock_ai_handler_class.get_ai_data_bytes_number.return_value = ai_data_bytes_number
+        self.mock_can_packet_container.raw_frame_data = raw_frame_data
+        assert AbstractCanPacketContainer.packet_type.fget(self.mock_can_packet_container) \
+               == self.mock_can_packet_type_class.return_value
+        self.mock_ai_handler_class.get_ai_data_bytes_number.assert_called_once_with(
+            self.mock_can_packet_container.addressing_format)
+        self.mock_can_packet_type_class.assert_called_once_with(raw_frame_data[ai_data_bytes_number] >> 4)
+
+    # target_address
+
+    @pytest.mark.parametrize("ai_info", [
+        {
+            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: "TA",
+            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: "SA",
+            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: "AE",
+            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: "Addressing",
+        },
+        {
+            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: 0xF9,
+            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: 0xE8,
+            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: None,
+            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: AddressingType.FUNCTIONAL,
+        }
+    ])
+    def test_target_address__get(self, ai_info):
+        self.mock_can_packet_container.get_addressing_info.return_value = ai_info
+        assert AbstractCanPacketContainer.target_address.fget(self.mock_can_packet_container) \
+               == ai_info[CanAddressingInformationHandler.TARGET_ADDRESS_NAME]
+        self.mock_can_packet_container.get_addressing_info.assert_called_once_with()
+
+    # source_address
+
+    @pytest.mark.parametrize("ai_info", [
+        {
+            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: "TA",
+            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: "SA",
+            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: "AE",
+            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: "Addressing",
+        },
+        {
+            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: 0xF9,
+            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: 0xE8,
+            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: None,
+            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: AddressingType.FUNCTIONAL,
+        }
+    ])
+    def test_source_address__get(self, ai_info):
+        self.mock_can_packet_container.get_addressing_info.return_value = ai_info
+        assert AbstractCanPacketContainer.source_address.fget(self.mock_can_packet_container) \
+               == ai_info[CanAddressingInformationHandler.SOURCE_ADDRESS_NAME]
+        self.mock_can_packet_container.get_addressing_info.assert_called_once_with()
+
+    # address_extension
+
+    @pytest.mark.parametrize("ai_info", [
+        {
+            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: "TA",
+            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: "SA",
+            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: "AE",
+            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: "Addressing",
+        },
+        {
+            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: 0xF9,
+            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: 0xE8,
+            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: None,
+            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: AddressingType.FUNCTIONAL,
+        }
+    ])
+    def test_address_extension__get(self, ai_info):
+        self.mock_can_packet_container.get_addressing_info.return_value = ai_info
+        assert AbstractCanPacketContainer.address_extension.fget(self.mock_can_packet_container) \
+               == ai_info[CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME]
+        self.mock_can_packet_container.get_addressing_info.assert_called_once_with()
+
+    # data_length
+
+    @pytest.mark.parametrize("packet_type", [None, CanPacketType.CONSECUTIVE_FRAME, CanPacketType.FLOW_CONTROL, "x"])
+    def test_data_length__none(self, packet_type):
+        self.mock_can_packet_container.packet_type = packet_type
+        assert AbstractCanPacketContainer.data_length.fget(self.mock_can_packet_container) is None
+
+    def test_data_length__single_frame(self):
+        self.mock_can_packet_container.packet_type = CanPacketType.SINGLE_FRAME
+        assert AbstractCanPacketContainer.data_length.fget(self.mock_can_packet_container) \
+               == self.mock_single_frame_handler_class.decode_sf_dl.return_value
+        self.mock_single_frame_handler_class.decode_sf_dl.assert_called_once_with(
+            addressing_format=self.mock_can_packet_container.addressing_format,
+            raw_frame_data=self.mock_can_packet_container.raw_frame_data)
+
+    def test_data_length__first_frame(self):
+        self.mock_can_packet_container.packet_type = CanPacketType.FIRST_FRAME
+        assert AbstractCanPacketContainer.data_length.fget(self.mock_can_packet_container) \
+               == self.mock_first_frame_handler_class.decode_ff_dl.return_value
+        self.mock_first_frame_handler_class.decode_ff_dl.assert_called_once_with(
+            addressing_format=self.mock_can_packet_container.addressing_format,
+            raw_frame_data=self.mock_can_packet_container.raw_frame_data)
+
+    # sequence_number
+
+    @pytest.mark.parametrize("packet_type", [None,
+                                             CanPacketType.SINGLE_FRAME,
+                                             CanPacketType.FIRST_FRAME,
+                                             CanPacketType.FLOW_CONTROL,
+                                             "something new"])
+    def test_sequence_number__none(self, packet_type):
+        self.mock_can_packet_container.packet_type = packet_type
+        assert AbstractCanPacketContainer.sequence_number.fget(self.mock_can_packet_container) is None
+
+    def test_sequence_number__consecutive_frame(self):
+        self.mock_can_packet_container.packet_type = CanPacketType.CONSECUTIVE_FRAME
+        assert AbstractCanPacketContainer.sequence_number.fget(self.mock_can_packet_container) \
+               == self.mock_consecutive_frame_handler_class.decode_sequence_number.return_value
+        self.mock_consecutive_frame_handler_class.decode_sequence_number.assert_called_once_with(
+            addressing_format=self.mock_can_packet_container.addressing_format,
+            raw_frame_data=self.mock_can_packet_container.raw_frame_data)
+
+    # payload
+
+    @pytest.mark.parametrize("packet_type", [None, CanPacketType.FLOW_CONTROL, "something new"])
+    def test_payload__none(self, packet_type):
+        self.mock_can_packet_container.packet_type = packet_type
+        assert AbstractCanPacketContainer.payload.fget(self.mock_can_packet_container) is None
+
+    @pytest.mark.parametrize("payload", [range(10), [0xFE, 0xDC]])
+    def test_payload__single_frame(self, payload):
+        self.mock_can_packet_container.packet_type = CanPacketType.SINGLE_FRAME
+        self.mock_single_frame_handler_class.decode_payload.return_value = payload
+        assert AbstractCanPacketContainer.payload.fget(self.mock_can_packet_container) == tuple(payload)
+        self.mock_single_frame_handler_class.decode_payload.assert_called_once_with(
+            addressing_format=self.mock_can_packet_container.addressing_format,
+            raw_frame_data=self.mock_can_packet_container.raw_frame_data)
+
+    @pytest.mark.parametrize("payload", [range(10), [0xFE, 0xDC]])
+    def test_payload__first_frame(self, payload):
+        self.mock_can_packet_container.packet_type = CanPacketType.FIRST_FRAME
+        self.mock_first_frame_handler_class.decode_payload.return_value = payload
+        assert AbstractCanPacketContainer.payload.fget(self.mock_can_packet_container) == tuple(payload)
+        self.mock_first_frame_handler_class.decode_payload.assert_called_once_with(
+            addressing_format=self.mock_can_packet_container.addressing_format,
+            raw_frame_data=self.mock_can_packet_container.raw_frame_data)
+
+    @pytest.mark.parametrize("payload", [range(10), [0xFE, 0xDC]])
+    def test_payload__consecutive_frame(self, payload):
+        self.mock_can_packet_container.packet_type = CanPacketType.CONSECUTIVE_FRAME
+        self.mock_consecutive_frame_handler_class.decode_payload.return_value = payload
+        assert AbstractCanPacketContainer.payload.fget(self.mock_can_packet_container) == tuple(payload)
+        self.mock_consecutive_frame_handler_class.decode_payload.assert_called_once_with(
+            addressing_format=self.mock_can_packet_container.addressing_format,
+            raw_frame_data=self.mock_can_packet_container.raw_frame_data)
+
+    # flow_status
+
+    @pytest.mark.parametrize("packet_type", [None,
+                                             CanPacketType.SINGLE_FRAME,
+                                             CanPacketType.FIRST_FRAME,
+                                             CanPacketType.CONSECUTIVE_FRAME,
+                                             "something new"])
+    def test_flow_status__none(self, packet_type):
+        self.mock_can_packet_container.packet_type = packet_type
+        assert AbstractCanPacketContainer.flow_status.fget(self.mock_can_packet_container) is None
+
+    def test_flow_status__flow_control(self):
+        self.mock_can_packet_container.packet_type = CanPacketType.FLOW_CONTROL
+        assert AbstractCanPacketContainer.flow_status.fget(self.mock_can_packet_container) \
+               == self.mock_flow_control_handler_class.decode_flow_status.return_value
+        self.mock_flow_control_handler_class.decode_flow_status.assert_called_once_with(
+            addressing_format=self.mock_can_packet_container.addressing_format,
+            raw_frame_data=self.mock_can_packet_container.raw_frame_data)
+
+    # block_size
+
+    @pytest.mark.parametrize("packet_type", [None,
+                                             CanPacketType.SINGLE_FRAME,
+                                             CanPacketType.FIRST_FRAME,
+                                             CanPacketType.CONSECUTIVE_FRAME,
+                                             "something new"])
+    def test_block_size__none(self, packet_type):
+        self.mock_can_packet_container.packet_type = packet_type
+        assert AbstractCanPacketContainer.block_size.fget(self.mock_can_packet_container) is None
+
+    def test_block_size__flow_control(self):
+        self.mock_can_packet_container.packet_type = CanPacketType.FLOW_CONTROL
+        assert AbstractCanPacketContainer.block_size.fget(self.mock_can_packet_container) \
+               == self.mock_flow_control_handler_class.decode_block_size.return_value
+        self.mock_flow_control_handler_class.decode_block_size.assert_called_once_with(
+            addressing_format=self.mock_can_packet_container.addressing_format,
+            raw_frame_data=self.mock_can_packet_container.raw_frame_data)
+
+    # st_min
+
+    @pytest.mark.parametrize("packet_type", [None,
+                                             CanPacketType.SINGLE_FRAME,
+                                             CanPacketType.FIRST_FRAME,
+                                             CanPacketType.CONSECUTIVE_FRAME,
+                                             "something new"])
+    def test_st_min__none(self, packet_type):
+        self.mock_can_packet_container.packet_type = packet_type
+        assert AbstractCanPacketContainer.st_min.fget(self.mock_can_packet_container) is None
+
+    def test_st_min__flow_control(self):
+        self.mock_can_packet_container.packet_type = CanPacketType.FLOW_CONTROL
+        assert AbstractCanPacketContainer.st_min.fget(self.mock_can_packet_container) \
+               == self.mock_flow_control_handler_class.decode_st_min.return_value
+        self.mock_flow_control_handler_class.decode_st_min.assert_called_once_with(
+            addressing_format=self.mock_can_packet_container.addressing_format,
+            raw_frame_data=self.mock_can_packet_container.raw_frame_data)
+
+    # get_addressing_info
+
+    @pytest.mark.parametrize("raw_frame_data, ai_data_bytes_number", [
+        ([0x12, 0xFE], 0),
+        ((0xF9, 0xE8, 0xD7, 0xC6, 0xB5), 1),
+    ])
+    def test_get_addressing_info(self, raw_frame_data, ai_data_bytes_number):
+        self.mock_can_packet_container.raw_frame_data = raw_frame_data
+        self.mock_ai_handler_class.get_ai_data_bytes_number.return_value = ai_data_bytes_number
+        assert AbstractCanPacketContainer.get_addressing_info(self=self.mock_can_packet_container) \
+               == self.mock_ai_handler_class.decode_ai.return_value
+        self.mock_ai_handler_class.get_ai_data_bytes_number.assert_called_once_with(
+            self.mock_can_packet_container.addressing_format)
+        self.mock_ai_handler_class.decode_ai.assert_called_once_with(
+            addressing_format=self.mock_can_packet_container.addressing_format,
+            can_id=self.mock_can_packet_container.can_id,
+            ai_data_bytes=self.mock_can_packet_container.raw_frame_data[:ai_data_bytes_number])

--- a/tests/software_tests/packet/test_abstract_can_packet_container.py
+++ b/tests/software_tests/packet/test_abstract_can_packet_container.py
@@ -88,10 +88,10 @@ class TestAbstractCanPacketContainer:
         }
     ])
     def test_target_address__get(self, ai_info):
-        self.mock_can_packet_container.get_addressing_info.return_value = ai_info
+        self.mock_can_packet_container.get_addressing_information.return_value = ai_info
         assert AbstractCanPacketContainer.target_address.fget(self.mock_can_packet_container) \
                == ai_info[CanAddressingInformationHandler.TARGET_ADDRESS_NAME]
-        self.mock_can_packet_container.get_addressing_info.assert_called_once_with()
+        self.mock_can_packet_container.get_addressing_information.assert_called_once_with()
 
     # source_address
 
@@ -110,10 +110,10 @@ class TestAbstractCanPacketContainer:
         }
     ])
     def test_source_address__get(self, ai_info):
-        self.mock_can_packet_container.get_addressing_info.return_value = ai_info
+        self.mock_can_packet_container.get_addressing_information.return_value = ai_info
         assert AbstractCanPacketContainer.source_address.fget(self.mock_can_packet_container) \
                == ai_info[CanAddressingInformationHandler.SOURCE_ADDRESS_NAME]
-        self.mock_can_packet_container.get_addressing_info.assert_called_once_with()
+        self.mock_can_packet_container.get_addressing_information.assert_called_once_with()
 
     # address_extension
 
@@ -132,10 +132,10 @@ class TestAbstractCanPacketContainer:
         }
     ])
     def test_address_extension__get(self, ai_info):
-        self.mock_can_packet_container.get_addressing_info.return_value = ai_info
+        self.mock_can_packet_container.get_addressing_information.return_value = ai_info
         assert AbstractCanPacketContainer.address_extension.fget(self.mock_can_packet_container) \
                == ai_info[CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME]
-        self.mock_can_packet_container.get_addressing_info.assert_called_once_with()
+        self.mock_can_packet_container.get_addressing_information.assert_called_once_with()
 
     # data_length
 
@@ -270,16 +270,16 @@ class TestAbstractCanPacketContainer:
             addressing_format=self.mock_can_packet_container.addressing_format,
             raw_frame_data=self.mock_can_packet_container.raw_frame_data)
 
-    # get_addressing_info
+    # get_addressing_information
 
     @pytest.mark.parametrize("raw_frame_data, ai_data_bytes_number", [
         ([0x12, 0xFE], 0),
         ((0xF9, 0xE8, 0xD7, 0xC6, 0xB5), 1),
     ])
-    def test_get_addressing_info(self, raw_frame_data, ai_data_bytes_number):
+    def test_get_addressing_information(self, raw_frame_data, ai_data_bytes_number):
         self.mock_can_packet_container.raw_frame_data = raw_frame_data
         self.mock_ai_handler_class.get_ai_data_bytes_number.return_value = ai_data_bytes_number
-        assert AbstractCanPacketContainer.get_addressing_info(self=self.mock_can_packet_container) \
+        assert AbstractCanPacketContainer.get_addressing_information(self=self.mock_can_packet_container) \
                == self.mock_ai_handler_class.decode_ai.return_value
         self.mock_ai_handler_class.get_ai_data_bytes_number.assert_called_once_with(
             self.mock_can_packet_container.addressing_format)

--- a/tests/software_tests/packet/test_abstract_packet.py
+++ b/tests/software_tests/packet/test_abstract_packet.py
@@ -38,11 +38,11 @@ class TestAbstractUdsPacketRecord:
     @pytest.mark.parametrize("frame", [None, 0, "some frame"])
     def test_frame__get(self, frame):
         self.mock_packet_record._AbstractUdsPacketRecord__frame = frame
-        assert AbstractUdsPacketRecord.frame.fget(self=self.mock_packet_record) == frame
+        assert AbstractUdsPacketRecord.frame.fget(self.mock_packet_record) == frame
 
     @pytest.mark.parametrize("frame", [None, 0, "some frame"])
     def test_frame__set(self, frame):
-        AbstractUdsPacketRecord.frame.fset(self=self.mock_packet_record, value=frame)
+        AbstractUdsPacketRecord.frame.fset(self.mock_packet_record, value=frame)
         assert self.mock_packet_record._AbstractUdsPacketRecord__frame == frame
         self.mock_packet_record._validate_frame.assert_called_once_with(frame)
 
@@ -51,7 +51,7 @@ class TestAbstractUdsPacketRecord:
     def test_frame__set__second_attempt(self, old_value, new_value):
         self.mock_packet_record._AbstractUdsPacketRecord__frame = old_value
         with pytest.raises(ReassignmentError):
-            AbstractUdsPacketRecord.frame.fset(self=self.mock_packet_record, value=new_value)
+            AbstractUdsPacketRecord.frame.fset(self.mock_packet_record, value=new_value)
         assert self.mock_packet_record._AbstractUdsPacketRecord__frame == old_value
         self.mock_packet_record._validate_frame.assert_not_called()
 
@@ -60,10 +60,10 @@ class TestAbstractUdsPacketRecord:
     @pytest.mark.parametrize("direction", [None, "some direction"] + list(TransmissionDirection))
     def test_direction__get(self, direction):
         self.mock_packet_record._AbstractUdsPacketRecord__direction = direction
-        assert AbstractUdsPacketRecord.direction.fget(self=self.mock_packet_record) == direction
+        assert AbstractUdsPacketRecord.direction.fget(self.mock_packet_record) == direction
 
     def test_direction__set(self, example_transmission_direction):
-        AbstractUdsPacketRecord.direction.fset(self=self.mock_packet_record, value=example_transmission_direction)
+        AbstractUdsPacketRecord.direction.fset(self.mock_packet_record, value=example_transmission_direction)
         assert self.mock_packet_record._AbstractUdsPacketRecord__direction == example_transmission_direction
         self.mock_validate_direction.assert_called_once_with(example_transmission_direction)
 
@@ -72,7 +72,7 @@ class TestAbstractUdsPacketRecord:
     def test_direction__set__second_attempt(self, old_value, new_value):
         self.mock_packet_record._AbstractUdsPacketRecord__direction = old_value
         with pytest.raises(ReassignmentError):
-            AbstractUdsPacketRecord.direction.fset(self=self.mock_packet_record, value=new_value)
+            AbstractUdsPacketRecord.direction.fset(self.mock_packet_record, value=new_value)
         assert self.mock_packet_record._AbstractUdsPacketRecord__direction == old_value
         self.mock_validate_direction.assert_not_called()
 
@@ -81,22 +81,22 @@ class TestAbstractUdsPacketRecord:
     @pytest.mark.parametrize("transmission_time", [None, 0, "some transmission_time"])
     def test_transmission_time__get(self, transmission_time):
         self.mock_packet_record._AbstractUdsPacketRecord__transmission_time = transmission_time
-        assert AbstractUdsPacketRecord.transmission_time.fget(self=self.mock_packet_record) == transmission_time
+        assert AbstractUdsPacketRecord.transmission_time.fget(self.mock_packet_record) == transmission_time
 
     def test_transmission_time__set(self):
         value = Mock(spec=TimeStamp)
-        AbstractUdsPacketRecord.transmission_time.fset(self=self.mock_packet_record, value=value)
+        AbstractUdsPacketRecord.transmission_time.fset(self.mock_packet_record, value=value)
         assert self.mock_packet_record._AbstractUdsPacketRecord__transmission_time == value
 
     @pytest.mark.parametrize("value", [None, "not a timestamp"])
     def test_transmission_time__set__invalid_type(self, value):
         with pytest.raises(TypeError):
-            AbstractUdsPacketRecord.transmission_time.fset(self=self.mock_packet_record, value=value)
+            AbstractUdsPacketRecord.transmission_time.fset(self.mock_packet_record, value=value)
 
     @pytest.mark.parametrize("old_value", [None, 0, "some transmission_time"])
     @pytest.mark.parametrize("new_value", [None, True, Mock(spec=TimeStamp)])
     def test_transmission_time__set__second_attempt(self, old_value, new_value):
         self.mock_packet_record._AbstractUdsPacketRecord__transmission_time = old_value
         with pytest.raises(ReassignmentError):
-            AbstractUdsPacketRecord.transmission_time.fset(self=self.mock_packet_record, value=new_value)
+            AbstractUdsPacketRecord.transmission_time.fset(self.mock_packet_record, value=new_value)
         assert self.mock_packet_record._AbstractUdsPacketRecord__transmission_time == old_value

--- a/tests/software_tests/packet/test_can_packet.py
+++ b/tests/software_tests/packet/test_can_packet.py
@@ -975,25 +975,25 @@ class TestAnyCanPacket:
         self.mock_ai_handler_class.get_ai_data_bytes_number.assert_called_once_with(
             self.mock_any_can_packet.addressing_format)
 
-    # get_addressing_info
+    # get_addressing_information
 
     @pytest.mark.parametrize("exception", [TypeError, ValueError, IndexError])
-    @patch(f"{SCRIPT_LOCATION}.AbstractCanPacketContainer.get_addressing_info")
-    def test_get_addressing_info__none(self, mock_get_addressing_info, exception):
-        mock_get_addressing_info.side_effect = exception
-        assert AnyCanPacket.get_addressing_info(self=self.mock_any_can_packet) == {
+    @patch(f"{SCRIPT_LOCATION}.AbstractCanPacketContainer.get_addressing_information")
+    def test_get_addressing_information__none(self, mock_get_addressing_information, exception):
+        mock_get_addressing_information.side_effect = exception
+        assert AnyCanPacket.get_addressing_information(self=self.mock_any_can_packet) == {
             CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: None,
             CanAddressingInformationHandler.TARGET_ADDRESS_NAME: None,
             CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: None,
             CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: None,
         }
-        mock_get_addressing_info.assert_called_once_with()
+        mock_get_addressing_information.assert_called_once_with()
 
-    @patch(f"{SCRIPT_LOCATION}.AbstractCanPacketContainer.get_addressing_info")
-    def test_get_addressing_info(self, mock_get_addressing_info):
-        assert AnyCanPacket.get_addressing_info(self=self.mock_any_can_packet) \
-               == mock_get_addressing_info.return_value
-        mock_get_addressing_info.assert_called_once_with()
+    @patch(f"{SCRIPT_LOCATION}.AbstractCanPacketContainer.get_addressing_information")
+    def test_get_addressing_information(self, mock_get_addressing_information):
+        assert AnyCanPacket.get_addressing_information(self=self.mock_any_can_packet) \
+               == mock_get_addressing_information.return_value
+        mock_get_addressing_information.assert_called_once_with()
 
 
 @pytest.mark.integration

--- a/tests/software_tests/packet/test_can_packet.py
+++ b/tests/software_tests/packet/test_can_packet.py
@@ -710,193 +710,63 @@ class TestCanPacket:
     @pytest.mark.parametrize("value", ["some", 5.5])
     def test_raw_frame_data__get(self, value):
         self.mock_can_packet._CanPacket__raw_frame_data = value
-        assert CanPacket.raw_frame_data.fget(self=self.mock_can_packet) == value
-
-    # addressing
-
-    @pytest.mark.parametrize("value", ["some", 5.5])
-    def test_addressing_type__get(self, value):
-        self.mock_can_packet._CanPacket__addressing_type = value
-        assert CanPacket.addressing_type.fget(self=self.mock_can_packet) == value
-
-    # addressing_format
-
-    @pytest.mark.parametrize("value", ["some", 5.5])
-    def test_addressing_format__get(self, value):
-        self.mock_can_packet._CanPacket__addressing_format = value
-        assert CanPacket.addressing_format.fget(self=self.mock_can_packet) == value
-
-    # packet_type
-
-    @pytest.mark.parametrize("value", ["some", 5.5])
-    def test_packet_type__get(self, value):
-        self.mock_can_packet._CanPacket__packet_type = value
-        assert CanPacket.packet_type.fget(self=self.mock_can_packet) == value
+        assert CanPacket.raw_frame_data.fget(self.mock_can_packet) == value
 
     # can_id
 
     @pytest.mark.parametrize("value", ["some", 5.5])
     def test_can_id__get(self, value):
         self.mock_can_packet._CanPacket__can_id = value
-        assert CanPacket.can_id.fget(self=self.mock_can_packet) == value
+        assert CanPacket.can_id.fget(self.mock_can_packet) == value
+
+    # addressing_format
+
+    @pytest.mark.parametrize("value", ["some", 5.5])
+    def test_addressing_format__get(self, value):
+        self.mock_can_packet._CanPacket__addressing_format = value
+        assert CanPacket.addressing_format.fget(self.mock_can_packet) == value
+
+    # addressing_type
+
+    @pytest.mark.parametrize("value", ["some", 5.5])
+    def test_addressing_type__get(self, value):
+        self.mock_can_packet._CanPacket__addressing_type = value
+        assert CanPacket.addressing_type.fget(self.mock_can_packet) == value
 
     # dlc
 
     @pytest.mark.parametrize("value", ["some", 5.5])
     def test_dlc__get(self, value):
         self.mock_can_packet._CanPacket__dlc = value
-        assert CanPacket.dlc.fget(self=self.mock_can_packet) == value
+        assert CanPacket.dlc.fget(self.mock_can_packet) == value
+
+    # packet_type
+
+    @pytest.mark.parametrize("value", ["some", 5.5])
+    def test_packet_type__get(self, value):
+        self.mock_can_packet._CanPacket__packet_type = value
+        assert CanPacket.packet_type.fget(self.mock_can_packet) == value
 
     # target_address
 
     @pytest.mark.parametrize("value", ["some", 5.5])
     def test_target_address__get(self, value):
         self.mock_can_packet._CanPacket__target_address = value
-        assert CanPacket.target_address.fget(self=self.mock_can_packet) == value
+        assert CanPacket.target_address.fget(self.mock_can_packet) == value
 
     # source_address
 
     @pytest.mark.parametrize("value", ["some", 5.5])
     def test_source_address__get(self, value):
         self.mock_can_packet._CanPacket__source_address = value
-        assert CanPacket.source_address.fget(self=self.mock_can_packet) == value
+        assert CanPacket.source_address.fget(self.mock_can_packet) == value
 
     # address_extension
 
     @pytest.mark.parametrize("value", ["some", 5.5])
     def test_address_extension__get(self, value):
         self.mock_can_packet._CanPacket__address_extension = value
-        assert CanPacket.address_extension.fget(self=self.mock_can_packet) == value
-
-    # payload
-
-    @pytest.mark.parametrize("packet_type", [None, CanPacketType.FLOW_CONTROL, "something new"])
-    def test_payload__none(self, packet_type):
-        self.mock_can_packet.packet_type = packet_type
-        assert CanPacket.payload.fget(self=self.mock_can_packet) is None
-
-    @pytest.mark.parametrize("payload", [range(10), [0xFE, 0xDC]])
-    def test_payload__single_frame(self, payload):
-        self.mock_can_packet.packet_type = CanPacketType.SINGLE_FRAME
-        self.mock_single_frame_handler_class.decode_payload.return_value = payload
-        assert CanPacket.payload.fget(self=self.mock_can_packet) == tuple(payload)
-        self.mock_single_frame_handler_class.decode_payload.assert_called_once_with(
-            addressing_format=self.mock_can_packet.addressing_format, raw_frame_data=self.mock_can_packet.raw_frame_data)
-
-    @pytest.mark.parametrize("payload", [range(10), [0xFE, 0xDC]])
-    def test_payload__first_frame(self, payload):
-        self.mock_can_packet.packet_type = CanPacketType.FIRST_FRAME
-        self.mock_first_frame_handler_class.decode_payload.return_value = payload
-        assert CanPacket.payload.fget(self=self.mock_can_packet) == tuple(payload)
-        self.mock_first_frame_handler_class.decode_payload.assert_called_once_with(
-            addressing_format=self.mock_can_packet.addressing_format, raw_frame_data=self.mock_can_packet.raw_frame_data)
-
-    @pytest.mark.parametrize("payload", [range(10), [0xFE, 0xDC]])
-    def test_payload__consecutive_frame(self, payload):
-        self.mock_can_packet.packet_type = CanPacketType.CONSECUTIVE_FRAME
-        self.mock_consecutive_frame_handler_class.decode_payload.return_value = payload
-        assert CanPacket.payload.fget(self=self.mock_can_packet) == tuple(payload)
-        self.mock_consecutive_frame_handler_class.decode_payload.assert_called_once_with(
-            addressing_format=self.mock_can_packet.addressing_format, raw_frame_data=self.mock_can_packet.raw_frame_data)
-
-    # data_length
-
-    @pytest.mark.parametrize("packet_type", [None, CanPacketType.CONSECUTIVE_FRAME, CanPacketType.FLOW_CONTROL, "x"])
-    def test_data_length__none(self, packet_type):
-        self.mock_can_packet.packet_type = packet_type
-        assert CanPacket.data_length.fget(self=self.mock_can_packet) is None
-
-    def test_data_length__single_frame(self):
-        self.mock_can_packet.packet_type = CanPacketType.SINGLE_FRAME
-        assert CanPacket.data_length.fget(self=self.mock_can_packet) \
-               == self.mock_single_frame_handler_class.decode_sf_dl.return_value
-        self.mock_single_frame_handler_class.decode_sf_dl.assert_called_once_with(
-            addressing_format=self.mock_can_packet.addressing_format,
-            raw_frame_data=self.mock_can_packet.raw_frame_data)
-
-    def test_data_length__first_frame(self):
-        self.mock_can_packet.packet_type = CanPacketType.FIRST_FRAME
-        assert CanPacket.data_length.fget(self=self.mock_can_packet) \
-               == self.mock_first_frame_handler_class.decode_ff_dl.return_value
-        self.mock_first_frame_handler_class.decode_ff_dl.assert_called_once_with(
-            addressing_format=self.mock_can_packet.addressing_format,
-            raw_frame_data=self.mock_can_packet.raw_frame_data)
-
-    # sequence_number
-
-    @pytest.mark.parametrize("packet_type", [None,
-                                             CanPacketType.SINGLE_FRAME,
-                                             CanPacketType.FIRST_FRAME,
-                                             CanPacketType.FLOW_CONTROL,
-                                             "something new"])
-    def test_sequence_number__none(self, packet_type):
-        self.mock_can_packet.packet_type = packet_type
-        assert CanPacket.sequence_number.fget(self=self.mock_can_packet) is None
-
-    def test_sequence_number__consecutive_frame(self):
-        self.mock_can_packet.packet_type = CanPacketType.CONSECUTIVE_FRAME
-        assert CanPacket.sequence_number.fget(self=self.mock_can_packet) \
-               == self.mock_consecutive_frame_handler_class.decode_sequence_number.return_value
-        self.mock_consecutive_frame_handler_class.decode_sequence_number.assert_called_once_with(
-            addressing_format=self.mock_can_packet.addressing_format,
-            raw_frame_data=self.mock_can_packet.raw_frame_data)
-
-    # flow_status
-
-    @pytest.mark.parametrize("packet_type", [None,
-                                             CanPacketType.SINGLE_FRAME,
-                                             CanPacketType.FIRST_FRAME,
-                                             CanPacketType.CONSECUTIVE_FRAME,
-                                             "something new"])
-    def test_flow_status__none(self, packet_type):
-        self.mock_can_packet.packet_type = packet_type
-        assert CanPacket.flow_status.fget(self=self.mock_can_packet) is None
-
-    def test_flow_status__flow_control(self):
-        self.mock_can_packet.packet_type = CanPacketType.FLOW_CONTROL
-        assert CanPacket.flow_status.fget(self=self.mock_can_packet) \
-               == self.mock_flow_control_handler_class.decode_flow_status.return_value
-        self.mock_flow_control_handler_class.decode_flow_status.assert_called_once_with(
-            addressing_format=self.mock_can_packet.addressing_format,
-            raw_frame_data=self.mock_can_packet.raw_frame_data)
-
-    # block_size
-
-    @pytest.mark.parametrize("packet_type", [None,
-                                             CanPacketType.SINGLE_FRAME,
-                                             CanPacketType.FIRST_FRAME,
-                                             CanPacketType.CONSECUTIVE_FRAME,
-                                             "something new"])
-    def test_block_size__none(self, packet_type):
-        self.mock_can_packet.packet_type = packet_type
-        assert CanPacket.block_size.fget(self=self.mock_can_packet) is None
-
-    def test_block_size__flow_control(self):
-        self.mock_can_packet.packet_type = CanPacketType.FLOW_CONTROL
-        assert CanPacket.block_size.fget(self=self.mock_can_packet) \
-               == self.mock_flow_control_handler_class.decode_block_size.return_value
-        self.mock_flow_control_handler_class.decode_block_size.assert_called_once_with(
-            addressing_format=self.mock_can_packet.addressing_format,
-            raw_frame_data=self.mock_can_packet.raw_frame_data)
-
-    # st_min
-
-    @pytest.mark.parametrize("packet_type", [None,
-                                             CanPacketType.SINGLE_FRAME,
-                                             CanPacketType.FIRST_FRAME,
-                                             CanPacketType.CONSECUTIVE_FRAME,
-                                             "something new"])
-    def test_st_min__none(self, packet_type):
-        self.mock_can_packet.packet_type = packet_type
-        assert CanPacket.st_min.fget(self=self.mock_can_packet) is None
-
-    def test_st_min__flow_control(self):
-        self.mock_can_packet.packet_type = CanPacketType.FLOW_CONTROL
-        assert CanPacket.st_min.fget(self=self.mock_can_packet) \
-               == self.mock_flow_control_handler_class.decode_st_min.return_value
-        self.mock_flow_control_handler_class.decode_st_min.assert_called_once_with(
-            addressing_format=self.mock_can_packet.addressing_format,
-            raw_frame_data=self.mock_can_packet.raw_frame_data)
+        assert CanPacket.address_extension.fget(self.mock_can_packet) == value
 
     # __validate_unambiguous_ai_change
 
@@ -1023,55 +893,63 @@ class TestAnyCanPacket:
     @pytest.mark.parametrize("raw_frame_data", ["some raw data", list(range(10))])
     def test_raw_frame_data__get(self, raw_frame_data):
         self.mock_any_can_packet._AnyCanPacket__raw_frame_data = raw_frame_data
-        assert AnyCanPacket.raw_frame_data.fget(self=self.mock_any_can_packet) == raw_frame_data
+        assert AnyCanPacket.raw_frame_data.fget(self.mock_any_can_packet) == raw_frame_data
 
     @pytest.mark.parametrize("raw_frame_data", ["some raw data", list(range(10))])
     def test_raw_frame_data__set(self, raw_frame_data):
-        AnyCanPacket.raw_frame_data.fset(self=self.mock_any_can_packet, value=raw_frame_data)
+        AnyCanPacket.raw_frame_data.fset(self.mock_any_can_packet, value=raw_frame_data)
         self.mock_validate_raw_bytes.assert_called_once_with(raw_frame_data, allow_empty=True)
         self.mock_can_dlc_handler_class.validate_data_bytes_number.assert_called_once_with(len(raw_frame_data))
         assert self.mock_any_can_packet._AnyCanPacket__raw_frame_data == tuple(raw_frame_data)
-        
-    # addressing_type
-
-    @pytest.mark.parametrize("addressing_type", ["some addresisng", AddressingType.PHYSICAL])
-    def test_addressing_type__get(self, addressing_type):
-        self.mock_any_can_packet._AnyCanPacket__addressing_type = addressing_type
-        assert AnyCanPacket.addressing_type.fget(self=self.mock_any_can_packet) == addressing_type
-
-    @pytest.mark.parametrize("addressing_type", ["some addresisng", AddressingType.PHYSICAL])
-    def test_addressing_type__set(self, addressing_type):
-        AnyCanPacket.addressing_type.fset(self=self.mock_any_can_packet, value=addressing_type)
-        self.mock_addressing_type_class.validate_member.assert_called_once_with(addressing_type)
-        self.mock_addressing_type_class.assert_called_once_with(addressing_type)
-        assert self.mock_any_can_packet._AnyCanPacket__addressing_type == self.mock_addressing_type_class.return_value
-
-    # addressing_format
-
-    @pytest.mark.parametrize("addressing_format", ["some addresisng format", CanAddressingFormat.EXTENDED_ADDRESSING])
-    def test_addressing_format__get(self, addressing_format):
-        self.mock_any_can_packet._AnyCanPacket__addressing_format = addressing_format
-        assert AnyCanPacket.addressing_format.fget(self=self.mock_any_can_packet) == addressing_format
-
-    @pytest.mark.parametrize("addressing_format", ["some addresisng format", CanAddressingFormat.EXTENDED_ADDRESSING])
-    def test_addressing_format__set(self, addressing_format):
-        AnyCanPacket.addressing_format.fset(self=self.mock_any_can_packet, value=addressing_format)
-        self.mock_addressing_format_class.validate_member.assert_called_once_with(addressing_format)
-        self.mock_addressing_format_class.assert_called_once_with(addressing_format)
-        assert self.mock_any_can_packet._AnyCanPacket__addressing_format == self.mock_addressing_format_class.return_value
 
     # can_id
 
     @pytest.mark.parametrize("can_id", ["some CAN ID", 0x98321])
     def test_can_id__get(self, can_id):
         self.mock_any_can_packet._AnyCanPacket__can_id = can_id
-        assert AnyCanPacket.can_id.fget(self=self.mock_any_can_packet) == can_id
+        assert AnyCanPacket.can_id.fget(self.mock_any_can_packet) == can_id
 
     @pytest.mark.parametrize("can_id", ["some CAN ID", 0x98321])
     def test_can_id__set(self, can_id):
-        AnyCanPacket.can_id.fset(self=self.mock_any_can_packet, value=can_id)
+        AnyCanPacket.can_id.fset(self.mock_any_can_packet, value=can_id)
         self.mock_can_id_handler_class.validate_can_id.assert_called_once_with(can_id)
         assert self.mock_any_can_packet._AnyCanPacket__can_id == can_id
+
+    # addressing_format
+
+    @pytest.mark.parametrize("addressing_format", ["some addresisng format", CanAddressingFormat.EXTENDED_ADDRESSING])
+    def test_addressing_format__get(self, addressing_format):
+        self.mock_any_can_packet._AnyCanPacket__addressing_format = addressing_format
+        assert AnyCanPacket.addressing_format.fget(self.mock_any_can_packet) == addressing_format
+
+    @pytest.mark.parametrize("addressing_format", ["some addresisng format", CanAddressingFormat.EXTENDED_ADDRESSING])
+    def test_addressing_format__set(self, addressing_format):
+        AnyCanPacket.addressing_format.fset(self.mock_any_can_packet, value=addressing_format)
+        self.mock_addressing_format_class.validate_member.assert_called_once_with(addressing_format)
+        self.mock_addressing_format_class.assert_called_once_with(addressing_format)
+        assert self.mock_any_can_packet._AnyCanPacket__addressing_format == self.mock_addressing_format_class.return_value
+
+    # addressing_type
+
+    @pytest.mark.parametrize("addressing_type", ["some addresisng", AddressingType.PHYSICAL])
+    def test_addressing_type__get(self, addressing_type):
+        self.mock_any_can_packet._AnyCanPacket__addressing_type = addressing_type
+        assert AnyCanPacket.addressing_type.fget(self.mock_any_can_packet) == addressing_type
+    @pytest.mark.parametrize("addressing_type", ["some addresisng", AddressingType.PHYSICAL])
+    def test_addressing_type__set(self, addressing_type):
+        AnyCanPacket.addressing_type.fset(self.mock_any_can_packet, value=addressing_type)
+        self.mock_addressing_type_class.validate_member.assert_called_once_with(addressing_type)
+        self.mock_addressing_type_class.assert_called_once_with(addressing_type)
+        assert self.mock_any_can_packet._AnyCanPacket__addressing_type == self.mock_addressing_type_class.return_value
+
+    # dlc
+
+    @pytest.mark.parametrize("raw_frame_data", ["some raw data", list(range(10))])
+    def test_dlc__get(self, raw_frame_data):
+        self.mock_any_can_packet.raw_frame_data = raw_frame_data
+        assert AnyCanPacket.dlc.fget(self.mock_any_can_packet) \
+               == self.mock_can_dlc_handler_class.encode_dlc.return_value
+        self.mock_can_dlc_handler_class.encode_dlc.assert_called_once_with(len(raw_frame_data))
 
     # packet_type
 
@@ -1082,7 +960,7 @@ class TestAnyCanPacket:
     def test_packet_type__get__none(self, ai_data_bytes_number, raw_frame_data):
         self.mock_ai_handler_class.get_ai_data_bytes_number.return_value = ai_data_bytes_number
         self.mock_any_can_packet.raw_frame_data = raw_frame_data
-        assert AnyCanPacket.packet_type.fget(self=self.mock_any_can_packet) is None
+        assert AnyCanPacket.packet_type.fget(self.mock_any_can_packet) is None
         self.mock_ai_handler_class.get_ai_data_bytes_number.assert_called_once_with(
             self.mock_any_can_packet.addressing_format)
 
@@ -1093,168 +971,29 @@ class TestAnyCanPacket:
     def test_packet_type__get(self, ai_data_bytes_number, raw_frame_data):
         self.mock_ai_handler_class.get_ai_data_bytes_number.return_value = ai_data_bytes_number
         self.mock_any_can_packet.raw_frame_data = raw_frame_data
-        assert AnyCanPacket.packet_type.fget(self=self.mock_any_can_packet) is raw_frame_data[ai_data_bytes_number] >> 4
+        assert AnyCanPacket.packet_type.fget(self.mock_any_can_packet) is raw_frame_data[ai_data_bytes_number] >> 4
         self.mock_ai_handler_class.get_ai_data_bytes_number.assert_called_once_with(
             self.mock_any_can_packet.addressing_format)
 
-    # dlc
+    # get_addressing_info
 
-    @pytest.mark.parametrize("raw_frame_data", ["some raw data", list(range(10))])
-    def test_dlc__get(self, raw_frame_data):
-        self.mock_any_can_packet.raw_frame_data = raw_frame_data
-        assert AnyCanPacket.dlc.fget(self=self.mock_any_can_packet) \
-               == self.mock_can_dlc_handler_class.encode_dlc.return_value
-        self.mock_can_dlc_handler_class.encode_dlc.assert_called_once_with(len(raw_frame_data))
-
-    # target_address
-
-    def test_target_address__get__none(self):
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.return_value = None
-        assert AnyCanPacket.target_address.fget(self=self.mock_any_can_packet) is None
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.assert_called_once_with()
-
-    @pytest.mark.parametrize("ai_info", [
-        {
-            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: "TA",
-            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: "SA",
-            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: "AE",
-            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: "Addressing",
-        },
-        {
-            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: 0xF9,
-            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: 0xE8,
-            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: None,
-            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: AddressingType.FUNCTIONAL,
-        }
-    ])
-    def test_target_address__get(self, ai_info):
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.return_value = ai_info
-        assert AnyCanPacket.target_address.fget(self=self.mock_any_can_packet) \
-               == ai_info[CanAddressingInformationHandler.TARGET_ADDRESS_NAME]
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.assert_called_once_with()
-
-    # source_address
-
-    def test_source_address__get__none(self):
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.return_value = None
-        assert AnyCanPacket.source_address.fget(self=self.mock_any_can_packet) is None
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.assert_called_once_with()
-
-    @pytest.mark.parametrize("ai_info", [
-        {
-            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: "TA",
-            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: "SA",
-            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: "AE",
-            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: "Addressing",
-        },
-        {
-            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: 0xF9,
-            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: 0xE8,
-            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: None,
-            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: AddressingType.FUNCTIONAL,
-        }
-    ])
-    def test_source_address__get(self, ai_info):
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.return_value = ai_info
-        assert AnyCanPacket.source_address.fget(self=self.mock_any_can_packet) \
-               == ai_info[CanAddressingInformationHandler.SOURCE_ADDRESS_NAME]
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.assert_called_once_with()
-
-    # address_extension
-
-    def test_address_extension__get__none(self):
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.return_value = None
-        assert AnyCanPacket.address_extension.fget(self=self.mock_any_can_packet) is None
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.assert_called_once_with()
-
-    @pytest.mark.parametrize("ai_info", [
-        {
-            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: "TA",
-            CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: "SA",
-            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: "AE",
-            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: "Addressing",
-        },
-        {
-            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: 0xF9,
+    @pytest.mark.parametrize("exception", [TypeError, ValueError, IndexError])
+    @patch(f"{SCRIPT_LOCATION}.AbstractCanPacketContainer.get_addressing_info")
+    def test_get_addressing_info__none(self, mock_get_addressing_info, exception):
+        mock_get_addressing_info.side_effect = exception
+        assert AnyCanPacket.get_addressing_info(self=self.mock_any_can_packet) == {
+            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: None,
+            CanAddressingInformationHandler.TARGET_ADDRESS_NAME: None,
             CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: None,
-            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: 0xE8,
-            CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: AddressingType.FUNCTIONAL,
+            CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: None,
         }
-    ])
-    def test_address_extension__get(self, ai_info):
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.return_value = ai_info
-        assert AnyCanPacket.address_extension.fget(self=self.mock_any_can_packet) \
-               == ai_info[CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME]
-        self.mock_any_can_packet._AnyCanPacket__get_addressing_info.assert_called_once_with()
+        mock_get_addressing_info.assert_called_once_with()
 
-    # payload
-
-    def test_payload__get(self):
-        assert AnyCanPacket.payload.fget(self=self.mock_any_can_packet) \
-               == self.mock_can_packet_class.payload.fget.return_value
-        self.mock_can_packet_class.payload.fget.assert_called_once_with(self.mock_any_can_packet)
-
-    # data_length
-
-    def test_data_length__get(self):
-        assert AnyCanPacket.data_length.fget(self=self.mock_any_can_packet) \
-               == self.mock_can_packet_class.data_length.fget.return_value
-        self.mock_can_packet_class.data_length.fget.assert_called_once_with(self.mock_any_can_packet)
-    
-    # sequence_number
-
-    def test_sequence_number__get(self):
-        assert AnyCanPacket.sequence_number.fget(self=self.mock_any_can_packet) \
-               == self.mock_can_packet_class.sequence_number.fget.return_value
-        self.mock_can_packet_class.sequence_number.fget.assert_called_once_with(self.mock_any_can_packet)
-
-    # flow_status
-
-    def test_flow_status__get(self):
-        assert AnyCanPacket.flow_status.fget(self=self.mock_any_can_packet) \
-               == self.mock_can_packet_class.flow_status.fget.return_value
-        self.mock_can_packet_class.flow_status.fget.assert_called_once_with(self.mock_any_can_packet)
-
-    # block_size
-
-    def test_block_size__get(self):
-        assert AnyCanPacket.block_size.fget(self=self.mock_any_can_packet) \
-               == self.mock_can_packet_class.block_size.fget.return_value
-        self.mock_can_packet_class.block_size.fget.assert_called_once_with(self.mock_any_can_packet)
-
-    # st_min
-
-    def test_st_min__get(self):
-        assert AnyCanPacket.st_min.fget(self=self.mock_any_can_packet) \
-               == self.mock_can_packet_class.st_min.fget.return_value
-        self.mock_can_packet_class.st_min.fget.assert_called_once_with(self.mock_any_can_packet)
-
-    # __get_addressing_info
-
-    def test_get_ai__none(self):
-        self.mock_any_can_packet.raw_frame_data = []
-        self.mock_ai_handler_class.get_ai_data_bytes_number.return_value = 1
-        assert AnyCanPacket._AnyCanPacket__get_addressing_info(self=self.mock_any_can_packet) is None
-        self.mock_ai_handler_class.get_ai_data_bytes_number.assert_called_once_with(
-            self.mock_any_can_packet.addressing_format)
-        self.mock_ai_handler_class.decode_ai.assert_not_called()
-
-    @pytest.mark.parametrize("raw_frame_data, ai_data_bytes_number", [
-        ([], 0),
-        ([0x12], 1),
-        ((0xF9, 0xE8, 0xD7, 0xC6, 0xB5), 1),
-    ])
-    def test_get_ai(self, raw_frame_data, ai_data_bytes_number):
-        self.mock_any_can_packet.raw_frame_data = raw_frame_data
-        self.mock_ai_handler_class.get_ai_data_bytes_number.return_value = ai_data_bytes_number
-        assert AnyCanPacket._AnyCanPacket__get_addressing_info(self=self.mock_any_can_packet) \
-               == self.mock_ai_handler_class.decode_ai.return_value
-        self.mock_ai_handler_class.get_ai_data_bytes_number.assert_called_once_with(
-            self.mock_any_can_packet.addressing_format)
-        self.mock_ai_handler_class.decode_ai.assert_called_once_with(
-            addressing_format=self.mock_any_can_packet.addressing_format,
-            can_id=self.mock_any_can_packet.can_id,
-            ai_data_bytes=self.mock_any_can_packet.raw_frame_data[:ai_data_bytes_number])
+    @patch(f"{SCRIPT_LOCATION}.AbstractCanPacketContainer.get_addressing_info")
+    def test_get_addressing_info(self, mock_get_addressing_info):
+        assert AnyCanPacket.get_addressing_info(self=self.mock_any_can_packet) \
+               == mock_get_addressing_info.return_value
+        mock_get_addressing_info.assert_called_once_with()
 
 
 @pytest.mark.integration

--- a/tests/software_tests/segmentation/test_can_segmenter.py
+++ b/tests/software_tests/segmentation/test_can_segmenter.py
@@ -111,30 +111,30 @@ class TestCanSegmenter:
     # supported_packet_classes
 
     def test_supported_packet_classes__get(self):
-        assert isinstance(CanSegmenter.supported_packet_classes.fget(self=self.mock_can_segmenter), tuple)
+        assert isinstance(CanSegmenter.supported_packet_classes.fget(self.mock_can_segmenter), tuple)
 
     # addressing_format
 
     @pytest.mark.parametrize("value", ["something", 5.5])
     def test_addressing_format__get(self, value):
         self.mock_can_segmenter._CanSegmenter__addressing_format = value
-        assert CanSegmenter.addressing_format.fget(self=self.mock_can_segmenter) == value
+        assert CanSegmenter.addressing_format.fget(self.mock_can_segmenter) == value
 
     # physical_ai
 
     @pytest.mark.parametrize("value", ["something", 5.5])
     def test_physical_ai__get(self, value):
         self.mock_can_segmenter._CanSegmenter__physical_ai = value
-        assert CanSegmenter.physical_ai.fget(self=self.mock_can_segmenter) == value
+        assert CanSegmenter.physical_ai.fget(self.mock_can_segmenter) == value
 
     def test_physical_ai__set__none(self):
-        CanSegmenter.physical_ai.fset(self=self.mock_can_segmenter, value=None)
+        CanSegmenter.physical_ai.fset(self.mock_can_segmenter, value=None)
         self.mock_can_ai_handler_class.validate_ai.assert_not_called()
         assert self.mock_can_segmenter._CanSegmenter__physical_ai is None
 
     @pytest.mark.parametrize("value", [{"a": 1, "b": 2}, {"arg1": "something", "arg2": "something else"}])
     def test_physical_ai__set(self, value):
-        CanSegmenter.physical_ai.fset(self=self.mock_can_segmenter, value=value)
+        CanSegmenter.physical_ai.fset(self.mock_can_segmenter, value=value)
         self.mock_can_ai_handler_class.validate_ai.assert_called_once_with(
             addressing_format=self.mock_can_segmenter.addressing_format,
             addressing_type=self.mock_addressing_type_class.PHYSICAL,
@@ -152,16 +152,16 @@ class TestCanSegmenter:
     @pytest.mark.parametrize("value", ["something", 5.5])
     def test_functional_ai__get(self, value):
         self.mock_can_segmenter._CanSegmenter__functional_ai = value
-        assert CanSegmenter.functional_ai.fget(self=self.mock_can_segmenter) == value
+        assert CanSegmenter.functional_ai.fget(self.mock_can_segmenter) == value
 
     def test_functional_ai__set__none(self):
-        CanSegmenter.functional_ai.fset(self=self.mock_can_segmenter, value=None)
+        CanSegmenter.functional_ai.fset(self.mock_can_segmenter, value=None)
         self.mock_can_ai_handler_class.validate_ai.assert_not_called()
         assert self.mock_can_segmenter._CanSegmenter__functional_ai is None
 
     @pytest.mark.parametrize("value", [{"a": 1, "b": 2}, {"arg1": "something", "arg2": "something else"}])
     def test_functional_ai__set(self, value):
-        CanSegmenter.functional_ai.fset(self=self.mock_can_segmenter, value=value)
+        CanSegmenter.functional_ai.fset(self.mock_can_segmenter, value=value)
         self.mock_can_ai_handler_class.validate_ai.assert_called_once_with(
             addressing_format=self.mock_can_segmenter.addressing_format,
             addressing_type=self.mock_addressing_type_class.FUNCTIONAL,
@@ -179,17 +179,17 @@ class TestCanSegmenter:
     @pytest.mark.parametrize("value", ["something", 5.5])
     def test_dlc__get(self, value):
         self.mock_can_segmenter._CanSegmenter__dlc = value
-        assert CanSegmenter.dlc.fget(self=self.mock_can_segmenter) == value
+        assert CanSegmenter.dlc.fget(self.mock_can_segmenter) == value
 
     @pytest.mark.parametrize("value", [0, CanDlcHandler.MIN_BASE_UDS_DLC - 1])
     def test_dlc__set__value_error(self, value):
         with pytest.raises(ValueError):
-            CanSegmenter.dlc.fset(self=self.mock_can_segmenter, value=value)
+            CanSegmenter.dlc.fset(self.mock_can_segmenter, value=value)
         self.mock_can_dlc_handler_class.validate_dlc.assert_called_once_with(value)
 
     @pytest.mark.parametrize("value", [CanDlcHandler.MIN_BASE_UDS_DLC, CanDlcHandler.MIN_BASE_UDS_DLC+1])
     def test_dlc__set(self, value):
-        CanSegmenter.dlc.fset(self=self.mock_can_segmenter, value=value)
+        CanSegmenter.dlc.fset(self.mock_can_segmenter, value=value)
         self.mock_can_dlc_handler_class.validate_dlc.assert_called_once_with(value)
         assert self.mock_can_segmenter._CanSegmenter__dlc == value
         
@@ -198,11 +198,11 @@ class TestCanSegmenter:
     @pytest.mark.parametrize("value", ["something", 5.5])
     def test_use_data_optimization__get(self, value):
         self.mock_can_segmenter._CanSegmenter__use_data_optimization = value
-        assert CanSegmenter.use_data_optimization.fget(self=self.mock_can_segmenter) == value
+        assert CanSegmenter.use_data_optimization.fget(self.mock_can_segmenter) == value
 
     @pytest.mark.parametrize("value", ["something", 5.5])
     def test_use_data_optimization__set(self, value):
-        CanSegmenter.use_data_optimization.fset(self=self.mock_can_segmenter, value=value)
+        CanSegmenter.use_data_optimization.fset(self.mock_can_segmenter, value=value)
         assert self.mock_can_segmenter._CanSegmenter__use_data_optimization == bool(value)
 
     # filler_byte
@@ -210,11 +210,11 @@ class TestCanSegmenter:
     @pytest.mark.parametrize("value", ["something", 5.5])
     def test_filler_byte__get(self, value):
         self.mock_can_segmenter._CanSegmenter__filler_byte = value
-        assert CanSegmenter.filler_byte.fget(self=self.mock_can_segmenter) == value
+        assert CanSegmenter.filler_byte.fget(self.mock_can_segmenter) == value
 
     @pytest.mark.parametrize("value", ["something", 5.5])
     def test_filler_byte__set(self, value):
-        CanSegmenter.filler_byte.fset(self=self.mock_can_segmenter, value=value)
+        CanSegmenter.filler_byte.fset(self.mock_can_segmenter, value=value)
         self.mock_validate_raw_byte.assert_called_once_with(value)
         assert self.mock_can_segmenter._CanSegmenter__filler_byte == value
 

--- a/uds/message/__init__.py
+++ b/uds/message/__init__.py
@@ -8,7 +8,7 @@ It provides tools for:
  - Negative Response Codes (NRC) definition
 """
 
-from .uds_message import UdsMessage, UdsMessageRecord
+from .uds_message import AbstractUdsMessageContainer, UdsMessage, UdsMessageRecord
 from .service_identifiers import RequestSID, ResponseSID, POSSIBLE_REQUEST_SIDS, POSSIBLE_RESPONSE_SIDS, \
     UnrecognizedSIDWarning
 from .nrc import NRC

--- a/uds/message/uds_message.py
+++ b/uds/message/uds_message.py
@@ -24,7 +24,7 @@ class AbstractUdsMessageContainer(ABC):
 
         :param other: Object to compare.
 
-        :return: True if both other object are the same type and carries the same diagnostic message, otherwise False.
+        :return: True if other object has the same type and carries the same diagnostic message, otherwise False.
         """
 
     @property
@@ -65,7 +65,7 @@ class UdsMessage(AbstractUdsMessageContainer):
 
         :param other: Object to compare.
 
-        :return: True if both other object are the same type and carries the same diagnostic message, otherwise False.
+        :return: True if other object has the same type and carries the same diagnostic message, otherwise False.
         """
         if not isinstance(other, self.__class__):
             raise TypeError("UDS Message can only be compared with another UDS Message")
@@ -120,7 +120,7 @@ class UdsMessageRecord(AbstractUdsMessageContainer):
 
         :param other: Object to compare.
 
-        :return: True if both other object are the same type and carries the same diagnostic message, otherwise False.
+        :return: True if other object has the same type and carries the same diagnostic message, otherwise False.
         """
         if not isinstance(other, self.__class__):
             raise TypeError("UDS Message Record can only be compared with another UDS Message Record")

--- a/uds/message/uds_message.py
+++ b/uds/message/uds_message.py
@@ -4,7 +4,7 @@ Module with common implementation of all diagnostic messages (requests and respo
 :ref:`Diagnostic message <knowledge-base-diagnostic-message>` are defined on upper layers of UDS OSI Model.
 """
 
-__all__ = ["UdsMessage", "UdsMessageRecord"]
+__all__ = ["AbstractUdsMessageContainer", "UdsMessage", "UdsMessageRecord"]
 
 from typing import Any
 from abc import ABC, abstractmethod

--- a/uds/packet/__init__.py
+++ b/uds/packet/__init__.py
@@ -9,9 +9,10 @@ It provides tools for:
 """
 
 from .abstract_packet_type import AbstractUdsPacketType, AbstractUdsPacketTypeAlias
-from .abstract_packet import AbstractUdsPacket, AbstractUdsPacketRecord, \
-    PacketsRecordsTuple, PacketsRecordsSequence, \
-    PacketAlias, PacketsSequence, PacketsDefinitionTuple
+from .abstract_packet import AbstractUdsPacketContainer, AbstractUdsPacket, AbstractUdsPacketRecord, \
+    PacketsContainersSequence, PacketsContainersTuple, PacketsContainersList, \
+    PacketsSequence, PacketsTuple, PacketsList, \
+    PacketsRecordsSequence, PacketsRecordsTuple, PacketsRecordsList
 from .can_packet_type import CanPacketType, CanPacketTypeAlias
 from .can_packet import CanPacket
 from .can_packet_record import CanPacketRecord

--- a/uds/packet/abstract_can_packet_container.py
+++ b/uds/packet/abstract_can_packet_container.py
@@ -59,7 +59,7 @@ class AbstractCanPacketContainer(ABC):
 
         None in other cases.
         """
-        return self.get_addressing_info()[CanAddressingInformationHandler.TARGET_ADDRESS_NAME]
+        return self.get_addressing_information()[CanAddressingInformationHandler.TARGET_ADDRESS_NAME]
 
     @property
     def source_address(self) -> Optional[RawByte]:
@@ -72,7 +72,7 @@ class AbstractCanPacketContainer(ABC):
 
         None in other cases.
         """
-        return self.get_addressing_info()[CanAddressingInformationHandler.SOURCE_ADDRESS_NAME]
+        return self.get_addressing_information()[CanAddressingInformationHandler.SOURCE_ADDRESS_NAME]
 
     @property
     def address_extension(self) -> Optional[RawByte]:
@@ -86,7 +86,7 @@ class AbstractCanPacketContainer(ABC):
 
         None in other cases.
         """
-        return self.get_addressing_info()[CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME]
+        return self.get_addressing_information()[CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME]
 
     @property
     def data_length(self) -> Optional[int]:
@@ -198,7 +198,7 @@ class AbstractCanPacketContainer(ABC):
                                                        raw_frame_data=self.raw_frame_data)
         return None
 
-    def get_addressing_info(self) -> dict:
+    def get_addressing_information(self) -> dict:
         """
         Get Addressing Information carried by this packet.
 

--- a/uds/packet/abstract_can_packet_container.py
+++ b/uds/packet/abstract_can_packet_container.py
@@ -1,0 +1,210 @@
+"""Abstract definition of CAN packets container."""
+
+__all__ = ["AbstractCanPacketContainer"]
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from uds.utilities import RawByte, RawBytesTuple
+from uds.transmission_attributes import AddressingTypeAlias
+from uds.can import CanAddressingInformationHandler, CanDlcHandler, \
+    CanSingleFrameHandler, CanFirstFrameHandler, CanConsecutiveFrameHandler, CanFlowControlHandler, \
+    CanAddressingFormatAlias, CanFlowStatusAlias
+from .can_packet_type import CanPacketTypeAlias, CanPacketType
+
+
+class AbstractCanPacketContainer(ABC):
+    """Abstract definition of CAN Packets containers."""
+
+    @property
+    @abstractmethod
+    def raw_frame_data(self) -> RawBytesTuple:
+        """Raw data bytes of a CAN frame that carries this CAN packet."""
+
+    @property
+    @abstractmethod
+    def can_id(self) -> int:
+        """CAN Identifier (CAN ID) of a CAN Frame that carries this CAN packet."""
+
+    @property
+    @abstractmethod
+    def addressing_format(self) -> CanAddressingFormatAlias:
+        """CAN addressing format used by this CAN packet."""
+
+    @property
+    @abstractmethod
+    def addressing_type(self) -> AddressingTypeAlias:
+        """Addressing type for which this CAN packet is relevant."""
+
+    @property
+    def dlc(self) -> int:
+        """Value of Data Length Code (DLC) of a CAN Frame that carries this CAN packet."""
+        return CanDlcHandler.encode_dlc(len(self.raw_frame_data))
+
+    @property
+    def packet_type(self) -> CanPacketTypeAlias:
+        """Type (N_PCI value) of this CAN packet."""
+        ai_data_bytes_number = CanAddressingInformationHandler.get_ai_data_bytes_number(self.addressing_format)
+        return CanPacketType(self.raw_frame_data[ai_data_bytes_number] >> 4)
+
+    @property
+    def target_address(self) -> Optional[RawByte]:
+        """
+        Target Address (TA) value of this CAN Packet.
+
+        Target Address value is used with following :ref:`addressing formats <knowledge-base-can-addressing>`:
+         - :ref:`Normal Fixed Addressing <knowledge-base-can-normal-fixed-addressing>`
+         - :ref:`Extended Addressing <knowledge-base-can-extended-addressing>`
+         - :ref:`Mixed 29-bit Addressing <knowledge-base-can-mixed-29-bit-addressing>`
+
+        None in other cases.
+        """
+        return self.get_addressing_info()[CanAddressingInformationHandler.TARGET_ADDRESS_NAME]
+
+    @property
+    def source_address(self) -> Optional[RawByte]:
+        """
+        Source Address (SA) value of this CAN Packet.
+
+        Source Address value is used with following :ref:`addressing formats <knowledge-base-can-addressing>`:
+         - :ref:`Normal Fixed Addressing <knowledge-base-can-normal-fixed-addressing>`
+         - :ref:`Mixed 29-bit Addressing <knowledge-base-can-mixed-29-bit-addressing>`
+
+        None in other cases.
+        """
+        return self.get_addressing_info()[CanAddressingInformationHandler.SOURCE_ADDRESS_NAME]
+
+    @property
+    def address_extension(self) -> Optional[RawByte]:
+        """
+        Address Extension (AE) value of this CAN Packet.
+
+        Address Extension is used with following :ref:`addressing formats <knowledge-base-can-addressing>`:
+         - :ref:`Mixed Addressing <knowledge-base-can-mixed-addressing>` - either:
+           - :ref:`Mixed 11-bit Addressing <knowledge-base-can-mixed-11-bit-addressing>`
+           - :ref:`Mixed 29-bit Addressing <knowledge-base-can-mixed-29-bit-addressing>`
+
+        None in other cases.
+        """
+        return self.get_addressing_info()[CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME]
+
+    @property
+    def data_length(self) -> Optional[int]:
+        """
+        Payload bytes number of a diagnostic message that is carried by this CAN packet.
+
+        Data length is only provided by packets of following types:
+         - :ref:`Single Frame <knowledge-base-can-single-frame>` -
+           :ref:`Single Frame Data Length <knowledge-base-can-single-frame-data-length>`
+         - :ref:`First Frame <knowledge-base-can-first-frame>` -
+           :ref:`First Frame Data Length <knowledge-base-can-first-frame-data-length>`
+
+        None in other cases.
+        """
+        if self.packet_type == CanPacketType.SINGLE_FRAME:
+            return CanSingleFrameHandler.decode_sf_dl(addressing_format=self.addressing_format,
+                                                      raw_frame_data=self.raw_frame_data)
+        if self.packet_type == CanPacketType.FIRST_FRAME:
+            return CanFirstFrameHandler.decode_ff_dl(addressing_format=self.addressing_format,
+                                                     raw_frame_data=self.raw_frame_data)
+        return None
+
+    @property
+    def sequence_number(self) -> Optional[int]:
+        """
+        Sequence Number carried by this CAN packet.
+
+        :ref:`Sequence Number <knowledge-base-can-sequence-number>` is only provided by packets of following types:
+         - :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>`
+
+        None in other cases.
+        """
+        if self.packet_type == CanPacketType.CONSECUTIVE_FRAME:
+            return CanConsecutiveFrameHandler.decode_sequence_number(addressing_format=self.addressing_format,
+                                                                     raw_frame_data=self.raw_frame_data)
+        return None
+
+    @property
+    def payload(self) -> Optional[RawBytesTuple]:
+        """
+        Diagnostic message payload carried by this CAN packet.
+
+        Payload is only provided by packets of following types:
+         - :ref:`Single Frame <knowledge-base-can-single-frame>`
+         - :ref:`First Frame <knowledge-base-can-first-frame>`
+         - :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>`
+
+        None in other cases.
+
+        .. warning:: For :ref:`Consecutive Frames <knowledge-base-can-consecutive-frame>` this value might contain
+            additional filler bytes (they are not part of diagnostic message payload) that were added during
+            :ref:`CAN Frame Data Padding <knowledge-base-can-frame-data-padding>`.
+            The presence of filler bytes in :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>`
+            cannot be determined basing solely on the information contained in this packet object.
+        """
+        if self.packet_type == CanPacketType.SINGLE_FRAME:
+            return tuple(CanSingleFrameHandler.decode_payload(addressing_format=self.addressing_format,
+                                                              raw_frame_data=self.raw_frame_data))
+        if self.packet_type == CanPacketType.FIRST_FRAME:
+            return tuple(CanFirstFrameHandler.decode_payload(addressing_format=self.addressing_format,
+                                                             raw_frame_data=self.raw_frame_data))
+        if self.packet_type == CanPacketType.CONSECUTIVE_FRAME:
+            return tuple(CanConsecutiveFrameHandler.decode_payload(addressing_format=self.addressing_format,
+                                                                   raw_frame_data=self.raw_frame_data))
+        return None
+
+    @property
+    def flow_status(self) -> Optional[CanFlowStatusAlias]:
+        """
+        Flow Status carried by this CAN packet.
+
+        :ref:`Flow Status <knowledge-base-can-flow-status>` is only provided by packets of following types:
+         - :ref:`Flow Control <knowledge-base-can-flow-control>`
+
+        None in other cases.
+        """
+        if self.packet_type == CanPacketType.FLOW_CONTROL:
+            return CanFlowControlHandler.decode_flow_status(addressing_format=self.addressing_format,
+                                                            raw_frame_data=self.raw_frame_data)
+        return None
+
+    @property
+    def block_size(self) -> Optional[RawByte]:
+        """
+        Block Size value carried by this CAN packet.
+
+        :ref:`Block Size <knowledge-base-can-flow-status>` is only provided by packets of following types:
+         - :ref:`Flow Control <knowledge-base-can-block-size>`
+
+        None in other cases.
+        """
+        if self.packet_type == CanPacketType.FLOW_CONTROL:
+            return CanFlowControlHandler.decode_block_size(addressing_format=self.addressing_format,
+                                                           raw_frame_data=self.raw_frame_data)
+        return None
+
+    @property
+    def st_min(self) -> Optional[RawByte]:
+        """
+        Separation Time minimum (STmin) value carried by this CAN packet.
+
+        :ref:`STmin <knowledge-base-can-st-min>` is only provided by packets of following types:
+         - :ref:`Flow Control <knowledge-base-can-block-size>`
+
+        None in other cases.
+        """
+        if self.packet_type == CanPacketType.FLOW_CONTROL:
+            return CanFlowControlHandler.decode_st_min(addressing_format=self.addressing_format,
+                                                       raw_frame_data=self.raw_frame_data)
+        return None
+
+    def get_addressing_info(self) -> dict:
+        """
+        Get Addressing Information carried by this packet.
+
+        :return: Addressing Information decoded from CAN ID and CAN Frame data of this packet.
+        """
+        ai_data_bytes_number = CanAddressingInformationHandler.get_ai_data_bytes_number(self.addressing_format)
+        return CanAddressingInformationHandler.decode_ai(addressing_format=self.addressing_format,
+                                                         can_id=self.can_id,
+                                                         ai_data_bytes=self.raw_frame_data[:ai_data_bytes_number])

--- a/uds/packet/abstract_packet.py
+++ b/uds/packet/abstract_packet.py
@@ -19,13 +19,13 @@ class AbstractUdsPacketContainer(ABC):
 
     @property
     @abstractmethod
-    def addressing_type(self) -> AddressingTypeAlias:
-        """Addressing for which this packet is relevant."""
+    def raw_frame_data(self) -> RawBytesTuple:
+        """Raw data bytes of a frame that carries this packet."""
 
     @property
     @abstractmethod
-    def raw_frame_data(self) -> RawBytesTuple:
-        """Raw data bytes of a frame that carries this packet."""
+    def addressing_type(self) -> AddressingTypeAlias:
+        """Addressing for which this packet is relevant."""
 
     @property
     @abstractmethod
@@ -34,13 +34,13 @@ class AbstractUdsPacketContainer(ABC):
 
     @property
     @abstractmethod
-    def payload(self) -> Optional[RawBytesTuple]:
-        """Raw payload bytes of a diagnostic message that are carried by this packet."""
+    def data_length(self) -> Optional[int]:
+        """Payload bytes number of a diagnostic message which was carried by this packet."""
 
     @property
     @abstractmethod
-    def data_length(self) -> Optional[int]:
-        """Payload bytes number of a diagnostic message which was carried by this packet."""
+    def payload(self) -> Optional[RawBytesTuple]:
+        """Raw payload bytes of a diagnostic message that are carried by this packet."""
 
 
 class AbstractUdsPacket(AbstractUdsPacketContainer):
@@ -48,13 +48,13 @@ class AbstractUdsPacket(AbstractUdsPacketContainer):
 
     @property
     @abstractmethod
-    def addressing_type(self) -> AddressingTypeAlias:
-        """Addressing for which this packet is relevant."""
+    def raw_frame_data(self) -> RawBytesTuple:
+        """Raw data bytes of a frame that carries this packet."""
 
     @property
     @abstractmethod
-    def raw_frame_data(self) -> RawBytesTuple:
-        """Raw data bytes of a frame that carries this packet."""
+    def addressing_type(self) -> AddressingTypeAlias:
+        """Addressing for which this packet is relevant."""
 
     @property
     @abstractmethod
@@ -63,13 +63,13 @@ class AbstractUdsPacket(AbstractUdsPacketContainer):
 
     @property
     @abstractmethod
-    def payload(self) -> Optional[RawBytesTuple]:
-        """Raw payload bytes of a diagnostic message that are carried by this packet."""
+    def data_length(self) -> Optional[int]:
+        """Payload bytes number of a diagnostic message which was carried by this packet."""
 
     @property
     @abstractmethod
-    def data_length(self) -> Optional[int]:
-        """Payload bytes number of a diagnostic message which was carried by this packet."""
+    def payload(self) -> Optional[RawBytesTuple]:
+        """Raw payload bytes of a diagnostic message that are carried by this packet."""
 
 
 class AbstractUdsPacketRecord(AbstractUdsPacketContainer):
@@ -161,13 +161,13 @@ class AbstractUdsPacketRecord(AbstractUdsPacketContainer):
 
     @property
     @abstractmethod
-    def addressing_type(self) -> AddressingTypeAlias:
-        """Addressing for which this packet is relevant."""
+    def raw_frame_data(self) -> RawBytesTuple:
+        """Raw data bytes of a frame that carries this packet."""
 
     @property
     @abstractmethod
-    def raw_frame_data(self) -> RawBytesTuple:
-        """Raw data bytes of a frame that carries this packet."""
+    def addressing_type(self) -> AddressingTypeAlias:
+        """Addressing for which this packet is relevant."""
 
     @property
     @abstractmethod
@@ -176,13 +176,13 @@ class AbstractUdsPacketRecord(AbstractUdsPacketContainer):
 
     @property
     @abstractmethod
-    def payload(self) -> Optional[RawBytesTuple]:
-        """Raw payload bytes of a diagnostic message that are carried by this packet."""
+    def data_length(self) -> Optional[int]:
+        """Payload bytes number of a diagnostic message which was carried by this packet."""
 
     @property
     @abstractmethod
-    def data_length(self) -> Optional[int]:
-        """Payload bytes number of a diagnostic message which was carried by this packet."""
+    def payload(self) -> Optional[RawBytesTuple]:
+        """Raw payload bytes of a diagnostic message that are carried by this packet."""
 
     @staticmethod
     @abstractmethod

--- a/uds/packet/abstract_packet.py
+++ b/uds/packet/abstract_packet.py
@@ -56,7 +56,7 @@ class AbstractUdsPacketRecord(ABC):
                  direction: TransmissionDirectionAlias,
                  transmission_time: TimeStamp) -> None:
         """
-        Create a record of a historic information about a packet that was either received or transmitted.
+        Create a record of historic information about a packet that was either received or transmitted.
 
         :param frame: Frame that carried this UDS packet.
         :param direction: Information whether this packet was transmitted or received.

--- a/uds/packet/abstract_packet.py
+++ b/uds/packet/abstract_packet.py
@@ -1,8 +1,4 @@
-"""
-Implementation of UDS packets that is common for all bus types.
-
-:ref:`UDS packets <knowledge-base-uds-packet>` are defined on middle layers of UDS OSI Model.
-"""
+"""Abstract definition of UDS packets that is common for all bus types."""
 
 __all__ = ["AbstractUdsPacketContainer", "AbstractUdsPacket", "AbstractUdsPacketRecord",
            "PacketsContainersSequence", "PacketsContainersTuple", "PacketsContainersList",
@@ -212,7 +208,7 @@ PacketsTuple = Tuple[AbstractUdsPacket, ...]
 """Typing alias of a tuple filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacket` instances."""
 PacketsList = List[AbstractUdsPacket]
 """Typing alias of a list filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacket` instances."""
-PacketsSequence = Union[PacketsTuple, PacketsList]
+PacketsSequence = Union[PacketsTuple, PacketsList]  # noqa: F841
 """Typing alias of a sequence filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacket` instances."""
 
 PacketsRecordsTuple = Tuple[AbstractUdsPacketRecord, ...]

--- a/uds/packet/abstract_packet.py
+++ b/uds/packet/abstract_packet.py
@@ -4,7 +4,7 @@ Implementation of UDS packets that is common for all bus types.
 :ref:`UDS packets <knowledge-base-uds-packet>` are defined on middle layers of UDS OSI Model.
 """
 
-__all__ = ["AbstractUdsPacket", "AbstractUdsPacketRecord",
+__all__ = ["AbstractUdsPacketContainer", "AbstractUdsPacket", "AbstractUdsPacketRecord",
            "PacketAlias", "PacketsTuple", "PacketsSequence",
            "PacketsDefinitionTuple", "PacketsDefinitionSequence",
            "PacketsRecordsTuple", "PacketsRecordsSequence"]
@@ -18,13 +18,13 @@ from uds.transmission_attributes.transmission_direction import TransmissionDirec
 from .abstract_packet_type import AbstractUdsPacketTypeAlias
 
 
-class AbstractUdsPacket(ABC):
-    """Abstract definition of UDS Packet (Network Protocol Data Unit - N_PDU)."""
+class AbstractUdsPacketContainer(ABC):
+    """Abstract definition of a container with UDS Packet information."""
 
     @property
     @abstractmethod
     def addressing_type(self) -> AddressingTypeAlias:
-        """Addressing type for which this packet is relevant."""
+        """Addressing for which this packet is relevant."""
 
     @property
     @abstractmethod
@@ -34,20 +34,49 @@ class AbstractUdsPacket(ABC):
     @property
     @abstractmethod
     def packet_type(self) -> AbstractUdsPacketTypeAlias:
-        """UDS packet type value - N_PCI value of this N_PDU."""
+        """Type (N_PCI value) of this UDS packet."""
 
     @property
     @abstractmethod
     def payload(self) -> Optional[RawBytesTuple]:
-        """Payload bytes of a diagnostic message carried by this packet."""
+        """Raw payload bytes of a diagnostic message that are carried by this packet."""
 
     @property
     @abstractmethod
     def data_length(self) -> Optional[int]:
-        """Payload bytes number of a diagnostic message which is carried by this packet."""
+        """Payload bytes number of a diagnostic message which was carried by this packet."""
 
 
-class AbstractUdsPacketRecord(ABC):
+class AbstractUdsPacket(AbstractUdsPacketContainer):
+    """Abstract definition of UDS Packet (Network Protocol Data Unit - N_PDU)."""
+
+    @property
+    @abstractmethod
+    def addressing_type(self) -> AddressingTypeAlias:
+        """Addressing for which this packet is relevant."""
+
+    @property
+    @abstractmethod
+    def raw_frame_data(self) -> RawBytesTuple:
+        """Raw data bytes of a frame that carries this packet."""
+
+    @property
+    @abstractmethod
+    def packet_type(self) -> AbstractUdsPacketTypeAlias:
+        """Type (N_PCI value) of this UDS packet."""
+
+    @property
+    @abstractmethod
+    def payload(self) -> Optional[RawBytesTuple]:
+        """Raw payload bytes of a diagnostic message that are carried by this packet."""
+
+    @property
+    @abstractmethod
+    def data_length(self) -> Optional[int]:
+        """Payload bytes number of a diagnostic message which was carried by this packet."""
+
+
+class AbstractUdsPacketRecord(AbstractUdsPacketContainer):
     """Abstract definition of a storage for historic information about transmitted or received UDS Packet."""
 
     @abstractmethod
@@ -136,23 +165,23 @@ class AbstractUdsPacketRecord(ABC):
 
     @property
     @abstractmethod
+    def addressing_type(self) -> AddressingTypeAlias:
+        """Addressing for which this packet is relevant."""
+
+    @property
+    @abstractmethod
     def raw_frame_data(self) -> RawBytesTuple:
         """Raw data bytes of a frame that carries this packet."""
 
     @property
     @abstractmethod
-    def addressing_type(self) -> AddressingTypeAlias:
-        """Addressing type over which this packet was transmitted."""
-
-    @property
-    @abstractmethod
     def packet_type(self) -> AbstractUdsPacketTypeAlias:
-        """UDS packet type value - N_PCI value of this N_PDU."""
+        """Type (N_PCI value) of this UDS packet."""
 
     @property
     @abstractmethod
     def payload(self) -> Optional[RawBytesTuple]:
-        """Payload bytes of a diagnostic message carried by this packet."""
+        """Raw payload bytes of a diagnostic message that are carried by this packet."""
 
     @property
     @abstractmethod

--- a/uds/packet/abstract_packet.py
+++ b/uds/packet/abstract_packet.py
@@ -5,9 +5,9 @@ Implementation of UDS packets that is common for all bus types.
 """
 
 __all__ = ["AbstractUdsPacketContainer", "AbstractUdsPacket", "AbstractUdsPacketRecord",
-           "PacketAlias", "PacketsTuple", "PacketsSequence",
-           "PacketsDefinitionTuple", "PacketsDefinitionSequence",
-           "PacketsRecordsTuple", "PacketsRecordsSequence"]
+           "PacketsContainersSequence", "PacketsContainersTuple", "PacketsContainersList",
+           "PacketsSequence", "PacketsTuple", "PacketsList",
+           "PacketsRecordsSequence", "PacketsRecordsTuple", "PacketsRecordsList"]
 
 from abc import ABC, abstractmethod
 from typing import Union, Optional, Any, Tuple, List
@@ -201,19 +201,23 @@ class AbstractUdsPacketRecord(AbstractUdsPacketContainer):
         """
 
 
-PacketsDefinitionTuple = Tuple[AbstractUdsPacket, ...]
-"""Typing alias of a tuple filled with :class:`~uds.message.uds_packet.AbstractUdsPacket` instances."""
-PacketsDefinitionSequence = Union[PacketsDefinitionTuple, List[AbstractUdsPacket]]
-"""Typing alias of a sequence filled with :class:`~uds.message.uds_packet.AbstractUdsPacket` instances."""
+PacketsContainersTuple = Tuple[AbstractUdsPacketContainer, ...]
+"""Typing alias of a tuple filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacketContainer` instances."""
+PacketsContainersList = List[AbstractUdsPacketContainer]
+"""Typing alias of a list filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacketContainer` instances."""
+PacketsContainersSequence = Union[PacketsContainersTuple, PacketsContainersList]
+"""Typing alias of a sequence filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacketContainer` instances."""
+
+PacketsTuple = Tuple[AbstractUdsPacket, ...]
+"""Typing alias of a tuple filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacket` instances."""
+PacketsList = List[AbstractUdsPacket]
+"""Typing alias of a list filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacket` instances."""
+PacketsSequence = Union[PacketsTuple, PacketsList]
+"""Typing alias of a sequence filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacket` instances."""
 
 PacketsRecordsTuple = Tuple[AbstractUdsPacketRecord, ...]
-"""Typing alias of a tuple filled with :class:`~uds.message.uds_packet.AbstractUdsPacketRecord` instances."""
-PacketsRecordsSequence = Union[PacketsRecordsTuple, List[AbstractUdsPacketRecord]]
-"""Typing alias of a sequence filled with :class:`~uds.message.uds_packet.AbstractUdsPacketRecord` instances."""
-
-PacketAlias = Union[AbstractUdsPacket, AbstractUdsPacketRecord]
-"""Typing alias of UDS packet."""
-PacketsTuple = Union[PacketsDefinitionTuple, PacketsRecordsTuple]  # noqa: F841
-"""Typing alias of a tuple filled with UDS packets."""
-PacketsSequence = Union[PacketsDefinitionSequence, PacketsRecordsSequence]
-"""Typing alias of a sequence filled with UDS packets."""
+"""Typing alias of a tuple filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacketRecord` instances."""
+PacketsRecordsList = List[AbstractUdsPacketRecord]
+"""Typing alias of a list filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacketRecord` instances."""
+PacketsRecordsSequence = Union[PacketsRecordsTuple, PacketsRecordsList]
+"""Typing alias of a sequence filled with :class:`~uds.packet.abstract_packet.AbstractUdsPacketRecord` instances."""

--- a/uds/packet/can_packet.py
+++ b/uds/packet/can_packet.py
@@ -698,14 +698,14 @@ class AnyCanPacket(AbstractCanPacketContainer, AbstractUdsPacket):
             return None
         return self.raw_frame_data[ai_data_bytes_number] >> 4
 
-    def get_addressing_info(self) -> dict:
+    def get_addressing_information(self) -> dict:
         """
         Get Addressing Information carried by this packet.
 
         :return: Addressing Information decoded from CAN ID and CAN Frame data of this packet.
         """
         try:
-            return super().get_addressing_info()
+            return super().get_addressing_information()
         except (TypeError, ValueError, IndexError):
             return {
                 CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: None,

--- a/uds/packet/can_packet.py
+++ b/uds/packet/can_packet.py
@@ -712,9 +712,8 @@ class AnyCanPacket(AbstractUdsPacket):
         """
         Create a storage for a single CAN packet.
 
-        .. note:: Intention of this of this method is to create a CAN Packet that is incompatible with ISO 15765,
-            therefore any parameter validation is restricted to sanity check (whether the data can be converted into
-            a CAN Frame).
+        .. note:: Intention of this method is to create a CAN Packet that is incompatible with ISO 15765, therefore
+            any parameter validation is restricted to sanity check (whether the data can be put into a CAN Frame).
             If you want to create a valid CAN Packet, use :class:`~uds.packet.can_packet.CanPacket` instead.
 
         :param raw_frame_data: Raw data bytes of a CAN frame that carries this CAN packet.

--- a/uds/packet/can_packet.py
+++ b/uds/packet/can_packet.py
@@ -12,11 +12,12 @@ from uds.can import DEFAULT_FILLER_BYTE, CanIdHandler, CanDlcHandler, \
     CanAddressingFormat, CanAddressingFormatAlias, CanAddressingInformationHandler, \
     CanSingleFrameHandler, CanFirstFrameHandler, CanConsecutiveFrameHandler, \
     CanFlowControlHandler, CanFlowStatusAlias
+from .abstract_can_packet_container import AbstractCanPacketContainer
 from .abstract_packet import AbstractUdsPacket
 from .can_packet_type import CanPacketType, CanPacketTypeAlias
 
 
-class CanPacket(AbstractUdsPacket):
+class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):
     """
     Definition of a CAN packet.
 
@@ -489,9 +490,9 @@ class CanPacket(AbstractUdsPacket):
         return self.__raw_frame_data
 
     @property
-    def addressing_type(self) -> AddressingTypeAlias:
-        """Addressing type for which this CAN packet is relevant."""
-        return self.__addressing_type
+    def can_id(self) -> int:
+        """CAN Identifier (CAN ID) of a CAN Frame that carries this CAN packet."""
+        return self.__can_id
 
     @property
     def addressing_format(self) -> CanAddressingFormatAlias:
@@ -499,19 +500,19 @@ class CanPacket(AbstractUdsPacket):
         return self.__addressing_format
 
     @property
-    def packet_type(self) -> CanPacketTypeAlias:
-        """Type (N_PCI value) of this CAN packet."""
-        return self.__packet_type
-
-    @property
-    def can_id(self) -> int:
-        """CAN Identifier (CAN ID) of a CAN Frame that carries this CAN packet."""
-        return self.__can_id
+    def addressing_type(self) -> AddressingTypeAlias:
+        """Addressing type for which this CAN packet is relevant."""
+        return self.__addressing_type
 
     @property
     def dlc(self) -> int:
         """Value of Data Length Code (DLC) of a CAN Frame that carries this CAN packet."""
         return self.__dlc
+
+    @property
+    def packet_type(self) -> CanPacketTypeAlias:
+        """Type (N_PCI value) of this CAN packet."""
+        return self.__packet_type
 
     @property
     def target_address(self) -> Optional[RawByte]:
@@ -554,116 +555,6 @@ class CanPacket(AbstractUdsPacket):
         """
         return self.__address_extension
 
-    @property
-    def payload(self) -> Optional[RawBytesTuple]:
-        """
-        Diagnostic message payload carried by this CAN packet.
-
-        Payload is only provided by packets of following types:
-         - :ref:`Single Frame <knowledge-base-can-single-frame>`
-         - :ref:`First Frame <knowledge-base-can-first-frame>`
-         - :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>`
-
-        None in other cases.
-
-        .. warning:: For :ref:`Consecutive Frames <knowledge-base-can-consecutive-frame>` this value might contain
-            additional filler bytes (they are not part of diagnostic message payload) that were added during
-            :ref:`CAN Frame Data Padding <knowledge-base-can-frame-data-padding>`.
-            The presence of filler bytes in :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>`
-            cannot be determined basing solely on the information contained in this packet object.
-        """
-        if self.packet_type == CanPacketType.SINGLE_FRAME:
-            return tuple(CanSingleFrameHandler.decode_payload(addressing_format=self.addressing_format,
-                                                              raw_frame_data=self.raw_frame_data))
-        if self.packet_type == CanPacketType.FIRST_FRAME:
-            return tuple(CanFirstFrameHandler.decode_payload(addressing_format=self.addressing_format,
-                                                             raw_frame_data=self.raw_frame_data))
-        if self.packet_type == CanPacketType.CONSECUTIVE_FRAME:
-            return tuple(CanConsecutiveFrameHandler.decode_payload(addressing_format=self.addressing_format,
-                                                                   raw_frame_data=self.raw_frame_data))
-        return None
-
-    @property
-    def data_length(self) -> Optional[int]:
-        """
-        Payload bytes number of a diagnostic message that is carried by this CAN packet.
-
-        Data length is only provided by packets of following types:
-         - :ref:`Single Frame <knowledge-base-can-single-frame>` -
-           :ref:`Single Frame Data Length <knowledge-base-can-single-frame-data-length>`
-         - :ref:`First Frame <knowledge-base-can-first-frame>` -
-           :ref:`First Frame Data Length <knowledge-base-can-first-frame-data-length>`
-
-        None in other cases.
-        """
-        if self.packet_type == CanPacketType.SINGLE_FRAME:
-            return CanSingleFrameHandler.decode_sf_dl(addressing_format=self.addressing_format,
-                                                      raw_frame_data=self.raw_frame_data)
-        if self.packet_type == CanPacketType.FIRST_FRAME:
-            return CanFirstFrameHandler.decode_ff_dl(addressing_format=self.addressing_format,
-                                                     raw_frame_data=self.raw_frame_data)
-        return None
-
-    @property
-    def sequence_number(self) -> Optional[int]:
-        """
-        Sequence Number carried by this CAN packet.
-
-        :ref:`Sequence Number <knowledge-base-can-sequence-number>` is only provided by packets of following types:
-         - :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>`
-
-        None in other cases.
-        """
-        if self.packet_type == CanPacketType.CONSECUTIVE_FRAME:
-            return CanConsecutiveFrameHandler.decode_sequence_number(addressing_format=self.addressing_format,
-                                                                     raw_frame_data=self.raw_frame_data)
-        return None
-
-    @property
-    def flow_status(self) -> Optional[CanFlowStatusAlias]:
-        """
-        Flow Status carried by this CAN packet.
-
-        :ref:`Flow Status <knowledge-base-can-flow-status>` is only provided by packets of following types:
-         - :ref:`Flow Control <knowledge-base-can-flow-control>`
-
-        None in other cases.
-        """
-        if self.packet_type == CanPacketType.FLOW_CONTROL:
-            return CanFlowControlHandler.decode_flow_status(addressing_format=self.addressing_format,
-                                                            raw_frame_data=self.raw_frame_data)
-        return None
-
-    @property
-    def block_size(self) -> Optional[RawByte]:
-        """
-        Block Size value carried by this CAN packet.
-
-        :ref:`Block Size <knowledge-base-can-flow-status>` is only provided by packets of following types:
-         - :ref:`Flow Control <knowledge-base-can-block-size>`
-
-        None in other cases.
-        """
-        if self.packet_type == CanPacketType.FLOW_CONTROL:
-            return CanFlowControlHandler.decode_block_size(addressing_format=self.addressing_format,
-                                                           raw_frame_data=self.raw_frame_data)
-        return None
-
-    @property
-    def st_min(self) -> Optional[RawByte]:
-        """
-        Separation Time minimum (STmin) value carried by this CAN packet.
-
-        :ref:`STmin <knowledge-base-can-st-min>` is only provided by packets of following types:
-         - :ref:`Flow Control <knowledge-base-can-block-size>`
-
-        None in other cases.
-        """
-        if self.packet_type == CanPacketType.FLOW_CONTROL:
-            return CanFlowControlHandler.decode_st_min(addressing_format=self.addressing_format,
-                                                       raw_frame_data=self.raw_frame_data)
-        return None
-
     def __validate_unambiguous_ai_change(self, addressing_format: CanAddressingFormatAlias) -> None:
         """
         Validate whether CAN Addressing Format change to provided value is ambiguous.
@@ -689,7 +580,7 @@ class CanPacket(AbstractUdsPacket):
             self.__raw_frame_data = tuple(ai_data_bytes + list(self.__raw_frame_data[len(ai_data_bytes):]))
 
 
-class AnyCanPacket(AbstractUdsPacket):
+class AnyCanPacket(AbstractCanPacketContainer, AbstractUdsPacket):
     """
     Definition of a CAN packet in any format.
 
@@ -750,19 +641,19 @@ class AnyCanPacket(AbstractUdsPacket):
         self.__raw_frame_data = tuple(value)
 
     @property
-    def addressing_type(self) -> AddressingTypeAlias:
-        """Addressing type for which this CAN packet is relevant."""
-        return self.__addressing_type
+    def can_id(self) -> int:
+        """CAN Identifier (CAN ID) of a CAN Frame that carries this CAN packet."""
+        return self.__can_id
 
-    @addressing_type.setter
-    def addressing_type(self, value: AddressingTypeAlias):
+    @can_id.setter
+    def can_id(self, value: int):
         """
-        Set value of addressing type for which this CAN packet is relevant.
+        Set CAN Identifier (CAN ID) value of a CAN Frame that carries this CAN packet.
 
-        :param value: Addressing type value to set.
+        :param value: CAN ID value to set.
         """
-        AddressingType.validate_member(value)
-        self.__addressing_type = AddressingType(value)
+        CanIdHandler.validate_can_id(value)
+        self.__can_id = value
 
     @property
     def addressing_format(self) -> CanAddressingFormatAlias:
@@ -780,19 +671,24 @@ class AnyCanPacket(AbstractUdsPacket):
         self.__addressing_format = CanAddressingFormat(value)
 
     @property
-    def can_id(self) -> int:
-        """CAN Identifier (CAN ID) of a CAN Frame that carries this CAN packet."""
-        return self.__can_id
+    def addressing_type(self) -> AddressingTypeAlias:
+        """Addressing type for which this CAN packet is relevant."""
+        return self.__addressing_type
 
-    @can_id.setter
-    def can_id(self, value: int):
+    @addressing_type.setter
+    def addressing_type(self, value: AddressingTypeAlias):
         """
-        Set CAN Identifier (CAN ID) value of a CAN Frame that carries this CAN packet.
+        Set value of addressing type for which this CAN packet is relevant.
 
-        :param value: CAN ID value to set.
+        :param value: Addressing type value to set.
         """
-        CanIdHandler.validate_can_id(value)
-        self.__can_id = value
+        AddressingType.validate_member(value)
+        self.__addressing_type = AddressingType(value)
+
+    @property
+    def dlc(self) -> int:
+        """Value of Data Length Code (DLC) of a CAN Frame that carries this CAN packet."""
+        return CanDlcHandler.encode_dlc(len(self.raw_frame_data))
 
     @property
     def packet_type(self) -> Optional[Nibble]:  # type: ignore
@@ -802,149 +698,18 @@ class AnyCanPacket(AbstractUdsPacket):
             return None
         return self.raw_frame_data[ai_data_bytes_number] >> 4
 
-    @property
-    def dlc(self) -> int:
-        """Value of Data Length Code (DLC) of a CAN Frame that carries this CAN packet."""
-        return CanDlcHandler.encode_dlc(len(self.raw_frame_data))
-
-    @property
-    def target_address(self) -> Optional[RawByte]:
-        """
-        Target Address (TA) value of this CAN Packet.
-
-        Target Address value is used with following :ref:`addressing formats <knowledge-base-can-addressing>`:
-         - :ref:`Normal Fixed Addressing <knowledge-base-can-normal-fixed-addressing>`
-         - :ref:`Extended Addressing <knowledge-base-can-extended-addressing>`
-         - :ref:`Mixed 29-bit Addressing <knowledge-base-can-mixed-29-bit-addressing>`
-
-        None in other cases.
-        """
-        addressing_info = self.__get_addressing_info()
-        return None if addressing_info is None else addressing_info[CanAddressingInformationHandler.TARGET_ADDRESS_NAME]
-
-    @property
-    def source_address(self) -> Optional[RawByte]:
-        """
-        Source Address (SA) value of this CAN Packet.
-
-        Source Address value is used with following :ref:`addressing formats <knowledge-base-can-addressing>`:
-         - :ref:`Normal Fixed Addressing <knowledge-base-can-normal-fixed-addressing>`
-         - :ref:`Mixed 29-bit Addressing <knowledge-base-can-mixed-29-bit-addressing>`
-
-        None in other cases.
-        """
-        addressing_info = self.__get_addressing_info()
-        return None if addressing_info is None else addressing_info[CanAddressingInformationHandler.SOURCE_ADDRESS_NAME]
-
-    @property
-    def address_extension(self) -> Optional[RawByte]:
-        """
-        Address Extension (AE) value of this CAN Packet.
-
-        Address Extension is used with following :ref:`addressing formats <knowledge-base-can-addressing>`:
-         - :ref:`Mixed Addressing <knowledge-base-can-mixed-addressing>` - either:
-           - :ref:`Mixed 11-bit Addressing <knowledge-base-can-mixed-11-bit-addressing>`
-           - :ref:`Mixed 29-bit Addressing <knowledge-base-can-mixed-29-bit-addressing>`
-
-        None in other cases.
-        """
-        addressing_info = self.__get_addressing_info()
-        return None if addressing_info is None \
-            else addressing_info[CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME]
-
-    @property
-    def payload(self) -> Optional[RawBytesTuple]:
-        """
-        Diagnostic message payload carried by this CAN packet.
-
-        Payload is only provided by packets of following types:
-         - :ref:`Single Frame <knowledge-base-can-single-frame>`
-         - :ref:`First Frame <knowledge-base-can-first-frame>`
-         - :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>`
-
-        None in other cases.
-
-        .. warning:: For :ref:`Consecutive Frames <knowledge-base-can-consecutive-frame>` this value might contain
-            additional filler bytes (they are not part of diagnostic message payload) that were added during
-            :ref:`CAN Frame Data Padding <knowledge-base-can-frame-data-padding>`.
-            The presence of filler bytes in :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>`
-            cannot be determined basing solely on the information contained in this packet object.
-        """
-        return CanPacket.payload.fget(self)  # type: ignore
-
-    @property
-    def data_length(self) -> Optional[int]:
-        """
-        Payload bytes number of a diagnostic message that is carried by this CAN packet.
-
-        Data length is only provided by packets of following types:
-         - :ref:`Single Frame <knowledge-base-can-single-frame>` -
-           :ref:`Single Frame Data Length <knowledge-base-can-single-frame-data-length>`
-         - :ref:`First Frame <knowledge-base-can-first-frame>` -
-           :ref:`First Frame Data Length <knowledge-base-can-first-frame-data-length>`
-
-        None in other cases.
-        """
-        return CanPacket.data_length.fget(self)  # type: ignore
-
-    @property
-    def sequence_number(self) -> Optional[int]:
-        """
-        Sequence Number carried by this CAN packet.
-
-        :ref:`Sequence Number <knowledge-base-can-sequence-number>` is only provided by packets of following types:
-         - :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>`
-
-        None in other cases.
-        """
-        return CanPacket.sequence_number.fget(self)  # type: ignore
-
-    @property
-    def flow_status(self) -> Optional[Nibble]:
-        """
-        Flow Status carried by this CAN packet.
-
-        :ref:`Flow Status <knowledge-base-can-flow-status>` is only provided by packets of following types:
-         - :ref:`Flow Control <knowledge-base-can-flow-control>`
-
-        None in other cases.
-        """
-        return CanPacket.flow_status.fget(self)  # type: ignore
-
-    @property
-    def block_size(self) -> Optional[RawByte]:
-        """
-        Block Size value carried by this CAN packet.
-
-        :ref:`Block Size <knowledge-base-can-flow-status>` is only provided by packets of following types:
-         - :ref:`Flow Control <knowledge-base-can-block-size>`
-
-        None in other cases.
-        """
-        return CanPacket.block_size.fget(self)  # type: ignore
-
-    @property
-    def st_min(self) -> Optional[RawByte]:
-        """
-        Separation Time minimum (STmin) value carried by this CAN packet.
-
-        :ref:`STmin <knowledge-base-can-st-min>` is only provided by packets of following types:
-         - :ref:`Flow Control <knowledge-base-can-block-size>`
-
-        None in other cases.
-        """
-        return CanPacket.st_min.fget(self)  # type: ignore
-
-    def __get_addressing_info(self) -> Optional[dict]:
+    def get_addressing_info(self) -> dict:
         """
         Get Addressing Information carried by this packet.
 
         :return: Addressing Information decoded from CAN ID and CAN Frame data of this packet.
-            None if Addressing Information cannot be decoded (invalid format of the CAN Packet).
         """
-        ai_data_bytes_number = CanAddressingInformationHandler.get_ai_data_bytes_number(self.addressing_format)
-        if ai_data_bytes_number > len(self.raw_frame_data):
-            return None
-        return CanAddressingInformationHandler.decode_ai(addressing_format=self.addressing_format,
-                                                         can_id=self.can_id,
-                                                         ai_data_bytes=self.raw_frame_data[:ai_data_bytes_number])
+        try:
+            return super().get_addressing_info()
+        except (TypeError, ValueError, IndexError):
+            return {
+                CanAddressingInformationHandler.ADDRESSING_TYPE_NAME: None,
+                CanAddressingInformationHandler.TARGET_ADDRESS_NAME: None,
+                CanAddressingInformationHandler.SOURCE_ADDRESS_NAME: None,
+                CanAddressingInformationHandler.ADDRESS_EXTENSION_NAME: None,
+            }

--- a/uds/packet/can_packet_record.py
+++ b/uds/packet/can_packet_record.py
@@ -34,7 +34,7 @@ class CanPacketRecord(AbstractUdsPacketRecord):
                  addressing_format: CanAddressingFormatAlias,
                  transmission_time: TimeStamp) -> None:
         """
-        Create a record of a historic information about a CAN packet that was either received or transmitted.
+        Create a record of historic information about a CAN packet that was either received or transmitted.
 
         :param frame: Either received or transmitted CAN frame that carried this CAN Packet.
         :param direction: Information whether this packet was transmitted or received.

--- a/uds/packet/can_packet_record.py
+++ b/uds/packet/can_packet_record.py
@@ -9,9 +9,9 @@ from can import Message as PythonCanMessage
 from uds.utilities import RawByte, RawBytesTuple, TimeStamp, InconsistentArgumentsError
 from uds.transmission_attributes import AddressingType, AddressingTypeAlias, TransmissionDirectionAlias
 from uds.can import CanAddressingFormat, CanAddressingFormatAlias, CanAddressingInformationHandler, \
-    CanDlcHandler, CanIdHandler, CanFlowStatusAlias
-from .can_packet import CanPacket
+    CanDlcHandler, CanIdHandler
 from .can_packet_type import CanPacketType, CanPacketTypeAlias
+from .abstract_can_packet_container import AbstractCanPacketContainer
 from .abstract_packet import AbstractUdsPacketRecord
 
 
@@ -19,7 +19,7 @@ CanFrameAlias = Union[PythonCanMessage]
 """Alias of supported CAN frames objects."""
 
 
-class CanPacketRecord(AbstractUdsPacketRecord):
+class CanPacketRecord(AbstractCanPacketContainer, AbstractUdsPacketRecord):
     """
     Definition of a CAN packet Record.
 
@@ -62,31 +62,6 @@ class CanPacketRecord(AbstractUdsPacketRecord):
         raise NotImplementedError(f"Missing implementation for: {self.frame}")
 
     @property
-    def addressing_type(self) -> AddressingTypeAlias:
-        """Addressing type over which this CAN packet was transmitted."""
-        return self.__addressing_type
-
-    @property
-    def addressing_format(self) -> CanAddressingFormatAlias:
-        """CAN addressing format used by this CAN packet."""
-        return self.__addressing_format
-
-    @property
-    def packet_type(self) -> CanPacketTypeAlias:
-        """CAN packet type value - N_PCI value of this N_PDU."""
-        return self.__packet_type
-
-    @property
-    def payload(self) -> Optional[RawBytesTuple]:
-        """Payload bytes of a diagnostic message carried by this CAN packet."""
-        return CanPacket.payload.fget(self)  # type: ignore
-
-    @property
-    def data_length(self) -> Optional[int]:
-        """Payload bytes number of a diagnostic message which was carried by this CAN packet."""
-        return CanPacket.data_length.fget(self)  # type: ignore
-
-    @property
     def can_id(self) -> int:
         """CAN Identifier (CAN ID) of a CAN Frame that carries this CAN packet."""
         if isinstance(self.frame, PythonCanMessage):
@@ -94,9 +69,19 @@ class CanPacketRecord(AbstractUdsPacketRecord):
         raise NotImplementedError(f"Missing implementation for: {self.frame}")
 
     @property
-    def dlc(self) -> int:
-        """Value of Data Length Code (DLC) of a CAN Frame that carries this CAN packet."""
-        return CanDlcHandler.encode_dlc(len(self.raw_frame_data))
+    def addressing_format(self) -> CanAddressingFormatAlias:
+        """CAN addressing format used by this CAN packet."""
+        return self.__addressing_format
+
+    @property
+    def addressing_type(self) -> AddressingTypeAlias:
+        """Addressing type over which this CAN packet was transmitted."""
+        return self.__addressing_type
+
+    @property
+    def packet_type(self) -> CanPacketTypeAlias:
+        """CAN packet type value - N_PCI value of this N_PDU."""
+        return self.__packet_type
 
     @property
     def target_address(self) -> Optional[RawByte]:
@@ -138,54 +123,6 @@ class CanPacketRecord(AbstractUdsPacketRecord):
         None in other cases.
         """
         return self.__address_extension
-
-    @property
-    def sequence_number(self) -> Optional[int]:
-        """
-        Sequence Number carried by this CAN packet.
-
-        :ref:`Sequence Number <knowledge-base-can-sequence-number>` is only provided by packets of following types:
-         - :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>`
-
-        None in other cases.
-        """
-        return CanPacket.sequence_number.fget(self)  # type: ignore
-
-    @property
-    def flow_status(self) -> Optional[CanFlowStatusAlias]:
-        """
-        Flow Status carried by this CAN packet.
-
-        :ref:`Flow Status <knowledge-base-can-flow-status>` is only provided by packets of following types:
-         - :ref:`Flow Control <knowledge-base-can-flow-control>`
-
-        None in other cases.
-        """
-        return CanPacket.flow_status.fget(self)  # type: ignore
-
-    @property
-    def block_size(self) -> Optional[RawByte]:
-        """
-        Block Size value carried by this CAN packet.
-
-        :ref:`Block Size <knowledge-base-can-flow-status>` is only provided by packets of following types:
-         - :ref:`Flow Control <knowledge-base-can-block-size>`
-
-        None in other cases.
-        """
-        return CanPacket.block_size.fget(self)  # type: ignore
-
-    @property
-    def st_min(self) -> Optional[RawByte]:
-        """
-        Separation Time minimum (STmin) value carried by this CAN packet.
-
-        :ref:`STmin <knowledge-base-can-st-min>` is only provided by packets of following types:
-         - :ref:`Flow Control <knowledge-base-can-block-size>`
-
-        None in other cases.
-        """
-        return CanPacket.st_min.fget(self)  # type: ignore
 
     @staticmethod
     def _validate_frame(value: Any) -> None:

--- a/uds/segmentation/abstract_segmenter.py
+++ b/uds/segmentation/abstract_segmenter.py
@@ -6,7 +6,7 @@ from typing import Tuple, Type, Union, Any
 from abc import ABC, abstractmethod
 
 from uds.message import UdsMessage, UdsMessageRecord
-from uds.packet import PacketAlias, PacketsSequence, PacketsDefinitionTuple
+from uds.packet import AbstractUdsPacketContainer, PacketsContainersSequence, PacketsTuple
 
 
 class SegmentationError(ValueError):
@@ -27,7 +27,7 @@ class AbstractSegmenter(ABC):
 
     @property
     @abstractmethod
-    def supported_packet_classes(self) -> Tuple[Type[PacketAlias], ...]:
+    def supported_packet_classes(self) -> Tuple[Type[AbstractUdsPacketContainer], ...]:
         """Classes that define packet objects supported by this segmenter."""
 
     def is_supported_packet(self, value: Any) -> bool:
@@ -58,7 +58,7 @@ class AbstractSegmenter(ABC):
         return len({type(element) for element in value}) == 1
 
     @abstractmethod
-    def is_complete_packets_sequence(self, packets: PacketsSequence) -> bool:
+    def is_complete_packets_sequence(self, packets: PacketsContainersSequence) -> bool:
         """
         Check whether provided packets are full sequence of packets that form exactly one diagnostic message.
 
@@ -69,7 +69,7 @@ class AbstractSegmenter(ABC):
         """
 
     @abstractmethod
-    def desegmentation(self, packets: PacketsSequence) -> Union[UdsMessage, UdsMessageRecord]:
+    def desegmentation(self, packets: PacketsContainersSequence) -> Union[UdsMessage, UdsMessageRecord]:
         """
         Perform desegmentation of UDS packets.
 
@@ -81,7 +81,7 @@ class AbstractSegmenter(ABC):
         """
 
     @abstractmethod
-    def segmentation(self, message: UdsMessage) -> PacketsDefinitionTuple:
+    def segmentation(self, message: UdsMessage) -> PacketsTuple:
         """
         Perform segmentation of a diagnostic message.
 

--- a/uds/transport_interface/abstract_packet_queue.py
+++ b/uds/transport_interface/abstract_packet_queue.py
@@ -2,7 +2,7 @@
 
 __all__ = ["AbstractPacketsQueue"]
 
-from typing import NoReturn, Optional
+from typing import NoReturn
 from abc import ABC, abstractmethod
 
 from uds.packet import AbstractUdsPacketContainer
@@ -12,7 +12,7 @@ class AbstractPacketsQueue(ABC):
     """Abstract definition of a queue with UDS packets."""
 
     @abstractmethod
-    def __init__(self, packet_class: Optional[type] = None) -> None:  # noqa: F841
+    def __init__(self, packet_class: type = None) -> None:  # noqa: F841
         """
         Create a queue for UDS packets storing.
 

--- a/uds/transport_interface/abstract_packet_queue.py
+++ b/uds/transport_interface/abstract_packet_queue.py
@@ -12,7 +12,7 @@ class AbstractPacketsQueue(ABC):
     """Abstract definition of a queue with UDS packets."""
 
     @abstractmethod
-    def __init__(self, packet_class: type = None) -> None:  # noqa: F841
+    def __init__(self, packet_class: type) -> None:  # noqa: F841
         """
         Create a queue for UDS packets storing.
 

--- a/uds/transport_interface/abstract_packet_queue.py
+++ b/uds/transport_interface/abstract_packet_queue.py
@@ -5,7 +5,7 @@ __all__ = ["AbstractPacketsQueue"]
 from typing import NoReturn, Optional
 from abc import ABC, abstractmethod
 
-from uds.packet import PacketAlias
+from uds.packet import AbstractUdsPacketContainer
 
 
 class AbstractPacketsQueue(ABC):
@@ -56,7 +56,7 @@ class AbstractPacketsQueue(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def get_packet(self) -> PacketAlias:
+    async def get_packet(self) -> AbstractUdsPacketContainer:
         """
         Get the next packet from the queue.
 
@@ -64,7 +64,7 @@ class AbstractPacketsQueue(ABC):
         """
 
     @abstractmethod
-    async def put_packet(self, packet: PacketAlias) -> None:
+    async def put_packet(self, packet: AbstractUdsPacketContainer) -> None:
         """
         Add a packet to the queue.
 

--- a/uds/transport_interface/packet_queues.py
+++ b/uds/transport_interface/packet_queues.py
@@ -5,7 +5,7 @@ __all__ = ["PacketsQueue", "TimestampedPacketsQueue"]
 from typing import Optional
 
 from uds.utilities import TimeStamp
-from uds.packet import PacketAlias
+from uds.packet import AbstractUdsPacketContainer
 from .abstract_packet_queue import AbstractPacketsQueue
 
 
@@ -24,7 +24,7 @@ class TimestampedPacketsQueue(AbstractPacketsQueue):
         """
         raise NotImplementedError
 
-    async def get_packet(self) -> PacketAlias:
+    async def get_packet(self) -> AbstractUdsPacketContainer:
         """
         Get the next packet from the queue.
 
@@ -35,7 +35,7 @@ class TimestampedPacketsQueue(AbstractPacketsQueue):
         """
         raise NotImplementedError
 
-    async def put_packet(self, packet: PacketAlias, timestamp: Optional[TimeStamp] = None) -> None:  # noqa: F841
+    async def put_packet(self, packet: AbstractUdsPacketContainer, timestamp: Optional[TimeStamp] = None) -> None:  # noqa: F841
         """
         Add a packet to the queue.
 
@@ -58,7 +58,7 @@ class PacketsQueue(AbstractPacketsQueue):
         """
         raise NotImplementedError
 
-    async def get_packet(self) -> PacketAlias:
+    async def get_packet(self) -> AbstractUdsPacketContainer:
         """
         Get the next packet from the queue.
 
@@ -66,7 +66,7 @@ class PacketsQueue(AbstractPacketsQueue):
         """
         raise NotImplementedError
 
-    async def put_packet(self, packet: PacketAlias) -> None:
+    async def put_packet(self, packet: AbstractUdsPacketContainer) -> None:
         """
         Add a packet at the end of the queue.
 


### PR DESCRIPTION
## Description
Common abstraction added:
- `AbstractUdsMessageContainer` for `UdsMessage` and `UdsMessageRecord`
- `AbstractUdsPacketContainer` for `AbstractUdsPacket` and `AbstractUdsPacketRecord`
- `AbstractCanPacketContainer` for `CanPacket`, `AnyCanPacket` and `CanPacketRecord`

## How Has This Been Tested?
- unit and integration tests

## Process
I know the [process](https://github.com/mdabrowski1990/uds/wiki/Software-Development-Life-Cycle) and did my best to follow it
