### PR TITLE
Annotations update

### DIFF
--- a/uds/can/abstract_addressing_information.py
+++ b/uds/can/abstract_addressing_information.py
@@ -6,7 +6,6 @@ from typing import Optional, TypedDict
 from abc import ABC, abstractmethod
 from copy import deepcopy
 
-from uds.utilities import RawByte
 from uds.transmission_attributes import AddressingTypeAlias, AddressingType
 from .addressing_format import CanAddressingFormatAlias
 from .frame_fields import CanIdHandler
@@ -32,16 +31,16 @@ class AbstractCanAddressingInformation(ABC):
         """Alias of :ref:`Addressing Information <knowledge-base-n-ai>` configuration parameters."""
 
         can_id: int
-        target_address: RawByte
-        source_address: RawByte
-        address_extension: RawByte
+        target_address: int
+        source_address: int
+        address_extension: int
 
     class _OptionalPacketAIParamsAlias(TypedDict, total=False):
         """Alias of optional :ref:`Addressing Information <knowledge-base-n-ai>` parameters of CAN packets stream."""
 
-        target_address: RawByte
-        source_address: RawByte
-        address_extension: RawByte
+        target_address: int
+        source_address: int
+        address_extension: int
 
     class PacketAIParamsAlias(_OptionalPacketAIParamsAlias, total=True):
         """Alias of :ref:`Addressing Information <knowledge-base-n-ai>` parameters of CAN packets stream."""
@@ -145,9 +144,9 @@ class AbstractCanAddressingInformation(ABC):
     def validate_packet_ai(cls,
                            addressing_type: AddressingTypeAlias,
                            can_id: Optional[int] = None,
-                           target_address: Optional[RawByte] = None,
-                           source_address: Optional[RawByte] = None,
-                           address_extension: Optional[RawByte] = None) -> PacketAIParamsAlias:
+                           target_address: Optional[int] = None,
+                           source_address: Optional[int] = None,
+                           address_extension: Optional[int] = None) -> PacketAIParamsAlias:
         """
         Validate Addressing Information parameters of a CAN packet.
 

--- a/uds/can/addressing_information.py
+++ b/uds/can/addressing_information.py
@@ -8,7 +8,7 @@ __all__ = ["CanAddressingInformation"]
 
 from typing import Optional, Dict, TypedDict, Type
 
-from uds.utilities import RawByte, RawBytes, RawBytesList, validate_raw_byte, validate_raw_bytes, \
+from uds.utilities import RawBytes, RawBytesList, validate_raw_byte, validate_raw_bytes, \
     InconsistentArgumentsError
 from uds.transmission_attributes import AddressingTypeAlias
 from .addressing_format import CanAddressingFormat, CanAddressingFormatAlias
@@ -34,16 +34,16 @@ class CanAddressingInformation:
     class DataBatesAIParamsAlias(TypedDict, total=False):
         """Alias of :ref:`Addressing Information <knowledge-base-n-ai>` parameters encoded in data field."""
 
-        target_address: RawByte
-        address_extension: RawByte
+        target_address: int
+        address_extension: int
 
     class DecodedAIParamsAlias(TypedDict, total=True):
         """Alias of :ref:`Addressing Information <knowledge-base-n-ai>` parameters encoded in CAN ID and data field."""
 
         addressing_type: Optional[AddressingTypeAlias]
-        target_address: Optional[RawByte]
-        source_address: Optional[RawByte]
-        address_extension: Optional[RawByte]
+        target_address: Optional[int]
+        source_address: Optional[int]
+        address_extension: Optional[int]
 
     def __new__(cls,  # type: ignore
                 addressing_format: CanAddressingFormatAlias,
@@ -71,9 +71,9 @@ class CanAddressingInformation:
                            addressing_format: CanAddressingFormatAlias,
                            addressing_type: AddressingTypeAlias,
                            can_id: Optional[int] = None,
-                           target_address: Optional[RawByte] = None,
-                           source_address: Optional[RawByte] = None,
-                           address_extension: Optional[RawByte] = None
+                           target_address: Optional[int] = None,
+                           source_address: Optional[int] = None,
+                           address_extension: Optional[int] = None
                            ) -> AbstractCanAddressingInformation.PacketAIParamsAlias:
         """
         Validate Addressing Information parameters of a CAN packet.
@@ -178,8 +178,8 @@ class CanAddressingInformation:
     @classmethod
     def encode_ai_data_bytes(cls,
                              addressing_format: CanAddressingFormatAlias,
-                             target_address: Optional[RawByte] = None,
-                             address_extension: Optional[RawByte] = None) -> RawBytesList:
+                             target_address: Optional[int] = None,
+                             address_extension: Optional[int] = None) -> RawBytesList:
         """
         Generate a list of data bytes that carry Addressing Information.
 

--- a/uds/can/consecutive_frame.py
+++ b/uds/can/consecutive_frame.py
@@ -9,8 +9,8 @@ __all__ = ["CanConsecutiveFrameHandler"]
 
 from typing import Optional
 
-from uds.utilities import Nibble, RawByte, RawBytes, RawBytesList, \
-    validate_raw_bytes, validate_raw_byte, validate_nibble, InconsistentArgumentsError
+from uds.utilities import RawBytes, RawBytesList, validate_raw_bytes, validate_raw_byte, validate_nibble, \
+    InconsistentArgumentsError
 from .addressing_format import CanAddressingFormatAlias
 from .addressing_information import CanAddressingInformation
 from .frame_fields import DEFAULT_FILLER_BYTE, CanDlcHandler
@@ -19,7 +19,7 @@ from .frame_fields import DEFAULT_FILLER_BYTE, CanDlcHandler
 class CanConsecutiveFrameHandler:
     """Helper class that provides utilities for Consecutive Frame CAN Packets."""
 
-    CONSECUTIVE_FRAME_N_PCI: Nibble = 0x2
+    CONSECUTIVE_FRAME_N_PCI: int = 0x2
     """Consecutive Frame N_PCI value."""
     SN_BYTES_USED: int = 1
     """Number of CAN Frame data bytes used to carry CAN Packet Type and Sequence Number in Consecutive Frame."""
@@ -28,11 +28,11 @@ class CanConsecutiveFrameHandler:
     def create_valid_frame_data(cls, *,
                                 addressing_format: CanAddressingFormatAlias,
                                 payload: RawBytes,
-                                sequence_number: Nibble,
+                                sequence_number: int,
                                 dlc: Optional[int] = None,
-                                filler_byte: RawByte = DEFAULT_FILLER_BYTE,
-                                target_address: Optional[RawByte] = None,
-                                address_extension: Optional[RawByte] = None) -> RawBytesList:
+                                filler_byte: int = DEFAULT_FILLER_BYTE,
+                                target_address: Optional[int] = None,
+                                address_extension: Optional[int] = None) -> RawBytesList:
         """
         Create a data field of a CAN frame that carries a valid Consecutive Frame packet.
 
