### PR TITLE
Improve typing

### DIFF
--- a/tests/software_tests/can/test_extended_addressing_information.py
+++ b/tests/software_tests/can/test_extended_addressing_information.py
@@ -71,7 +71,7 @@ class TestExtendedCanAddressingInformation:
                                                                    can_id=can_id,
                                                                    target_address=target_address) == {
             AbstractCanAddressingInformation.ADDRESSING_FORMAT_NAME: CanAddressingFormat.EXTENDED_ADDRESSING,
-            AbstractCanAddressingInformation.ADDRESSING_TYPE_NAME: addressing_type,
+            AbstractCanAddressingInformation.ADDRESSING_TYPE_NAME: self.mock_validate_addressing_type.return_value,
             AbstractCanAddressingInformation.CAN_ID_NAME: can_id,
             AbstractCanAddressingInformation.TARGET_ADDRESS_NAME: target_address,
             AbstractCanAddressingInformation.SOURCE_ADDRESS_NAME: None,

--- a/tests/software_tests/can/test_normal_addressing_information.py
+++ b/tests/software_tests/can/test_normal_addressing_information.py
@@ -66,7 +66,7 @@ class TestNormal11BitCanAddressingInformation:
         assert Normal11BitCanAddressingInformation.validate_packet_ai(addressing_type=addressing_type,
                                                                       can_id=can_id) == {
                    AbstractCanAddressingInformation.ADDRESSING_FORMAT_NAME: CanAddressingFormat.NORMAL_11BIT_ADDRESSING,
-                   AbstractCanAddressingInformation.ADDRESSING_TYPE_NAME: addressing_type,
+                   AbstractCanAddressingInformation.ADDRESSING_TYPE_NAME: self.mock_validate_addressing_type.return_value,
                    AbstractCanAddressingInformation.CAN_ID_NAME: can_id,
                    AbstractCanAddressingInformation.TARGET_ADDRESS_NAME: None,
                    AbstractCanAddressingInformation.SOURCE_ADDRESS_NAME: None,
@@ -159,7 +159,7 @@ class TestNormalFixedCanAddressingInformation:
                                                                       target_address=target_address,
                                                                       source_address=source_address) == {
             AbstractCanAddressingInformation.ADDRESSING_FORMAT_NAME: CanAddressingFormat.NORMAL_FIXED_ADDRESSING,
-            AbstractCanAddressingInformation.ADDRESSING_TYPE_NAME: addressing_type,
+            AbstractCanAddressingInformation.ADDRESSING_TYPE_NAME: self.mock_validate_addressing_type.return_value,
             AbstractCanAddressingInformation.CAN_ID_NAME: self.mock_can_id_handler_class.encode_normal_fixed_addressed_can_id.return_value,
             AbstractCanAddressingInformation.TARGET_ADDRESS_NAME: target_address,
             AbstractCanAddressingInformation.SOURCE_ADDRESS_NAME: source_address,
@@ -170,7 +170,7 @@ class TestNormalFixedCanAddressingInformation:
         self.mock_can_id_handler_class.validate_can_id.assert_not_called()
         self.mock_can_id_handler_class.decode_normal_fixed_addressed_can_id.assert_not_called()
         self.mock_can_id_handler_class.encode_normal_fixed_addressed_can_id.assert_called_once_with(
-            addressing_type=addressing_type,
+            addressing_type=self.mock_validate_addressing_type.return_value,
             target_address=target_address,
             source_address=source_address
         )
@@ -187,7 +187,7 @@ class TestNormalFixedCanAddressingInformation:
         decoded_target_address = target_address or "ta"
         decoded_source_address = source_address or "sa"
         self.mock_can_id_handler_class.decode_normal_fixed_addressed_can_id.return_value = {
-            self.mock_can_id_handler_class.ADDRESSING_TYPE_NAME: addressing_type,
+            self.mock_can_id_handler_class.ADDRESSING_TYPE_NAME: self.mock_validate_addressing_type.return_value,
             self.mock_can_id_handler_class.TARGET_ADDRESS_NAME: decoded_target_address,
             self.mock_can_id_handler_class.SOURCE_ADDRESS_NAME: decoded_source_address,
         }
@@ -196,7 +196,7 @@ class TestNormalFixedCanAddressingInformation:
                                                                       target_address=target_address,
                                                                       source_address=source_address) == {
             AbstractCanAddressingInformation.ADDRESSING_FORMAT_NAME: CanAddressingFormat.NORMAL_FIXED_ADDRESSING,
-            AbstractCanAddressingInformation.ADDRESSING_TYPE_NAME: addressing_type,
+            AbstractCanAddressingInformation.ADDRESSING_TYPE_NAME: self.mock_validate_addressing_type.return_value,
             AbstractCanAddressingInformation.CAN_ID_NAME: can_id,
             AbstractCanAddressingInformation.TARGET_ADDRESS_NAME: decoded_target_address,
             AbstractCanAddressingInformation.SOURCE_ADDRESS_NAME: decoded_source_address,

--- a/tests/software_tests/packet/test_can_packet_type.py
+++ b/tests/software_tests/packet/test_can_packet_type.py
@@ -24,10 +24,12 @@ class TestCanPacketType:
 
     @pytest.mark.parametrize("value", [2, 3, CanPacketType.CONSECUTIVE_FRAME, CanPacketType.FLOW_CONTROL])
     def test_is_initial_packet_type__false(self, value):
+        self.mock_validate_member.side_effect = lambda arg: arg
         assert CanPacketType.is_initial_packet_type(value) is False
         self.mock_validate_member.assert_called_once_with(value)
 
     @pytest.mark.parametrize("value", [0, 1, CanPacketType.FIRST_FRAME, CanPacketType.SINGLE_FRAME])
     def test_is_initial_packet_type__true(self, value):
+        self.mock_validate_member.side_effect = lambda arg: arg
         assert CanPacketType.is_initial_packet_type(value) is True
         self.mock_validate_member.assert_called_once_with(value)

--- a/tests/software_tests/utilities/test_bytes_operations.py
+++ b/tests/software_tests/utilities/test_bytes_operations.py
@@ -40,6 +40,7 @@ class TestFunctions:
         ([0x98, 0x76, 0x54, 0x32, 0x1F], Endianness.LITTLE_ENDIAN, 0x1F32547698),
     ])
     def test_bytes_list_to_int(self, bytes_list, endianness, expected_output):
+        self.mock_validate_endianness.side_effect = lambda arg: arg
         assert bytes_list_to_int(bytes_list=bytes_list, endianness=endianness) == expected_output
         self.mock_validate_raw_bytes.assert_called_once_with(bytes_list)
         self.mock_validate_endianness.assert_called_once_with(endianness)

--- a/uds/can/addressing_information.py
+++ b/uds/can/addressing_information.py
@@ -197,11 +197,11 @@ class CanAddressingInformation:
                                  CanAddressingFormat.NORMAL_FIXED_ADDRESSING):
             return []
         if addressing_format == CanAddressingFormat.EXTENDED_ADDRESSING:
-            validate_raw_byte(target_address)
+            validate_raw_byte(target_address)  # type: ignore
             return [target_address]  # type: ignore
         if addressing_format in (CanAddressingFormat.MIXED_11BIT_ADDRESSING,
                                  CanAddressingFormat.MIXED_29BIT_ADDRESSING):
-            validate_raw_byte(address_extension)
+            validate_raw_byte(address_extension)  # type: ignore
             return [address_extension]  # type: ignore
         raise NotImplementedError(f"Missing implementation for: {addressing_format}")
 

--- a/uds/can/addressing_information.py
+++ b/uds/can/addressing_information.py
@@ -137,12 +137,12 @@ class CanAddressingInformation:
         """
         from_data_bytes = cls.decode_ai_data_bytes(addressing_format=addressing_format, ai_data_bytes=ai_data_bytes)
         from_can_id = CanIdHandler.decode_can_id(addressing_format=addressing_format, can_id=can_id)
-        items_names = (AbstractCanAddressingInformation.ADDRESSING_TYPE_NAME,
-                       AbstractCanAddressingInformation.TARGET_ADDRESS_NAME,
-                       AbstractCanAddressingInformation.SOURCE_ADDRESS_NAME,
-                       AbstractCanAddressingInformation.ADDRESS_EXTENSION_NAME)
-        return {name: from_data_bytes.get(name, None) or from_can_id.get(name, None)
-                for name in items_names}  # type: ignore
+        return cls.DecodedAIParamsAlias(
+            addressing_type=from_can_id.get(AbstractCanAddressingInformation.ADDRESSING_TYPE_NAME, None),  # type: ignore  # noqa: E501
+            target_address=from_data_bytes.get(AbstractCanAddressingInformation.TARGET_ADDRESS_NAME, None)  # type: ignore  # noqa: E501
+            or from_can_id.get(AbstractCanAddressingInformation.TARGET_ADDRESS_NAME, None),
+            source_address=from_can_id.get(AbstractCanAddressingInformation.SOURCE_ADDRESS_NAME, None),  # type: ignore
+            address_extension=from_data_bytes.get(AbstractCanAddressingInformation.ADDRESS_EXTENSION_NAME, None))  # type: ignore  # noqa: E501
 
     @classmethod
     def decode_ai_data_bytes(cls,
@@ -166,12 +166,12 @@ class CanAddressingInformation:
                                    ai_data_bytes=ai_data_bytes)
         if addressing_format in {CanAddressingFormat.NORMAL_11BIT_ADDRESSING,
                                  CanAddressingFormat.NORMAL_FIXED_ADDRESSING}:
-            return {}
+            return cls.DataBytesAIParamsAlias()
         if addressing_format == CanAddressingFormat.EXTENDED_ADDRESSING:
-            return {AbstractCanAddressingInformation.TARGET_ADDRESS_NAME: ai_data_bytes[0]}  # type: ignore
+            return cls.DataBytesAIParamsAlias(target_address=ai_data_bytes[0])
         if addressing_format in {CanAddressingFormat.MIXED_11BIT_ADDRESSING,
                                  CanAddressingFormat.MIXED_29BIT_ADDRESSING}:
-            return {AbstractCanAddressingInformation.ADDRESS_EXTENSION_NAME:  ai_data_bytes[0]}  # type: ignore
+            return cls.DataBytesAIParamsAlias(address_extension=ai_data_bytes[0])
         raise NotImplementedError(f"Missing implementation for: {addressing_format}")
 
     @classmethod

--- a/uds/can/extended_addressing_information.py
+++ b/uds/can/extended_addressing_information.py
@@ -52,10 +52,9 @@ class ExtendedCanAddressingInformation(AbstractCanAddressingInformation):
         if not CanIdHandler.is_extended_addressed_can_id(can_id):  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with "
                                              f"Extended Addressing Format. Actual value: {can_id}")
-        return PacketAIParamsAlias(
-            addressing_format=CanAddressingFormat.EXTENDED_ADDRESSING,
-            addressing_type=addressing_type,
-            can_id=can_id,  # type: ignore
-            target_address=target_address,
-            source_address=source_address,
-            address_extension=address_extension)
+        return PacketAIParamsAlias(addressing_format=CanAddressingFormat.EXTENDED_ADDRESSING,
+                                   addressing_type=addressing_type,
+                                   can_id=can_id,  # type: ignore
+                                   target_address=target_address,
+                                   source_address=source_address,
+                                   address_extension=address_extension)

--- a/uds/can/extended_addressing_information.py
+++ b/uds/can/extended_addressing_information.py
@@ -46,7 +46,7 @@ class ExtendedCanAddressingInformation(AbstractCanAddressingInformation):
         if (source_address, address_extension) != (None, None):
             raise UnusedArgumentError("Values of Source Address and Address Extension are not supported by "
                                       "Extended Addressing format and all must be None.")
-        AddressingType.validate_member(addressing_type)
+        addressing_type = AddressingType.validate_member(addressing_type)
         CanIdHandler.validate_can_id(can_id)  # type: ignore
         validate_raw_byte(target_address)  # type: ignore
         if not CanIdHandler.is_extended_addressed_can_id(can_id):  # type: ignore

--- a/uds/can/extended_addressing_information.py
+++ b/uds/can/extended_addressing_information.py
@@ -47,8 +47,8 @@ class ExtendedCanAddressingInformation(AbstractCanAddressingInformation):
             raise UnusedArgumentError("Values of Source Address and Address Extension are not supported by "
                                       "Extended Addressing format and all must be None.")
         AddressingType.validate_member(addressing_type)
-        CanIdHandler.validate_can_id(can_id)
-        validate_raw_byte(target_address)
+        CanIdHandler.validate_can_id(can_id)  # type: ignore
+        validate_raw_byte(target_address)  # type: ignore
         if not CanIdHandler.is_extended_addressed_can_id(can_id):  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with "
                                              f"Extended Addressing Format. Actual value: {can_id}")

--- a/uds/can/flow_control.py
+++ b/uds/can/flow_control.py
@@ -9,7 +9,7 @@ This module contains implementation of :ref:`Flow Control <knowledge-base-can-fl
 
 __all__ = ["CanFlowStatus", "CanSTminTranslator", "CanFlowControlHandler", "UnrecognizedSTminWarning"]
 
-from typing import Optional, Any
+from typing import Optional
 from warnings import warn
 
 from aenum import unique
@@ -119,7 +119,7 @@ class CanSTminTranslator:
         raise ValueError(f"Provided value is out of valid STmin ranges. Actual value: {time_value}")
 
     @classmethod
-    def is_time_value(cls, value: Any) -> bool:
+    def is_time_value(cls, value: TimeMillisecondsAlias) -> bool:
         """
         Check if provided value is a valid time value of STmin.
 