@@ -84,11 +84,11 @@ class CanConsecutiveFrameHandler:
     def create_any_frame_data(cls, *,
                               addressing_format: CanAddressingFormatAlias,
                               payload: RawBytes,
-                              sequence_number: Nibble,
+                              sequence_number: int,
                               dlc: int,
-                              filler_byte: RawByte = DEFAULT_FILLER_BYTE,
-                              target_address: Optional[RawByte] = None,
-                              address_extension: Optional[RawByte] = None) -> RawBytesList:
+                              filler_byte: int = DEFAULT_FILLER_BYTE,
+                              target_address: Optional[int] = None,
+                              address_extension: Optional[int] = None) -> RawBytesList:
         """
         Create a data field of a CAN frame that carries a Consecutive Frame packet.
 
@@ -274,7 +274,7 @@ class CanConsecutiveFrameHandler:
             raise InconsistentArgumentsError("Provided `raw_frame_data` does not contain any payload bytes.")
 
     @classmethod
-    def __encode_sn(cls, sequence_number: Nibble) -> RawBytesList:
+    def __encode_sn(cls, sequence_number: int) -> RawBytesList:
         """
         Create Consecutive Frame data bytes with CAN Packet Type and Sequence Number parameters.
 

--- a/uds/can/extended_addressing_information.py
+++ b/uds/can/extended_addressing_information.py
@@ -4,7 +4,7 @@ __all__ = ["ExtendedCanAddressingInformation"]
 
 from typing import Optional
 
-from uds.utilities import InconsistentArgumentsError, UnusedArgumentError, RawByte, validate_raw_byte
+from uds.utilities import InconsistentArgumentsError, UnusedArgumentError, validate_raw_byte
 from uds.transmission_attributes import AddressingType, AddressingTypeAlias
 from .addressing_format import CanAddressingFormat, CanAddressingFormatAlias
 from .frame_fields import CanIdHandler
@@ -26,9 +26,9 @@ class ExtendedCanAddressingInformation(AbstractCanAddressingInformation):
     def validate_packet_ai(cls,
                            addressing_type: AddressingTypeAlias,
                            can_id: Optional[int] = None,
-                           target_address: Optional[RawByte] = None,
-                           source_address: Optional[RawByte] = None,
-                           address_extension: Optional[RawByte] = None
+                           target_address: Optional[int] = None,
+                           source_address: Optional[int] = None,
+                           address_extension: Optional[int] = None
                            ) -> AbstractCanAddressingInformation.PacketAIParamsAlias:
         """
         Validate Addressing Information parameters of a CAN packet that uses Extended Addressing format.

--- a/uds/can/first_frame.py
+++ b/uds/can/first_frame.py
@@ -9,8 +9,8 @@ __all__ = ["CanFirstFrameHandler"]
 
 from typing import Optional
 
-from uds.utilities import Nibble, RawByte, RawBytes, RawBytesList, int_to_bytes_list, bytes_list_to_int, \
-    validate_raw_bytes, InconsistentArgumentsError
+from uds.utilities import RawBytes, RawBytesList, int_to_bytes_list, bytes_list_to_int, validate_raw_bytes, \
+    InconsistentArgumentsError
 from .addressing_format import CanAddressingFormatAlias
 from .addressing_information import CanAddressingInformation
 from .frame_fields import CanDlcHandler
@@ -20,7 +20,7 @@ from .single_frame import CanSingleFrameHandler
 class CanFirstFrameHandler:
     """Helper class that provides utilities for First Frame CAN Packets."""
 
-    FIRST_FRAME_N_PCI: Nibble = 0x1
+    FIRST_FRAME_N_PCI: int = 0x1
     """First Frame N_PCI value."""
     MAX_SHORT_FF_DL_VALUE: int = 0xFFF
     """Maximum value of :ref:`First Frame Data Length (FF_DL) <knowledge-base-can-first-frame-data-length>` for which
@@ -40,8 +40,8 @@ class CanFirstFrameHandler:
                                 payload: RawBytes,
                                 dlc: int,
                                 ff_dl: int,
-                                target_address: Optional[RawByte] = None,
-                                address_extension: Optional[RawByte] = None) -> RawBytesList:
+                                target_address: Optional[int] = None,
+                                address_extension: Optional[int] = None) -> RawBytesList:
         """
         Create a data field of a CAN frame that carries a valid First Frame packet.
 
@@ -83,8 +83,8 @@ class CanFirstFrameHandler:
                               dlc: int,
                               ff_dl: int,
                               long_ff_dl_format: bool = False,
-                              target_address: Optional[RawByte] = None,
-                              address_extension: Optional[RawByte] = None) -> RawBytesList:
+                              target_address: Optional[int] = None,
+                              address_extension: Optional[int] = None) -> RawBytesList:
         """
         Create a data field of a CAN frame that carries a First Frame packet.
 

--- a/uds/can/flow_control.py
+++ b/uds/can/flow_control.py
@@ -15,9 +15,8 @@ from warnings import warn
 
 from aenum import unique
 
-from uds.utilities import NibbleEnum, ValidatedEnum, TimeMilliseconds, \
-    Nibble, RawByte, RawBytes, RawBytesList, validate_nibble, validate_raw_byte, validate_raw_bytes, \
-    InconsistentArgumentsError
+from uds.utilities import InconsistentArgumentsError, NibbleEnum, ValidatedEnum, TimeMilliseconds, \
+    RawBytes, RawBytesList, validate_nibble, validate_raw_byte, validate_raw_bytes
 from .addressing_format import CanAddressingFormatAlias
 from .addressing_information import CanAddressingInformation
 from .frame_fields import DEFAULT_FILLER_BYTE, CanDlcHandler
@@ -51,7 +50,7 @@ class CanFlowStatus(NibbleEnum, ValidatedEnum):
     """Asks to abort transmission of a diagnostic message."""
 
 
-CanFlowStatusAlias = Union[CanFlowStatus, Nibble]
+CanFlowStatusAlias = Union[CanFlowStatus, int]
 """Typing alias that describes :class:`~uds.can.flow_control.CanFlowStatus` member."""
 
 
@@ -71,9 +70,9 @@ class CanSTminTranslator:
     MAX_VALUE_MS_RANGE: int = 127
     """Maximal value of STmin in milliseconds range (raw value and time value in milliseconds are equal)."""
 