--- a/uds/can/flow_control.py
+++ b/uds/can/flow_control.py
@@ -425,8 +425,8 @@ class CanFlowControlHandler:
         """
         CanFlowStatus.validate_member(flow_status)
         if flow_status == CanFlowStatus.ContinueToSend:
-            validate_raw_byte(block_size)
-            validate_raw_byte(st_min)
+            validate_raw_byte(block_size)  # type: ignore
+            validate_raw_byte(st_min)  # type: ignore
         else:
             if block_size is not None:
                 validate_raw_byte(block_size)

--- a/uds/can/frame_fields.py
+++ b/uds/can/frame_fields.py
@@ -95,9 +95,9 @@ class CanIdHandler:
         if addressing_format in (CanAddressingFormat.NORMAL_11BIT_ADDRESSING,
                                  CanAddressingFormat.EXTENDED_ADDRESSING,
                                  CanAddressingFormat.MIXED_11BIT_ADDRESSING):
-            return {cls.ADDRESSING_TYPE_NAME: None,  # type: ignore
-                    cls.TARGET_ADDRESS_NAME: None,
-                    cls.SOURCE_ADDRESS_NAME: None}  # no addressing information can be decoded
+            return cls.CanIdAIAlias(addressing_type=None,
+                                    target_address=None,
+                                    source_address=None)  # no addressing information can be decoded
         raise NotImplementedError(f"Unknown addressing format value was provided: {addressing_format}")
 
     @classmethod
@@ -122,15 +122,13 @@ class CanIdHandler:
         source_address = can_id & 0xFF
         can_id_offset = can_id & (~0xFFFF)  # value with Target Address and Source Address information erased
         if can_id_offset == cls.NORMAL_FIXED_PHYSICAL_ADDRESSING_OFFSET:
-            addressing_type = AddressingType(AddressingType.PHYSICAL)
-            return {cls.ADDRESSING_TYPE_NAME: addressing_type,  # type: ignore
-                    cls.TARGET_ADDRESS_NAME: target_address,
-                    cls.SOURCE_ADDRESS_NAME: source_address}
+            return cls.CanIdAIAlias(addressing_type=AddressingType.PHYSICAL,
+                                    target_address=target_address,
+                                    source_address=source_address)
         if can_id_offset == cls.NORMAL_FIXED_FUNCTIONAL_ADDRESSING_OFFSET:
-            addressing_type = AddressingType(AddressingType.FUNCTIONAL)
-            return {cls.ADDRESSING_TYPE_NAME: addressing_type,  # type: ignore
-                    cls.TARGET_ADDRESS_NAME: target_address,
-                    cls.SOURCE_ADDRESS_NAME: source_address}
+            return cls.CanIdAIAlias(addressing_type=AddressingType.FUNCTIONAL,
+                                    target_address=target_address,
+                                    source_address=source_address)
         raise NotImplementedError("CAN ID in Normal Fixed Addressing format was provided, but cannot be handled."
                                   f"Actual value: {can_id}")
 
@@ -156,15 +154,13 @@ class CanIdHandler:
         source_address = can_id & 0xFF
         can_id_offset = can_id & (~0xFFFF)  # value with Target Address and Source Address information erased
         if can_id_offset == cls.MIXED_29BIT_PHYSICAL_ADDRESSING_OFFSET:
-            addressing_type = AddressingType(AddressingType.PHYSICAL)
-            return {cls.ADDRESSING_TYPE_NAME: addressing_type,  # type: ignore
-                    cls.TARGET_ADDRESS_NAME: target_address,
-                    cls.SOURCE_ADDRESS_NAME: source_address}
+            return cls.CanIdAIAlias(addressing_type=AddressingType.PHYSICAL,
+                                    target_address=target_address,
+                                    source_address=source_address)
         if can_id_offset == cls.MIXED_29BIT_FUNCTIONAL_ADDRESSING_OFFSET:
-            addressing_type = AddressingType(AddressingType.FUNCTIONAL)
-            return {cls.ADDRESSING_TYPE_NAME: addressing_type,  # type: ignore
-                    cls.TARGET_ADDRESS_NAME: target_address,
-                    cls.SOURCE_ADDRESS_NAME: source_address}
+            return cls.CanIdAIAlias(addressing_type=AddressingType.FUNCTIONAL,
+                                    target_address=target_address,
+                                    source_address=source_address)
         raise NotImplementedError("CAN ID in Normal Fixed Addressing format was provided, but cannot be handled."
                                   f"Actual value: {can_id}")
 

--- a/uds/can/frame_fields.py
+++ b/uds/can/frame_fields.py
@@ -9,7 +9,7 @@ Handlers for :ref:`CAN Frame <knowledge-base-can-frame>` fields:
 
 __all__ = ["CanIdHandler", "CanDlcHandler", "DEFAULT_FILLER_BYTE"]
 
-from typing import Any, Optional, Tuple, Set, TypedDict, Dict
+from typing import Optional, Tuple, Set, TypedDict, Dict
 from bisect import bisect_left
 
 from uds.transmission_attributes import AddressingType
@@ -372,7 +372,7 @@ class CanIdHandler:
         return isinstance(can_id, int) and cls.MIN_EXTENDED_VALUE <= can_id <= cls.MAX_EXTENDED_VALUE
 
     @classmethod
-    def validate_can_id(cls, value: Any, extended_can_id: Optional[bool] = None) -> None:
+    def validate_can_id(cls, value: int, extended_can_id: Optional[bool] = None) -> None:
         """
         Validate whether provided value is either Standard or Extended CAN ID.
 
@@ -481,7 +481,7 @@ class CanDlcHandler:
         return dlc in cls.__DLC_SPECIFIC_FOR_CAN_FD
 
     @classmethod
-    def validate_dlc(cls, value: Any) -> None:
+    def validate_dlc(cls, value: int) -> None:
         """
         Validate whether the provided value is a valid value of CAN DLC.
 
@@ -496,7 +496,7 @@ class CanDlcHandler:
             raise ValueError(f"Provided value is out of DLC values range. Actual value: {value}")
 
     @classmethod
-    def validate_data_bytes_number(cls, value: Any, exact_value: bool = True) -> None:
+    def validate_data_bytes_number(cls, value: int, exact_value: bool = True) -> None:
         """
         Validate whether provided value is a valid number of data bytes that might be carried a CAN frame.
 

--- a/uds/can/mixed_addressing_information.py
+++ b/uds/can/mixed_addressing_information.py
@@ -47,8 +47,8 @@ class Mixed11BitCanAddressingInformation(AbstractCanAddressingInformation):
             raise UnusedArgumentError("Values of Target Address and Source Address are not supported by "
                                       "Mixed 11-bit Addressing format and all must be None.")
         AddressingType.validate_member(addressing_type)
-        CanIdHandler.validate_can_id(can_id)
-        validate_raw_byte(address_extension)
+        CanIdHandler.validate_can_id(can_id)  # type: ignore
+        validate_raw_byte(address_extension)  # type: ignore
         if not CanIdHandler.is_mixed_11bit_addressed_can_id(can_id):  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with "
                                              f"Mixed 11-bit Addressing Format. Actual value: {can_id}")