-    MIN_RAW_VALUE_100US_RANGE: RawByte = 0xF1
+    MIN_RAW_VALUE_100US_RANGE: int = 0xF1
     """Minimal raw value of STmin in 100 microseconds range."""
-    MAX_RAW_VALUE_100US_RANGE: RawByte = 0xF9
+    MAX_RAW_VALUE_100US_RANGE: int = 0xF9
     """Maximal raw value of STmin in 100 microseconds range."""
     MIN_TIME_VALUE_100US_RANGE: TimeMilliseconds = 0.1
     """Minimal time value (in milliseconds) of STmin in 100 microseconds range."""
@@ -84,7 +83,7 @@ class CanSTminTranslator:
     """Accuracy used for floating point values (rounding is necessary due to float operation in python)."""
 
     @classmethod
-    def decode(cls, raw_value: RawByte) -> TimeMilliseconds:
+    def decode(cls, raw_value: int) -> TimeMilliseconds:
         """
         Map raw value of STmin into time value.
 
@@ -105,7 +104,7 @@ class CanSTminTranslator:
         return cls.MAX_STMIN_TIME
 
     @classmethod
-    def encode(cls, time_value: TimeMilliseconds) -> RawByte:
+    def encode(cls, time_value: TimeMilliseconds) -> int:
         """
         Map time value of STmin into raw value.
 
@@ -167,7 +166,7 @@ class CanSTminTranslator:
 class CanFlowControlHandler:
     """Helper class that provides utilities for Flow Control CAN Packets."""
 
-    FLOW_CONTROL_N_PCI: Nibble = 0x3
+    FLOW_CONTROL_N_PCI: int = 0x3
     """N_PCI value of Flow Control."""
     FS_BYTES_USED: int = 3
     """Number of CAN Frame data bytes used to carry CAN Packet Type, Flow Status, Block Size and STmin."""
@@ -180,12 +179,12 @@ class CanFlowControlHandler:
     def create_valid_frame_data(cls, *,
                                 addressing_format: CanAddressingFormatAlias,
                                 flow_status: CanFlowStatusAlias,
-                                block_size: Optional[RawByte] = None,
-                                st_min: Optional[RawByte] = None,
+                                block_size: Optional[int] = None,
+                                st_min: Optional[int] = None,
                                 dlc: Optional[int] = None,
-                                filler_byte: RawByte = DEFAULT_FILLER_BYTE,
-                                target_address: Optional[RawByte] = None,
-                                address_extension: Optional[RawByte] = None) -> RawBytesList:
+                                filler_byte: int = DEFAULT_FILLER_BYTE,
+                                target_address: Optional[int] = None,
+                                address_extension: Optional[int] = None) -> RawBytesList:
         """
         Create a data field of a CAN frame that carries a valid Flow Control packet.
 
@@ -240,11 +239,11 @@ class CanFlowControlHandler:
                               addressing_format: CanAddressingFormatAlias,
                               flow_status: CanFlowStatusAlias,
                               dlc: int,
-                              block_size: Optional[RawByte] = None,
-                              st_min: Optional[RawByte] = None,
-                              filler_byte: RawByte = DEFAULT_FILLER_BYTE,
-                              target_address: Optional[RawByte] = None,
-                              address_extension: Optional[RawByte] = None) -> RawBytesList:
+                              block_size: Optional[int] = None,
+                              st_min: Optional[int] = None,
+                              filler_byte: int = DEFAULT_FILLER_BYTE,
+                              target_address: Optional[int] = None,
+                              address_extension: Optional[int] = None) -> RawBytesList:
         """
         Create a data field of a CAN frame that carries a Flow Control packet.
 
@@ -328,7 +327,7 @@ class CanFlowControlHandler:
         return CanFlowStatus(raw_frame_data[ai_bytes_number] & 0xF)
 
     @classmethod
-    def decode_block_size(cls, addressing_format: CanAddressingFormatAlias, raw_frame_data: RawBytes) -> RawByte:
+    def decode_block_size(cls, addressing_format: CanAddressingFormatAlias, raw_frame_data: RawBytes) -> int:
         """
         Extract Block Size value from Flow Control data bytes.
 
@@ -353,7 +352,7 @@ class CanFlowControlHandler:
         return raw_frame_data[ai_data_bytes_number + cls.BS_BYTE_POSITION]
 
     @classmethod
-    def decode_st_min(cls, addressing_format: CanAddressingFormatAlias, raw_frame_data: RawBytes) -> RawByte:
+    def decode_st_min(cls, addressing_format: CanAddressingFormatAlias, raw_frame_data: RawBytes) -> int:
         """
         Extract STmin value from Flow Control data bytes.
 
@@ -412,9 +411,9 @@ class CanFlowControlHandler:
     @classmethod
     def __encode_valid_flow_status(cls,
                                    flow_status: CanFlowStatusAlias,
-                                   block_size: Optional[RawByte] = None,
-                                   st_min: Optional[RawByte] = None,
-                                   filler_byte: RawByte = DEFAULT_FILLER_BYTE) -> RawBytesList:
+                                   block_size: Optional[int] = None,
+                                   st_min: Optional[int] = None,
+                                   filler_byte: int = DEFAULT_FILLER_BYTE) -> RawBytesList:
         """
         Create Flow Control data bytes with CAN Packet Type and Flow Status, Block Size and STmin parameters.
 
@@ -444,9 +443,9 @@ class CanFlowControlHandler:
 
     @classmethod
     def __encode_any_flow_status(cls,
-                                 flow_status: Nibble,
-                                 block_size: Optional[RawByte] = None,
-                                 st_min: Optional[RawByte] = None) -> RawBytesList:
+                                 flow_status: int,
+                                 block_size: Optional[int] = None,
+                                 st_min: Optional[int] = None) -> RawBytesList:
         """
         Create Flow Control data bytes with CAN Packet Type and Flow Status, Block Size and STmin parameters.
 

--- a/uds/can/frame_fields.py
+++ b/uds/can/frame_fields.py
@@ -13,11 +13,11 @@ from typing import Any, Optional, Tuple, Set, TypedDict, Dict
 from bisect import bisect_left
 
 from uds.transmission_attributes import AddressingType, AddressingTypeAlias
-from uds.utilities import RawByte, validate_raw_byte
+from uds.utilities import validate_raw_byte
 from .addressing_format import CanAddressingFormat, CanAddressingFormatAlias
 
 