@@ -93,15 +93,15 @@ class Mixed29BitCanAddressingInformation(AbstractCanAddressingInformation):
         :return: Normalized dictionary with the provided Addressing Information.
         """
         AddressingType.validate_member(addressing_type)
-        validate_raw_byte(address_extension)
+        validate_raw_byte(address_extension)  # type: ignore
         if can_id is None:
             if None in (target_address, source_address):
                 raise InconsistentArgumentsError(f"Values of target_address and source_address must be provided,"
                                                  f"if can_id value is None for Mixed 29-bit Addressing Format. "
                                                  f"Actual values: "
                                                  f"target_address={target_address}, source_address={source_address}")
-            validate_raw_byte(target_address)
-            validate_raw_byte(source_address)
+            validate_raw_byte(target_address)  # type: ignore
+            validate_raw_byte(source_address)  # type: ignore
             encoded_can_id = CanIdHandler.encode_mixed_addressed_29bit_can_id(
                 addressing_type=addressing_type,
                 target_address=target_address,  # type: ignore

--- a/uds/can/mixed_addressing_information.py
+++ b/uds/can/mixed_addressing_information.py
@@ -52,13 +52,12 @@ class Mixed11BitCanAddressingInformation(AbstractCanAddressingInformation):
         if not CanIdHandler.is_mixed_11bit_addressed_can_id(can_id):  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with "
                                              f"Mixed 11-bit Addressing Format. Actual value: {can_id}")
-        return PacketAIParamsAlias(
-            addressing_format=CanAddressingFormat.MIXED_11BIT_ADDRESSING,
-            addressing_type=addressing_type,
-            can_id=can_id,  # type: ignore
-            target_address=target_address,
-            source_address=source_address,
-            address_extension=address_extension)
+        return PacketAIParamsAlias(addressing_format=CanAddressingFormat.MIXED_11BIT_ADDRESSING,
+                                   addressing_type=addressing_type,
+                                   can_id=can_id,  # type: ignore
+                                   target_address=target_address,
+                                   source_address=source_address,
+                                   address_extension=address_extension)
 
 
 class Mixed29BitCanAddressingInformation(AbstractCanAddressingInformation):
@@ -107,13 +106,12 @@ class Mixed29BitCanAddressingInformation(AbstractCanAddressingInformation):
                 addressing_type=addressing_type,
                 target_address=target_address,  # type: ignore
                 source_address=source_address)  # type: ignore
-            return PacketAIParamsAlias(
-                addressing_format=CanAddressingFormat.MIXED_29BIT_ADDRESSING,
-                addressing_type=addressing_type,
-                can_id=encoded_can_id,
-                target_address=target_address,
-                source_address=source_address,
-                address_extension=address_extension)
+            return PacketAIParamsAlias(addressing_format=CanAddressingFormat.MIXED_29BIT_ADDRESSING,
+                                       addressing_type=addressing_type,
+                                       can_id=encoded_can_id,
+                                       target_address=target_address,
+                                       source_address=source_address,
+                                       address_extension=address_extension)
         decoded_info = CanIdHandler.decode_mixed_addressed_29bit_can_id(can_id)
         if addressing_type != decoded_info[CanIdHandler.ADDRESSING_TYPE_NAME]:  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with Addressing Type."
@@ -124,10 +122,9 @@ class Mixed29BitCanAddressingInformation(AbstractCanAddressingInformation):
         if source_address not in (decoded_info[CanIdHandler.SOURCE_ADDRESS_NAME], None):  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with Source Address."
                                              f"Actual values: can_id={can_id}, source_address={source_address}")
-        return PacketAIParamsAlias(
-            addressing_format=CanAddressingFormat.MIXED_29BIT_ADDRESSING,
-            addressing_type=addressing_type,
-            can_id=can_id,
-            target_address=decoded_info[CanIdHandler.TARGET_ADDRESS_NAME],  # type: ignore
-            source_address=decoded_info[CanIdHandler.SOURCE_ADDRESS_NAME],  # type: ignore
-            address_extension=address_extension)
+        return PacketAIParamsAlias(addressing_format=CanAddressingFormat.MIXED_29BIT_ADDRESSING,
+                                   addressing_type=addressing_type,
+                                   can_id=can_id,
+                                   target_address=decoded_info[CanIdHandler.TARGET_ADDRESS_NAME],  # type: ignore
+                                   source_address=decoded_info[CanIdHandler.SOURCE_ADDRESS_NAME],  # type: ignore
+                                   address_extension=address_extension)

--- a/uds/can/normal_addressing_information.py
+++ b/uds/can/normal_addressing_information.py
@@ -46,7 +46,7 @@ class Normal11BitCanAddressingInformation(AbstractCanAddressingInformation):
         if (target_address, source_address, address_extension) != (None, None, None):
             raise UnusedArgumentError("Values of Target Address, Source Address and Address Extension are "
                                       "not supported by Normal 11-bit Addressing format and all must be None.")
-        AddressingType.validate_member(addressing_type)
+        addressing_type = AddressingType.validate_member(addressing_type)
         CanIdHandler.validate_can_id(can_id)  # type: ignore
         if not CanIdHandler.is_normal_11bit_addressed_can_id(can_id):  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with "
@@ -95,7 +95,7 @@ class NormalFixedCanAddressingInformation(AbstractCanAddressingInformation):
         if address_extension is not None:
             raise UnusedArgumentError("Values of TAddress Extension is not supported by Normal Fixed Addressing format "
                                       "and all must be None.")
-        AddressingType.validate_member(addressing_type)
+        addressing_type = AddressingType.validate_member(addressing_type)
         if can_id is None:
             if None in (target_address, source_address):
                 raise InconsistentArgumentsError(f"Values of target_address and source_address must be provided,"

--- a/uds/can/normal_addressing_information.py
+++ b/uds/can/normal_addressing_information.py
@@ -52,13 +52,12 @@ class Normal11BitCanAddressingInformation(AbstractCanAddressingInformation):
         if not CanIdHandler.is_normal_11bit_addressed_can_id(can_id):  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with "
                                              f"Normal 11-bit Addressing Format. Actual value: {can_id}")
-        return PacketAIParamsAlias(
-            addressing_format=CanAddressingFormat.NORMAL_11BIT_ADDRESSING,
-            addressing_type=addressing_type,
-            can_id=can_id,  # type: ignore
-            target_address=target_address,
-            source_address=source_address,
-            address_extension=address_extension)
+        return PacketAIParamsAlias(addressing_format=CanAddressingFormat.NORMAL_11BIT_ADDRESSING,
+                                   addressing_type=addressing_type,
+                                   can_id=can_id,  # type: ignore
+                                   target_address=target_address,
+                                   source_address=source_address,
+                                   address_extension=address_extension)
 
 
 class NormalFixedCanAddressingInformation(AbstractCanAddressingInformation):
@@ -111,13 +110,12 @@ class NormalFixedCanAddressingInformation(AbstractCanAddressingInformation):
                 addressing_type=addressing_type,
                 target_address=target_address,  # type: ignore
                 source_address=source_address)  # type: ignore
-            return PacketAIParamsAlias(
-                addressing_format=CanAddressingFormat.NORMAL_FIXED_ADDRESSING,
-                addressing_type=addressing_type,
-                can_id=encoded_can_id,
-                target_address=target_address,
-                source_address=source_address,
-                address_extension=address_extension)
+            return PacketAIParamsAlias(addressing_format=CanAddressingFormat.NORMAL_FIXED_ADDRESSING,
+                                       addressing_type=addressing_type,
+                                       can_id=encoded_can_id,
+                                       target_address=target_address,
+                                       source_address=source_address,
+                                       address_extension=address_extension)
         decoded_info = CanIdHandler.decode_normal_fixed_addressed_can_id(can_id)
         if addressing_type != decoded_info[CanIdHandler.ADDRESSING_TYPE_NAME]:  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with Addressing Type."
@@ -128,10 +126,9 @@ class NormalFixedCanAddressingInformation(AbstractCanAddressingInformation):
         if source_address not in (decoded_info[CanIdHandler.SOURCE_ADDRESS_NAME], None):  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with Source Address."
                                              f"Actual values: can_id={can_id}, source_address={source_address}")
-        return PacketAIParamsAlias(
-            addressing_format=CanAddressingFormat.NORMAL_FIXED_ADDRESSING,
-            addressing_type=addressing_type,
-            can_id=can_id,
-            target_address=decoded_info[CanIdHandler.TARGET_ADDRESS_NAME],  # type: ignore
-            source_address=decoded_info[CanIdHandler.SOURCE_ADDRESS_NAME],  # type: ignore
-            address_extension=address_extension)
+        return PacketAIParamsAlias(addressing_format=CanAddressingFormat.NORMAL_FIXED_ADDRESSING,
+                                   addressing_type=addressing_type,
+                                   can_id=can_id,
+                                   target_address=decoded_info[CanIdHandler.TARGET_ADDRESS_NAME],  # type: ignore
+                                   source_address=decoded_info[CanIdHandler.SOURCE_ADDRESS_NAME],  # type: ignore
+                                   address_extension=address_extension)

--- a/uds/can/normal_addressing_information.py
+++ b/uds/can/normal_addressing_information.py
@@ -28,8 +28,7 @@ class Normal11BitCanAddressingInformation(AbstractCanAddressingInformation):
                            can_id: Optional[int] = None,
                            target_address: Optional[int] = None,
                            source_address: Optional[int] = None,
-                           address_extension: Optional[int] = None
-                           ) -> PacketAIParamsAlias:
+                           address_extension: Optional[int] = None) -> PacketAIParamsAlias:
         """
         Validate Addressing Information parameters of a CAN packet that uses Normal 11-bit Addressing format.
 
@@ -48,7 +47,7 @@ class Normal11BitCanAddressingInformation(AbstractCanAddressingInformation):
             raise UnusedArgumentError("Values of Target Address, Source Address and Address Extension are "
                                       "not supported by Normal 11-bit Addressing format and all must be None.")
         AddressingType.validate_member(addressing_type)
-        CanIdHandler.validate_can_id(can_id)
+        CanIdHandler.validate_can_id(can_id)  # type: ignore
         if not CanIdHandler.is_normal_11bit_addressed_can_id(can_id):  # type: ignore
             raise InconsistentArgumentsError(f"Provided value of CAN ID is not compatible with "
                                              f"Normal 11-bit Addressing Format. Actual value: {can_id}")
@@ -77,8 +76,7 @@ class NormalFixedCanAddressingInformation(AbstractCanAddressingInformation):
                            can_id: Optional[int] = None,
                            target_address: Optional[int] = None,
                            source_address: Optional[int] = None,
-                           address_extension: Optional[int] = None
-                           ) -> PacketAIParamsAlias:
+                           address_extension: Optional[int] = None) -> PacketAIParamsAlias:
         """
         Validate Addressing Information parameters of a CAN packet that uses Normal Fixed Addressing format.
 
@@ -104,8 +102,8 @@ class NormalFixedCanAddressingInformation(AbstractCanAddressingInformation):
                                                  f"if can_id value is None for Normal Fixed Addressing Format. "
                                                  f"Actual values: "
                                                  f"target_address={target_address}, source_address={source_address}")
-            validate_raw_byte(target_address)
-            validate_raw_byte(source_address)
+            validate_raw_byte(target_address)  # type: ignore
+            validate_raw_byte(source_address)  # type: ignore
             encoded_can_id = CanIdHandler.encode_normal_fixed_addressed_can_id(
                 addressing_type=addressing_type,
                 target_address=target_address,  # type: ignore

--- a/uds/message/uds_message.py
+++ b/uds/message/uds_message.py
@@ -6,7 +6,7 @@ Module with common implementation of all diagnostic messages (requests and respo
 
 __all__ = ["AbstractUdsMessageContainer", "UdsMessage", "UdsMessageRecord"]
 
-from typing import Any
+from typing import Sequence
 from abc import ABC, abstractmethod
 from datetime import datetime
 
@@ -129,7 +129,7 @@ class UdsMessageRecord(AbstractUdsMessageContainer):
             and self.direction == other.direction
 
     @staticmethod
-    def __validate_packets_records(value: Any) -> None:
+    def __validate_packets_records(value: PacketsRecordsSequence) -> None:
         """
         Validate whether the argument contains UDS Packets records.
 