-DEFAULT_FILLER_BYTE: RawByte = 0xCC
+DEFAULT_FILLER_BYTE: int = 0xCC
 """Default value of Filler Byte.
 Filler Bytes are used for :ref:`CAN Frame Data Padding <knowledge-base-can-frame-data-padding>`.
 .. note:: The value is specified by ISO 15765-2:2016 (chapter 10.4.2.1)."""
@@ -63,8 +63,8 @@ class CanIdHandler:
         """Alias of :ref:`Addressing Information <knowledge-base-n-ai>` that is carried by CAN Identifier."""
 
         addressing_type: Optional[AddressingTypeAlias]
-        target_address: Optional[RawByte]
-        source_address: Optional[RawByte]
+        target_address: Optional[int]
+        source_address: Optional[int]
 
     @classmethod
     def decode_can_id(cls, addressing_format: CanAddressingFormatAlias, can_id: int) -> CanIdAIAlias:
@@ -171,8 +171,8 @@ class CanIdHandler:
     @classmethod
     def encode_normal_fixed_addressed_can_id(cls,
                                              addressing_type: AddressingTypeAlias,
-                                             target_address: RawByte,
-                                             source_address: RawByte) -> int:
+                                             target_address: int,
+                                             source_address: int) -> int:
         """
         Generate CAN ID value for Normal Fixed CAN Addressing format.
 
@@ -199,8 +199,8 @@ class CanIdHandler:
     @classmethod
     def encode_mixed_addressed_29bit_can_id(cls,
                                             addressing_type: AddressingTypeAlias,
-                                            target_address: RawByte,
-                                            source_address: RawByte) -> int:
+                                            target_address: int,
+                                            source_address: int) -> int:
         """
         Generate CAN ID value for Mixed 29-bit CAN Addressing format.
 

--- a/uds/can/mixed_addressing_information.py
+++ b/uds/can/mixed_addressing_information.py
@@ -4,7 +4,7 @@ __all__ = ["Mixed11BitCanAddressingInformation", "Mixed29BitCanAddressingInforma
 
 from typing import Optional
 
-from uds.utilities import InconsistentArgumentsError, UnusedArgumentError, RawByte, validate_raw_byte
+from uds.utilities import InconsistentArgumentsError, UnusedArgumentError, validate_raw_byte
 from uds.transmission_attributes import AddressingType, AddressingTypeAlias
 from .addressing_format import CanAddressingFormat, CanAddressingFormatAlias
 from .frame_fields import CanIdHandler
@@ -26,9 +26,9 @@ class Mixed11BitCanAddressingInformation(AbstractCanAddressingInformation):
     def validate_packet_ai(cls,
                            addressing_type: AddressingTypeAlias,
                            can_id: Optional[int] = None,
-                           target_address: Optional[RawByte] = None,
-                           source_address: Optional[RawByte] = None,
-                           address_extension: Optional[RawByte] = None
+                           target_address: Optional[int] = None,
+                           source_address: Optional[int] = None,
+                           address_extension: Optional[int] = None
                            ) -> AbstractCanAddressingInformation.PacketAIParamsAlias:
         """
         Validate Addressing Information parameters of a CAN packet that uses Mixed 11-bit Addressing format.
@@ -76,9 +76,9 @@ class Mixed29BitCanAddressingInformation(AbstractCanAddressingInformation):
     def validate_packet_ai(cls,
                            addressing_type: AddressingTypeAlias,
                            can_id: Optional[int] = None,
-                           target_address: Optional[RawByte] = None,
-                           source_address: Optional[RawByte] = None,
-                           address_extension: Optional[RawByte] = None
+                           target_address: Optional[int] = None,
+                           source_address: Optional[int] = None,
+                           address_extension: Optional[int] = None
                            ) -> AbstractCanAddressingInformation.PacketAIParamsAlias:
         """
         Validate Addressing Information parameters of a CAN packet that uses Mixed 29-bit Addressing format.

--- a/uds/can/normal_addressing_information.py
+++ b/uds/can/normal_addressing_information.py
@@ -4,7 +4,7 @@ __all__ = ["Normal11BitCanAddressingInformation", "NormalFixedCanAddressingInfor
 
 from typing import Optional
 
-from uds.utilities import InconsistentArgumentsError, UnusedArgumentError, RawByte, validate_raw_byte
+from uds.utilities import InconsistentArgumentsError, UnusedArgumentError, validate_raw_byte
 from uds.transmission_attributes import AddressingType, AddressingTypeAlias
 from .addressing_format import CanAddressingFormat, CanAddressingFormatAlias
 from .frame_fields import CanIdHandler
@@ -26,9 +26,9 @@ class Normal11BitCanAddressingInformation(AbstractCanAddressingInformation):
     def validate_packet_ai(cls,
                            addressing_type: AddressingTypeAlias,
                            can_id: Optional[int] = None,
-                           target_address: Optional[RawByte] = None,
-                           source_address: Optional[RawByte] = None,
-                           address_extension: Optional[RawByte] = None
+                           target_address: Optional[int] = None,
+                           source_address: Optional[int] = None,
+                           address_extension: Optional[int] = None
                            ) -> AbstractCanAddressingInformation.PacketAIParamsAlias:
         """
         Validate Addressing Information parameters of a CAN packet that uses Normal 11-bit Addressing format.
@@ -74,9 +74,9 @@ class NormalFixedCanAddressingInformation(AbstractCanAddressingInformation):
     def validate_packet_ai(cls,
                            addressing_type: AddressingTypeAlias,
                            can_id: Optional[int] = None,
-                           target_address: Optional[RawByte] = None,
-                           source_address: Optional[RawByte] = None,
-                           address_extension: Optional[RawByte] = None
+                           target_address: Optional[int] = None,
+                           source_address: Optional[int] = None,
+                           address_extension: Optional[int] = None
                            ) -> AbstractCanAddressingInformation.PacketAIParamsAlias:
         """
         Validate Addressing Information parameters of a CAN packet that uses Normal Fixed Addressing format.

--- a/uds/can/single_frame.py
+++ b/uds/can/single_frame.py
@@ -9,8 +9,8 @@ __all__ = ["CanSingleFrameHandler"]
 
 from typing import Optional
 
-from uds.utilities import Nibble, RawByte, RawBytes, RawBytesList, \
-    validate_raw_bytes, validate_raw_byte, validate_nibble, InconsistentArgumentsError
+from uds.utilities import RawBytes, RawBytesList, validate_raw_bytes, validate_raw_byte, validate_nibble, \
+    InconsistentArgumentsError
 from .addressing_format import CanAddressingFormatAlias
 from .addressing_information import CanAddressingInformation
 from .frame_fields import DEFAULT_FILLER_BYTE, CanDlcHandler
@@ -19,7 +19,7 @@ from .frame_fields import DEFAULT_FILLER_BYTE, CanDlcHandler
 class CanSingleFrameHandler:
     """Helper class that provides utilities for Single Frame CAN Packets."""
 
-    SINGLE_FRAME_N_PCI: Nibble = 0
+    SINGLE_FRAME_N_PCI: int = 0
     """N_PCI value of Single Frame."""
     MAX_DLC_VALUE_SHORT_SF_DL: int = 8
     """Maximum value of DLC for which short
@@ -36,9 +36,9 @@ class CanSingleFrameHandler:
                                 addressing_format: CanAddressingFormatAlias,
                                 payload: RawBytes,
                                 dlc: Optional[int] = None,
-                                filler_byte: RawByte = DEFAULT_FILLER_BYTE,
-                                target_address: Optional[RawByte] = None,
-                                address_extension: Optional[RawByte] = None) -> RawBytesList:
+                                filler_byte: int = DEFAULT_FILLER_BYTE,
+                                target_address: Optional[int] = None,
+                                address_extension: Optional[int] = None) -> RawBytesList:
         """
         Create a data field of a CAN frame that carries a valid Single Frame packet.
 
@@ -92,11 +92,11 @@ class CanSingleFrameHandler:
                               addressing_format: CanAddressingFormatAlias,
                               payload: RawBytes,
                               dlc: int,
-                              sf_dl_short: Nibble,
-                              sf_dl_long: Optional[RawByte] = None,
-                              filler_byte: RawByte = DEFAULT_FILLER_BYTE,
-                              target_address: Optional[RawByte] = None,
-                              address_extension: Optional[RawByte] = None) -> RawBytesList:
+                              sf_dl_short: int,
+                              sf_dl_long: Optional[int] = None,
+                              filler_byte: int = DEFAULT_FILLER_BYTE,
+                              target_address: Optional[int] = None,
+                              address_extension: Optional[int] = None) -> RawBytesList:
         """
         Create a data field of a CAN frame that carries a Single Frame packet.
 
@@ -391,7 +391,7 @@ class CanSingleFrameHandler:
         return cls.__encode_any_sf_dl(sf_dl_long=sf_dl)
 
     @classmethod
-    def __encode_any_sf_dl(cls, sf_dl_short: Nibble = 0, sf_dl_long: Optional[RawByte] = None) -> RawBytesList:
+    def __encode_any_sf_dl(cls, sf_dl_short: int = 0, sf_dl_long: Optional[int] = None) -> RawBytesList:
         """
         Create Single Frame data bytes with CAN Packet Type and Single Frame Data Length parameters.
 