@@ -139,9 +139,8 @@ class UdsMessageRecord(AbstractUdsMessageContainer):
         :raise ValueError: At least one of UDS Packet Records sequence elements is not an object of
             :class:`~uds.message.uds_packet.AbstractUdsPacketRecord` class.
         """
-        if not isinstance(value, (tuple, list)):
-            raise TypeError(f"Provided value is not list or tuple type. "
-                            f"Actual type: {type(value)}")
+        if not isinstance(value, Sequence):
+            raise TypeError(f"Provided value is not a sequence. Actual type: {type(value)}")
         if not value or any(not isinstance(element, AbstractUdsPacketRecord) for element in value):
             raise ValueError(f"Provided value must contain only instances of AbstractUdsPacketRecord class. "
                              f"Actual value: {value}")

--- a/uds/packet/abstract_packet_type.py
+++ b/uds/packet/abstract_packet_type.py
@@ -2,7 +2,6 @@
 
 __all__ = ["AbstractUdsPacketType"]
 
-from typing import Any
 from abc import abstractmethod
 
 from uds.utilities import NibbleEnum, ValidatedEnum, ExtendableEnum
@@ -20,7 +19,7 @@ class AbstractUdsPacketType(NibbleEnum, ValidatedEnum, ExtendableEnum):
 
     @classmethod
     @abstractmethod
-    def is_initial_packet_type(cls, value: Any) -> bool:
+    def is_initial_packet_type(cls, value: "AbstractUdsPacketType") -> bool:
         """
         Check whether given argument is a member or a value of packet type that initiates a diagnostic message.
 