--- a/uds/message/service_identifiers.py
+++ b/uds/message/service_identifiers.py
@@ -11,7 +11,7 @@ from warnings import warn
 
 from aenum import unique
 
-from uds.utilities import RawByte, RawBytesSet, ByteEnum, ValidatedEnum, ExtendableEnum
+from uds.utilities import RawBytesSet, ByteEnum, ValidatedEnum, ExtendableEnum
 
 # reserved SID values
 _REQUEST_SIDS_DEFINED_BY_SAEJ1979 = set(range(0x01, 0x10))
@@ -50,7 +50,7 @@ class RequestSID(ByteEnum, ValidatedEnum, ExtendableEnum):
     """
 
     @classmethod
-    def is_request_sid(cls, value: RawByte) -> bool:
+    def is_request_sid(cls, value: int) -> bool:
         """
         Check whether given value is Service Identifier (SID).
 
@@ -113,7 +113,7 @@ class ResponseSID(ByteEnum, ValidatedEnum, ExtendableEnum):
     """
 
     @classmethod
-    def is_response_sid(cls, value: RawByte) -> bool:
+    def is_response_sid(cls, value: int) -> bool:
         """
         Check whether given value is Response Service Identifier (RSID).
 

--- a/uds/packet/abstract_can_packet_container.py
+++ b/uds/packet/abstract_can_packet_container.py
@@ -5,7 +5,7 @@ __all__ = ["AbstractCanPacketContainer"]
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from uds.utilities import RawByte, RawBytesTuple
+from uds.utilities import RawBytesTuple
 from uds.transmission_attributes import AddressingTypeAlias
 from uds.can import AbstractCanAddressingInformation, CanAddressingInformation, CanDlcHandler, \
     CanSingleFrameHandler, CanFirstFrameHandler, CanConsecutiveFrameHandler, CanFlowControlHandler, \
@@ -48,7 +48,7 @@ class AbstractCanPacketContainer(ABC):
         return CanPacketType(self.raw_frame_data[ai_data_bytes_number] >> 4)
 
     @property
-    def target_address(self) -> Optional[RawByte]:
+    def target_address(self) -> Optional[int]:
         """
         Target Address (TA) value of this CAN Packet.
 
@@ -62,7 +62,7 @@ class AbstractCanPacketContainer(ABC):
         return self.get_addressing_information()[AbstractCanAddressingInformation.TARGET_ADDRESS_NAME]  # type: ignore
 
     @property
-    def source_address(self) -> Optional[RawByte]:
+    def source_address(self) -> Optional[int]:
         """
         Source Address (SA) value of this CAN Packet.
 
@@ -75,7 +75,7 @@ class AbstractCanPacketContainer(ABC):
         return self.get_addressing_information()[AbstractCanAddressingInformation.SOURCE_ADDRESS_NAME]  # type: ignore
 
     @property
-    def address_extension(self) -> Optional[RawByte]:
+    def address_extension(self) -> Optional[int]:
         """
         Address Extension (AE) value of this CAN Packet.
 
@@ -169,7 +169,7 @@ class AbstractCanPacketContainer(ABC):
         return None
 
     @property
-    def block_size(self) -> Optional[RawByte]:
+    def block_size(self) -> Optional[int]:
         """
         Block Size value carried by this CAN packet.
 
@@ -184,7 +184,7 @@ class AbstractCanPacketContainer(ABC):
         return None
 
     @property
-    def st_min(self) -> Optional[RawByte]:
+    def st_min(self) -> Optional[int]:
         """
         Separation Time minimum (STmin) value carried by this CAN packet.
 

--- a/uds/packet/abstract_packet_type.py
+++ b/uds/packet/abstract_packet_type.py
@@ -5,7 +5,7 @@ __all__ = ["AbstractUdsPacketType", "AbstractUdsPacketTypeAlias"]
 from typing import Any, Union
 from abc import abstractmethod
 
-from uds.utilities import NibbleEnum, ValidatedEnum, ExtendableEnum, Nibble
+from uds.utilities import NibbleEnum, ValidatedEnum, ExtendableEnum
 
 
 class AbstractUdsPacketType(NibbleEnum, ValidatedEnum, ExtendableEnum):
@@ -30,5 +30,5 @@ class AbstractUdsPacketType(NibbleEnum, ValidatedEnum, ExtendableEnum):
         """
 
 
-AbstractUdsPacketTypeAlias = Union[AbstractUdsPacketType, Nibble]
+AbstractUdsPacketTypeAlias = Union[AbstractUdsPacketType, int]
 """Alias that describes :class:`~uds.packet.abstract_packet_type.AbstractUdsPacketType` member."""

--- a/uds/packet/can_packet.py
+++ b/uds/packet/can_packet.py
@@ -5,8 +5,7 @@ __all__ = ["CanPacket", "AnyCanPacket"]
 from typing import Optional, Any, TypedDict
 from warnings import warn
 
-from uds.utilities import Nibble, RawByte, RawBytes, RawBytesTuple, validate_raw_bytes, \
-    AmbiguityError, UnusedArgumentWarning
+from uds.utilities import AmbiguityError, UnusedArgumentWarning, RawBytes, RawBytesTuple, validate_raw_bytes
 from uds.transmission_attributes import AddressingType, AddressingTypeAlias
 from uds.can import DEFAULT_FILLER_BYTE, CanIdHandler, CanDlcHandler, \
     CanAddressingFormat, CanAddressingFormatAlias, AbstractCanAddressingInformation, CanAddressingInformation, \
@@ -32,9 +31,9 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
                  addressing_format: CanAddressingFormatAlias,
                  addressing_type: AddressingTypeAlias,
                  can_id: Optional[int] = None,
-                 target_address: Optional[RawByte] = None,
-                 source_address: Optional[RawByte] = None,
-                 address_extension: Optional[RawByte] = None,
+                 target_address: Optional[int] = None,
+                 source_address: Optional[int] = None,
+                 address_extension: Optional[int] = None,
                  dlc: Optional[int] = None,
                  **packet_type_specific_kwargs: Any) -> None:
         """
@@ -84,9 +83,9 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
         self.__packet_type: CanPacketTypeAlias = None  # type: ignore
         self.__can_id: int = None  # type: ignore
         self.__dlc: int = None  # type: ignore
-        self.__target_address: Optional[RawByte] = None
-        self.__source_address: Optional[RawByte] = None
-        self.__address_extension: Optional[RawByte] = None
+        self.__target_address: Optional[int] = None
+        self.__source_address: Optional[int] = None
+        self.__address_extension: Optional[int] = None
         # set the proper attribute values after arguments validation
         self.set_address_information(addressing_type=addressing_type,
                                      addressing_format=addressing_format,
@@ -102,9 +101,9 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
                                 addressing_format: CanAddressingFormatAlias,
                                 addressing_type: AddressingTypeAlias,
                                 can_id: Optional[int] = None,
-                                target_address: Optional[RawByte] = None,
-                                source_address: Optional[RawByte] = None,
-                                address_extension: Optional[RawByte] = None) -> None:
+                                target_address: Optional[int] = None,
+                                source_address: Optional[int] = None,
+                                address_extension: Optional[int] = None) -> None:
         """
         Change addressing information for this CAN packet.
 
@@ -191,8 +190,8 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
     def set_address_information_normal_fixed(self,
                                              addressing_type: AddressingTypeAlias,
                                              can_id: Optional[int] = None,
-                                             target_address: Optional[RawByte] = None,
-                                             source_address: Optional[RawByte] = None) -> None:
+                                             target_address: Optional[int] = None,
+                                             source_address: Optional[int] = None) -> None:
         """
         Change addressing information for this CAN packet to use Normal Fixed Addressing format.
 
@@ -220,7 +219,7 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
     def set_address_information_extended(self,
                                          addressing_type: AddressingTypeAlias,
                                          can_id: int,
-                                         target_address: RawByte) -> None:
+                                         target_address: int) -> None:
         """
         Change addressing information for this CAN packet to use Extended Addressing format.
 
@@ -243,7 +242,7 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
     def set_address_information_mixed_11bit(self,
                                             addressing_type: AddressingTypeAlias,
                                             can_id: int,
-                                            address_extension: RawByte) -> None:
+                                            address_extension: int) -> None:
         """
         Change addressing information for this CAN packet to use Mixed 11-bit Addressing format.
 
@@ -265,10 +264,10 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
 
     def set_address_information_mixed_29bit(self,
                                             addressing_type: AddressingTypeAlias,
-                                            address_extension: RawByte,
+                                            address_extension: int,
                                             can_id: Optional[int] = None,
-                                            target_address: Optional[RawByte] = None,
-                                            source_address: Optional[RawByte] = None) -> None:
+                                            target_address: Optional[int] = None,
+                                            source_address: Optional[int] = None) -> None:
         """
         Change addressing information for this CAN packet to use Mixed 29-bit Addressing format.
 
@@ -350,7 +349,7 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
     def set_single_frame_data(self,
                               payload: RawBytes,
                               dlc: Optional[int] = None,
-                              filler_byte: RawByte = DEFAULT_FILLER_BYTE) -> None:
+                              filler_byte: int = DEFAULT_FILLER_BYTE) -> None:
         """
         Change packet type (to Single Frame) and data field of this CAN packet.
 
@@ -405,7 +404,7 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
                                    payload: RawBytes,
                                    sequence_number: int,
                                    dlc: Optional[int] = None,
-                                   filler_byte: RawByte = DEFAULT_FILLER_BYTE) -> None:
+                                   filler_byte: int = DEFAULT_FILLER_BYTE) -> None:
         """
         Change packet type (to Consecutive Frame) and data field of this CAN packet.
 
@@ -435,10 +434,10 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
 
     def set_flow_control_data(self,
                               flow_status: CanFlowStatusAlias,
-                              block_size: Optional[RawByte] = None,
-                              st_min: Optional[RawByte] = None,
+                              block_size: Optional[int] = None,
+                              st_min: Optional[int] = None,
                               dlc: Optional[int] = None,
-                              filler_byte: RawByte = DEFAULT_FILLER_BYTE) -> None:
+                              filler_byte: int = DEFAULT_FILLER_BYTE) -> None:
         """
         Change packet type (to Flow Control) and data field of this CAN packet.
 
@@ -499,7 +498,7 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
         return self.__packet_type
 
     @property
-    def target_address(self) -> Optional[RawByte]:
+    def target_address(self) -> Optional[int]:
         """
         Target Address (TA) value of this CAN Packet.
 
@@ -513,7 +512,7 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
         return self.__target_address
 
     @property