--- a/uds/packet/can_packet_type.py
+++ b/uds/packet/can_packet_type.py
@@ -2,8 +2,6 @@
 
 __all__ = ["CanPacketType"]
 
-from typing import Any
-
 from aenum import unique
 
 from uds.can import CanSingleFrameHandler, CanFirstFrameHandler, CanConsecutiveFrameHandler, CanFlowControlHandler
@@ -29,7 +27,7 @@ class CanPacketType(AbstractUdsPacketType):
     """CAN packet type (N_PCI) value of :ref:`Flow Control (FC) <knowledge-base-can-flow-control>`."""
 
     @classmethod
-    def is_initial_packet_type(cls, value: Any) -> bool:
+    def is_initial_packet_type(cls, value: "CanPacketType") -> bool:
         """
         Check whether given argument is a CAN packet type that initiates a diagnostic message.
 

--- a/uds/packet/can_packet_type.py
+++ b/uds/packet/can_packet_type.py
@@ -35,5 +35,4 @@ class CanPacketType(AbstractUdsPacketType):
 
         :return: True if given argument is a packet type that initiates a diagnostic message, else False.
         """
-        cls.validate_member(value)
-        return value in (cls.SINGLE_FRAME, cls.FIRST_FRAME)
+        return cls.validate_member(value) in (cls.SINGLE_FRAME, cls.FIRST_FRAME)

--- a/uds/utilities/bytes_operations.py
+++ b/uds/utilities/bytes_operations.py
@@ -36,8 +36,7 @@ def bytes_list_to_int(bytes_list: RawBytesAlias, endianness: Endianness = Endian
     :return: The integer value represented by provided list of bytes.
     """
     validate_raw_bytes(bytes_list)
-    Endianness.validate_member(endianness)
-    return int.from_bytes(bytes=bytes_list, byteorder=endianness)
+    return int.from_bytes(bytes=bytes_list, byteorder=Endianness.validate_member(endianness).value)
 
 
 def int_to_bytes_list(int_value: int,

--- a/uds/utilities/common_types.py
+++ b/uds/utilities/common_types.py
@@ -3,7 +3,7 @@
 __all__ = ["TimeMillisecondsAlias", "RawBytesAlias", "RawBytesTupleAlias", "RawBytesListAlias", "RawBytesSetAlias",
            "validate_nibble", "validate_raw_byte", "validate_raw_bytes"]
 
-from typing import Any, Union, Tuple, List, Set
+from typing import Union, Tuple, List, Set
 
 
 TimeMillisecondsAlias = Union[int, float]
@@ -18,7 +18,7 @@ RawBytesAlias = Union[RawBytesTupleAlias, RawBytesListAlias, bytearray]
 """Alias of a sequence filled with byte values."""
 
 
-def validate_nibble(value: Any) -> None:
+def validate_nibble(value: int) -> None:
     """
     Validate whether provided value stores a nibble value.
 
@@ -33,7 +33,7 @@ def validate_nibble(value: Any) -> None:
         raise ValueError(f"Provided value is out of nibble values range (0x0-0xF). Actual value: {value}")
 
 
-def validate_raw_byte(value: Any) -> None:
+def validate_raw_byte(value: int) -> None:
     """
     Validate whether provided value stores a raw byte value.
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
- Improve usage of TypedDict class for typing - create TypedDict object instaed of a normal dict whenever a TypedDict is used to specify the return value
- explicitly define types of parameters in validation methods
- replace some `Any` annotations


## How Has This Been Tested?
<!--- Please shortly describe how you tested your code. -->
- unit tests
- static code analysis


## Process
<!--- If you are familiar with the process, leave the line below. If not, please describe what you did, so we could help you deliver your changed according to our quality policies -->
I know the [process](https://github.com/mdabrowski1990/uds/wiki/Software-Development-Life-Cycle) and did my best to follow it