-    def source_address(self) -> Optional[RawByte]:
+    def source_address(self) -> Optional[int]:
         """
         Source Address (SA) value of this CAN Packet.
 
@@ -526,7 +525,7 @@ class CanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/conf
         return self.__source_address
 
     @property
-    def address_extension(self) -> Optional[RawByte]:
+    def address_extension(self) -> Optional[int]:
         """
         Address Extension (AE) value of this CAN Packet.
 
@@ -582,9 +581,9 @@ class AnyCanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/c
         """Alias of :ref:`Addressing Information <knowledge-base-n-ai>` parameters encoded in any CAN Packet."""
 
         addressing_type: Optional[AddressingTypeAlias]
-        target_address: Optional[RawByte]
-        source_address: Optional[RawByte]
-        address_extension: Optional[RawByte]
+        target_address: Optional[int]
+        source_address: Optional[int]
+        address_extension: Optional[int]
 
     def __init__(self, *,
                  raw_frame_data: RawBytes,
@@ -682,7 +681,7 @@ class AnyCanPacket(AbstractCanPacketContainer, AbstractUdsPacket):  # lgtm [py/c
         return CanDlcHandler.encode_dlc(len(self.raw_frame_data))
 
     @property
-    def packet_type(self) -> Optional[Nibble]:  # type: ignore
+    def packet_type(self) -> Optional[int]:  # type: ignore
         """Type (N_PCI value) of this CAN packet."""
         ai_data_bytes_number = CanAddressingInformation.get_ai_data_bytes_number(self.addressing_format)
         if ai_data_bytes_number >= len(self.raw_frame_data):

--- a/uds/packet/can_packet_record.py
+++ b/uds/packet/can_packet_record.py
@@ -48,7 +48,7 @@ class CanPacketRecord(AbstractCanPacketContainer, AbstractUdsPacketRecord):  # l
         super().__init__(frame=frame, direction=direction, transmission_time=transmission_time)
         self.__addressing_type = AddressingType(addressing_type)
         self.__addressing_format = CanAddressingFormat(addressing_format)
-        self.__packet_type: CanPacketType
+        self.__packet_type: CanPacketTypeAlias
         self.__target_address: Optional[int]
         self.__source_address: Optional[int]
         self.__address_extension: Optional[int]

--- a/uds/packet/can_packet_record.py
+++ b/uds/packet/can_packet_record.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from can import Message as PythonCanMessage
 
-from uds.utilities import RawByte, RawBytesTuple, InconsistentArgumentsError
+from uds.utilities import RawBytesTuple, InconsistentArgumentsError
 from uds.transmission_attributes import AddressingType, AddressingTypeAlias, TransmissionDirectionAlias
 from uds.can import CanAddressingFormat, CanAddressingFormatAlias, \
     CanAddressingInformation, AbstractCanAddressingInformation, \
@@ -49,9 +49,9 @@ class CanPacketRecord(AbstractCanPacketContainer, AbstractUdsPacketRecord):  # l
         self.__addressing_type = AddressingType(addressing_type)
         self.__addressing_format = CanAddressingFormat(addressing_format)
         self.__packet_type: CanPacketType
-        self.__target_address: Optional[RawByte]
-        self.__source_address: Optional[RawByte]
-        self.__address_extension: Optional[RawByte]
+        self.__target_address: Optional[int]
+        self.__source_address: Optional[int]
+        self.__address_extension: Optional[int]
         self.__assess_packet_type()
         self.__assess_ai_attributes()
 
@@ -85,7 +85,7 @@ class CanPacketRecord(AbstractCanPacketContainer, AbstractUdsPacketRecord):  # l
         return self.__packet_type
 
     @property
-    def target_address(self) -> Optional[RawByte]:
+    def target_address(self) -> Optional[int]:
         """
         Target Address (TA) value of this CAN Packet.
 
@@ -99,7 +99,7 @@ class CanPacketRecord(AbstractCanPacketContainer, AbstractUdsPacketRecord):  # l
         return self.__target_address
 
     @property
-    def source_address(self) -> Optional[RawByte]:
+    def source_address(self) -> Optional[int]:
         """
         Source Address (SA) value of this CAN Packet.
 
@@ -112,7 +112,7 @@ class CanPacketRecord(AbstractCanPacketContainer, AbstractUdsPacketRecord):  # l
         return self.__source_address
 
     @property
-    def address_extension(self) -> Optional[RawByte]:
+    def address_extension(self) -> Optional[int]:
         """
         Address Extension (AE) value of this CAN Packet.
 

--- a/uds/packet/can_packet_type.py
+++ b/uds/packet/can_packet_type.py
@@ -6,7 +6,6 @@ from typing import Any, Union
 
 from aenum import unique
 
-from uds.utilities import Nibble
 from uds.can import CanSingleFrameHandler, CanFirstFrameHandler, CanConsecutiveFrameHandler, CanFlowControlHandler
 from .abstract_packet_type import AbstractUdsPacketType
 
@@ -42,5 +41,5 @@ class CanPacketType(AbstractUdsPacketType):
         return value in (cls.SINGLE_FRAME, cls.FIRST_FRAME)
 
 
-CanPacketTypeAlias = Union[CanPacketType, Nibble]
+CanPacketTypeAlias = Union[CanPacketType, int]
 """Alias that describes :class:`~uds.packet.can_packet_type.CanPacketType` member type."""

--- a/uds/segmentation/can_segmenter.py
+++ b/uds/segmentation/can_segmenter.py
@@ -5,7 +5,7 @@ __all__ = ["CanSegmenter"]
 from typing import Union, Tuple, Type
 from copy import copy
 
-from uds.utilities import RawByte, RawBytesList, validate_raw_byte
+from uds.utilities import RawBytesList, validate_raw_byte
 from uds.transmission_attributes import AddressingType
 from uds.can import AbstractCanAddressingInformation, CanAddressingInformation, \
     CanAddressingFormat, CanAddressingFormatAlias, \
@@ -29,7 +29,7 @@ class CanSegmenter(AbstractSegmenter):
                  functional_ai: InputAIParamsAlias,
                  dlc: int = CanDlcHandler.MIN_BASE_UDS_DLC,
                  use_data_optimization: bool = False,
-                 filler_byte: RawByte = DEFAULT_FILLER_BYTE) -> None:
+                 filler_byte: int = DEFAULT_FILLER_BYTE) -> None:
         """
         Configure CAN Segmenter.
 
@@ -143,19 +143,19 @@ class CanSegmenter(AbstractSegmenter):
         self.__use_data_optimization: bool = bool(value)
 
     @property
-    def filler_byte(self) -> RawByte:
+    def filler_byte(self) -> int:
         """Filler byte value to use for CAN Frame Data Padding during segmentation."""
         return self.__filler_byte
 
     @filler_byte.setter
-    def filler_byte(self, value: RawByte):
+    def filler_byte(self, value: int):
         """
         Set value of filler byte to use for CAN Frame Data Padding.
 
         :param value: Value to set.
         """
         validate_raw_byte(value)
-        self.__filler_byte: RawByte = value
+        self.__filler_byte: int = value
 
     def desegmentation(self, packets: PacketsContainersSequence) -> Union[UdsMessage, UdsMessageRecord]:
         """

--- a/uds/transport_interface/abstract_can_transport_interface.py
+++ b/uds/transport_interface/abstract_can_transport_interface.py
@@ -7,7 +7,7 @@ from typing import Optional, Union, Any, Iterator, Iterable
 from abc import abstractmethod
 from warnings import warn
 
-from uds.utilities import TimeMilliseconds, RawByte, ValueWarning
+from uds.utilities import TimeMilliseconds, ValueWarning
 from uds.packet import CanPacket, CanPacketRecord, CanPacketType
 from uds.can import AbstractCanAddressingInformation, CanFlowStatus, CanSTminTranslator
 from uds.segmentation import CanSegmenter
@@ -369,12 +369,12 @@ class AbstractCanTransportInterface(AbstractTransportInterface):
         self.segmenter.use_data_optimization = value
 
     @property
-    def filler_byte(self) -> RawByte:
+    def filler_byte(self) -> int:
         """Filler byte value to use for CAN Frame Data Padding during segmentation."""
         return self.segmenter.filler_byte
 
     @filler_byte.setter
-    def filler_byte(self, value: RawByte):
+    def filler_byte(self, value: int):
         """
         Set value of filler byte to use for CAN Frame Data Padding.
 

--- a/uds/utilities/__init__.py
+++ b/uds/utilities/__init__.py
@@ -1,7 +1,7 @@
 """Various helper functions, classes and variables that are shared and reused within the project."""
 
 from .enums import ValidatedEnum, ExtendableEnum, ByteEnum, NibbleEnum
-from .common_types import Nibble, RawByte, RawBytes, RawBytesTuple, RawBytesList, RawBytesSet, \
+from .common_types import RawBytes, RawBytesTuple, RawBytesList, RawBytesSet, \
     validate_nibble, validate_raw_bytes, validate_raw_byte, \
     TimeMilliseconds
 from .bytes_operations import Endianness, EndiannessAlias, int_to_bytes_list, bytes_list_to_int

--- a/uds/utilities/common_types.py
+++ b/uds/utilities/common_types.py
@@ -1,12 +1,13 @@
 """Module with all common types (and its aliases) used in the package and helper functions for these types."""
 
-__all__ = ["RawBytes", "RawBytesTuple", "RawBytesList", "RawBytesSet",
-           "validate_nibble", "validate_raw_byte", "validate_raw_bytes",
-           "TimeMilliseconds"]
+__all__ = ["TimeMilliseconds", "RawBytes", "RawBytesTuple", "RawBytesList", "RawBytesSet",
+           "validate_nibble", "validate_raw_byte", "validate_raw_bytes"]
 
 from typing import Union, Tuple, List, Set, Any
 
 
+TimeMilliseconds = Union[int, float]
+"""Alias of a time value in milliseconds."""
 RawBytesTuple = Tuple[int, ...]
 """Alias of a tuple filled with byte values."""
 RawBytesSet = Set[int]
@@ -15,8 +16,6 @@ RawBytesList = List[int]
 """Alias of a list filled with byte values."""
 RawBytes = Union[RawBytesTuple, RawBytesList, bytearray]
 """Alias of a sequence filled with byte values."""
-TimeMilliseconds = Union[int, float]
-"""Alias of a time value in milliseconds."""
 
 
 def validate_nibble(value: Any) -> None:

--- a/uds/utilities/common_types.py
+++ b/uds/utilities/common_types.py
@@ -1,21 +1,17 @@
 """Module with all common types (and its aliases) used in the package and helper functions for these types."""
 
-__all__ = ["Nibble", "RawByte", "RawBytes", "RawBytesTuple", "RawBytesList", "RawBytesSet",
+__all__ = ["RawBytes", "RawBytesTuple", "RawBytesList", "RawBytesSet",
            "validate_nibble", "validate_raw_byte", "validate_raw_bytes",
            "TimeMilliseconds"]
 
 from typing import Union, Tuple, List, Set, Any
 
 
-Nibble = int
-"""Alias of a `nibble <https://en.wikipedia.org/wiki/Nibble>`_ value (integer in range 0x0-0xF)."""
-RawByte = int
-"""Alias of a byte value (integer in range 0x00-0xFF)."""
-RawBytesTuple = Tuple[RawByte, ...]
+RawBytesTuple = Tuple[int, ...]
 """Alias of a tuple filled with byte values."""
-RawBytesSet = Set[RawByte]
+RawBytesSet = Set[int]
 """Alias of a set filled with byte values."""
-RawBytesList = List[RawByte]
+RawBytesList = List[int]
 """Alias of a list filled with byte values."""
 RawBytes = Union[RawBytesTuple, RawBytesList, bytearray]
 """Alias of a sequence filled with byte values."""

--- a/uds/utilities/enums.py
+++ b/uds/utilities/enums.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from aenum import Enum, IntEnum, extend_enum
 
-from .common_types import validate_nibble, Nibble, validate_raw_byte, RawByte
+from .common_types import validate_nibble, validate_raw_byte
 
 
 class ExtendableEnum(Enum):
@@ -72,7 +72,7 @@ class ValidatedEnum(Enum):
 class ByteEnum(IntEnum):
     """Enum which members are one byte integers (0x00-0xFF) only."""
 
-    def __new__(cls, value: RawByte):
+    def __new__(cls, value: int):
         """
         Creation of a new member.
 
@@ -87,7 +87,7 @@ class ByteEnum(IntEnum):
 class NibbleEnum(IntEnum):
     """Enum which members are one nibble (4 bits) integers (0x0-0xF) only."""
 
-    def __new__(cls, value: Nibble):
+    def __new__(cls, value: int):
         """
         Creation of a new member.
 


### PR DESCRIPTION
## Description
Get rid of `Nibble` and `RawByte` variables that were meant to be aliases of int, but in fact were just copy of int type.


## How Has This Been Tested?
- unit tests
- review


## Process
I know the [process](https://github.com/mdabrowski1990/uds/wiki/Software-Development-Life-Cycle) and did my best to follow it
