### PR TITLE
Python-CAN Transport Interface without receiving own frames

### DIFF
--- a/tests/prospector_profile.yaml
+++ b/tests/prospector_profile.yaml
@@ -17,8 +17,8 @@ pep8:
 pylint:
   options:
     max-line-length: 120
-    max-args: 10
-    max-positional-arguments: 10
+    max-args: 12
+    max-positional-arguments: 12
     max-attributes: 25
     min-public-methods: 1
     max-public-methods: 30

--- a/tests/prospector_profile.yaml
+++ b/tests/prospector_profile.yaml
@@ -6,7 +6,6 @@ doc-warnings: true
 autodetect: false
 test-warnings: true
 
-
 # default tools configuration: http://prospector.landscape.io/en/master/supported_tools.html#defaults
 
 pep8:
@@ -44,7 +43,6 @@ mccabe:
   options:
     max-complexity: 12
 
-
 # additional tools configuration: http://prospector.landscape.io/en/master/supported_tools.html#optional-extras
 
 mypy:
@@ -54,11 +52,10 @@ mypy:
   disable:
     - attr-defined
 
-
 vulture:
   run: true
 
-bandit:  # there is probably no use of it (not applicable for this project), but it is run anyway to make sure everything is secured
+bandit:  # run it as a security precaution
   run: true
 
 pyroma:

--- a/tests/software_tests/can/transport_interface/test_common.py
+++ b/tests/software_tests/can/transport_interface/test_common.py
@@ -58,19 +58,23 @@ class TestAbstractCanTransportInterface:
         assert (self.mock_can_transport_interface.flow_control_parameters_generator
                 == AbstractCanTransportInterface.DEFAULT_FLOW_CONTROL_PARAMETERS)
         self.mock_can_transport_interface.segmenter = self.mock_can_segmenter.return_value
-        self.mock_abstract_transport_interface_init.assert_called_once_with(network_manager=network_manager)
+        self.mock_abstract_transport_interface_init.assert_called_once_with(network_manager=network_manager,
+                                                                            network_manager_receives_own_frames=True)
         self.mock_can_segmenter.assert_called_once_with(addressing_information=addressing_information)
 
-    @pytest.mark.parametrize("network_manager, addressing_information, n_as_timeout, n_ar_timeout, n_bs_timeout, "
-                             "n_br, n_cs, n_cr_timeout, flow_control_parameters_generator, segmenter_configuration", [
-        (Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), {"a": 1, "bc": 2, "def_xyz": Mock()})
+    @pytest.mark.parametrize("network_manager, addressing_information, network_manager_receives_own_frames, "
+                             "n_as_timeout, n_ar_timeout, n_bs_timeout, n_br, n_cs, n_cr_timeout, "
+                             "flow_control_parameters_generator, segmenter_configuration", [
+        (Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), {"a": 1, "bc": 2, "def_xyz": Mock()})
     ])
-    def test_init__all_args(self, network_manager, addressing_information, n_as_timeout, n_ar_timeout, n_bs_timeout,
-                            n_br, n_cs, n_cr_timeout, flow_control_parameters_generator, segmenter_configuration):
+    def test_init__all_args(self, network_manager, addressing_information, network_manager_receives_own_frames,
+                            n_as_timeout, n_ar_timeout, n_bs_timeout, n_br, n_cs, n_cr_timeout,
+                            flow_control_parameters_generator, segmenter_configuration):
         assert AbstractCanTransportInterface.__init__(
             self.mock_can_transport_interface,
             network_manager=network_manager,
             addressing_information=addressing_information,
+            network_manager_receives_own_frames=network_manager_receives_own_frames,
             n_as_timeout=n_as_timeout,
             n_ar_timeout=n_ar_timeout,
             n_bs_timeout=n_bs_timeout,
@@ -92,232 +96,11 @@ class TestAbstractCanTransportInterface:
         assert (self.mock_can_transport_interface.flow_control_parameters_generator
                 == flow_control_parameters_generator)
         self.mock_can_transport_interface.segmenter = self.mock_can_segmenter.return_value
-        self.mock_abstract_transport_interface_init.assert_called_once_with(network_manager=network_manager)
+        self.mock_abstract_transport_interface_init.assert_called_once_with(
+            network_manager=network_manager,
+            network_manager_receives_own_frames=network_manager_receives_own_frames)
         self.mock_can_segmenter.assert_called_once_with(addressing_information=addressing_information,
                                                         **segmenter_configuration)
-
-    # _update_n_ar_measured
-
-    @pytest.mark.parametrize("value", [Mock(), "some value"])
-    @patch(f"{SCRIPT_LOCATION}.isinstance")
-    def test_update_n_ar_measured__type_error(self, mock_isinstance, value):
-        mock_isinstance.return_value = False
-        with pytest.raises(TypeError):
-            AbstractCanTransportInterface._update_n_ar_measured(self.mock_can_transport_interface, value)
-        mock_isinstance.assert_called_once_with(value, (int, float))
-
-    @pytest.mark.parametrize("value", [-1, -0.0001])
-    @patch(f"{SCRIPT_LOCATION}.isinstance")
-    def test_update_n_ar_measured__value_error(self, mock_isinstance, value):
-        mock_isinstance.return_value = True
-        with pytest.raises(ValueError):
-            AbstractCanTransportInterface._update_n_ar_measured(self.mock_can_transport_interface, value)
-        mock_isinstance.assert_called_once_with(value, (int, float))
-
-    @pytest.mark.parametrize("value", [0, AbstractCanTransportInterface.N_AR_TIMEOUT])
-    def test_update_n_ar_measured__no_warning(self, value):
-        self.mock_can_transport_interface.n_ar_timeout = AbstractCanTransportInterface.N_AR_TIMEOUT
-        assert AbstractCanTransportInterface._update_n_ar_measured(self.mock_can_transport_interface, value) is None
-        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_ar_measured == value
-        self.mock_warn.assert_not_called()
-
-    @pytest.mark.parametrize("value, n_ar_timeout", [
-        (AbstractCanTransportInterface.N_AR_TIMEOUT + 1, AbstractCanTransportInterface.N_AR_TIMEOUT),
-        (AbstractCanTransportInterface.N_AR_TIMEOUT - 1, AbstractCanTransportInterface.N_AR_TIMEOUT // 2),
-    ])
-    def test_update_n_ar_measured__warning(self, value, n_ar_timeout):
-        self.mock_can_transport_interface.n_ar_timeout = n_ar_timeout
-        assert AbstractCanTransportInterface._update_n_ar_measured(self.mock_can_transport_interface, value) is None
-        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_ar_measured == value
-        self.mock_warn.assert_called_once()
-        
-    # _update_n_as_measured
-
-    @pytest.mark.parametrize("value", [Mock(), "some value"])
-    @patch(f"{SCRIPT_LOCATION}.isinstance")
-    def test_update_n_as_measured__type_error(self, mock_isinstance, value):
-        mock_isinstance.return_value = False
-        with pytest.raises(TypeError):
-            AbstractCanTransportInterface._update_n_as_measured(self.mock_can_transport_interface, value)
-        mock_isinstance.assert_called_once_with(value, (int, float))
-
-    @pytest.mark.parametrize("value", [-1, -0.0001])
-    @patch(f"{SCRIPT_LOCATION}.isinstance")
-    def test_update_n_as_measured__value_error(self, mock_isinstance, value):
-        mock_isinstance.return_value = True
-        with pytest.raises(ValueError):
-            AbstractCanTransportInterface._update_n_as_measured(self.mock_can_transport_interface, value)
-        mock_isinstance.assert_called_once_with(value, (int, float))
-
-    @pytest.mark.parametrize("value", [0, AbstractCanTransportInterface.N_AS_TIMEOUT])
-    def test_update_n_as_measured__no_warning(self, value):
-        self.mock_can_transport_interface.n_as_timeout = AbstractCanTransportInterface.N_AS_TIMEOUT
-        assert AbstractCanTransportInterface._update_n_as_measured(self.mock_can_transport_interface, value) is None
-        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_as_measured == value
-        self.mock_warn.assert_not_called()
-
-    @pytest.mark.parametrize("value, n_as_timeout", [
-        (AbstractCanTransportInterface.N_AS_TIMEOUT + 1, AbstractCanTransportInterface.N_AS_TIMEOUT),
-        (AbstractCanTransportInterface.N_AS_TIMEOUT - 1, AbstractCanTransportInterface.N_AS_TIMEOUT // 2),
-    ])
-    def test_update_n_as_measured__warning(self, value, n_as_timeout):
-        self.mock_can_transport_interface.n_as_timeout = n_as_timeout
-        assert AbstractCanTransportInterface._update_n_as_measured(self.mock_can_transport_interface, value) is None
-        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_as_measured == value
-        self.mock_warn.assert_called_once()
-
-    # _update_n_bs_measured
-
-    @pytest.mark.parametrize("message_record", [
-        Mock(), "not a message"
-    ])
-    @patch(f"{SCRIPT_LOCATION}.isinstance")
-    def test_update_n_bs_measured__type_error(self, mock_isinstance, message_record):
-        mock_isinstance.return_value = False
-        with pytest.raises(TypeError):
-            AbstractCanTransportInterface._update_n_bs_measured(self.mock_can_transport_interface,
-                                                                message_record=message_record)
-        mock_isinstance.assert_called_once_with(message_record, UdsMessageRecord)
-
-    @pytest.mark.parametrize("message_record", [
-        Mock(direction=TransmissionDirection.RECEIVED), Mock(direction="not transmitted")
-    ])
-    @patch(f"{SCRIPT_LOCATION}.isinstance")
-    def test_update_n_bs_measured__value_error(self, mock_isinstance, message_record):
-        mock_isinstance.return_value = True
-        with pytest.raises(ValueError):
-            AbstractCanTransportInterface._update_n_bs_measured(self.mock_can_transport_interface,
-                                                                message_record=message_record)
-        mock_isinstance.assert_called_once_with(message_record, UdsMessageRecord)
-
-    def test_update_n_bs_measured__1_record(self):
-        mock_message_record = Mock(spec=UdsMessageRecord,
-                                   direction=TransmissionDirection.TRANSMITTED,
-                                   packets_records=(Mock(spec=CanPacketRecord),))
-        assert AbstractCanTransportInterface._update_n_bs_measured(self.mock_can_transport_interface,
-                                                                   message_record=mock_message_record) is None
-        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_bs_measured is None
-
-    @pytest.mark.parametrize("message_record, expected_n_bs_measurements", [
-        (Mock(spec=UdsMessageRecord, direction=TransmissionDirection.TRANSMITTED, packets_records=(
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FIRST_FRAME,
-                     transmission_time=datetime(year=1234, month=1, day=2)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
-                     transmission_time=datetime(year=1234, month=1, day=2, microsecond=1000)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
-                     transmission_time=datetime(year=1234, month=1, day=2, microsecond=3000)))),
-         (1,)),
-        (Mock(spec=UdsMessageRecord, direction=TransmissionDirection.TRANSMITTED, packets_records=(
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FIRST_FRAME,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=12,
-                                                microsecond=987654)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
-                                                microsecond=154)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
-                                                microsecond=57000)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
-                                                microsecond=58954)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
-                                                microsecond=58955)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
-                                                microsecond=868955)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=14,
-                                                microsecond=955)),
-        )),
-         (12.5, 56.846, 0.001)),
-    ])
-    def test_update_n_bs_measured__multiple_records(self, message_record, expected_n_bs_measurements):
-        assert AbstractCanTransportInterface._update_n_bs_measured(self.mock_can_transport_interface,
-                                                                   message_record=message_record) is None
-        assert (self.mock_can_transport_interface._AbstractCanTransportInterface__n_bs_measured
-                == expected_n_bs_measurements)
-
-    # _update_n_cr_measured
-
-    @pytest.mark.parametrize("message_record", [
-        Mock(), "not a message"
-    ])
-    @patch(f"{SCRIPT_LOCATION}.isinstance")
-    def test_update_n_cr_measured__type_error(self, mock_isinstance, message_record):
-        mock_isinstance.return_value = False
-        with pytest.raises(TypeError):
-            AbstractCanTransportInterface._update_n_cr_measured(self.mock_can_transport_interface,
-                                                                message_record=message_record)
-        mock_isinstance.assert_called_once_with(message_record, UdsMessageRecord)
-
-    @pytest.mark.parametrize("message_record", [
-        Mock(direction=TransmissionDirection.TRANSMITTED), Mock(direction="not received")
-    ])
-    @patch(f"{SCRIPT_LOCATION}.isinstance")
-    def test_update_n_cr_measured__value_error(self, mock_isinstance, message_record):
-        mock_isinstance.return_value = True
-        with pytest.raises(ValueError):
-            AbstractCanTransportInterface._update_n_cr_measured(self.mock_can_transport_interface,
-                                                                message_record=message_record)
-        mock_isinstance.assert_called_once_with(message_record, UdsMessageRecord)
-
-    def test_update_n_cr_measured__1_record(self):
-        mock_message_record = Mock(spec=UdsMessageRecord,
-                                   direction=TransmissionDirection.RECEIVED,
-                                   packets_records=(Mock(spec=CanPacketRecord),))
-        assert AbstractCanTransportInterface._update_n_cr_measured(self.mock_can_transport_interface,
-                                                                   message_record=mock_message_record) is None
-        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_cr_measured is None
-
-    @pytest.mark.parametrize("message, expected_n_cr_measurements", [
-        (Mock(spec=UdsMessageRecord, direction=TransmissionDirection.RECEIVED, packets_records=(
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FIRST_FRAME,
-                     transmission_time=datetime(year=1234, month=1, day=2)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
-                     transmission_time=datetime(year=1234, month=1, day=2, microsecond=1000)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
-                     transmission_time=datetime(year=1234, month=1, day=2, microsecond=3000)))),
-         (2,)),
-        (Mock(spec=UdsMessageRecord, direction=TransmissionDirection.RECEIVED, packets_records=(
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FIRST_FRAME,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=12,
-                                                microsecond=987654)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
-                                                microsecond=154)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
-                                                microsecond=57000)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
-                                                microsecond=58954)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
-                                                microsecond=58955)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
-                                                microsecond=868955)),
-                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
-                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=14,
-                                                microsecond=955)),
-        )),
-         (1.954, 810.0, 132)),
-    ])
-    def test_update_n_cr_measured__multiple_records(self, message, expected_n_cr_measurements):
-        assert AbstractCanTransportInterface._update_n_cr_measured(self.mock_can_transport_interface,
-                                                                   message_record=message) is None
-        assert (self.mock_can_transport_interface._AbstractCanTransportInterface__n_cr_measured
-                == expected_n_cr_measurements)
-
-    # clear_measurements
-
-    def test_clear_measurements(self):
-        assert AbstractCanTransportInterface.clear_measurements(self.mock_can_transport_interface) is None
-        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_ar_measured is None
-        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_as_measured is None
-        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_bs_measured is None
-        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_cr_measured is None
 
     # segmenter
 
@@ -341,6 +124,65 @@ class TestAbstractCanTransportInterface:
         with pytest.raises(TypeError):
             AbstractCanTransportInterface.segmenter.fset(self.mock_can_transport_interface, value)
         mock_isinstance.assert_called_once_with(value, self.mock_can_segmenter)
+
+        # dlc
+
+    def test_dlc__get(self):
+        assert AbstractCanTransportInterface.dlc.fget(self.mock_can_transport_interface) \
+               == self.mock_can_transport_interface.segmenter.dlc
+
+    @pytest.mark.parametrize("value", ["something", Mock()])
+    def test_dlc__set(self, value):
+        AbstractCanTransportInterface.dlc.fset(self.mock_can_transport_interface, value)
+        assert self.mock_can_transport_interface.segmenter.dlc == value
+
+    # use_data_optimization
+
+    def test_use_data_optimization__get(self):
+        assert AbstractCanTransportInterface.use_data_optimization.fget(self.mock_can_transport_interface) \
+               == self.mock_can_transport_interface.segmenter.use_data_optimization
+
+    @pytest.mark.parametrize("value", ["something", Mock()])
+    def test_use_data_optimization__set(self, value):
+        AbstractCanTransportInterface.use_data_optimization.fset(self.mock_can_transport_interface, value)
+        assert self.mock_can_transport_interface.segmenter.use_data_optimization == value
+
+    # filler_byte
+
+    def test_filler_byte__get(self):
+        assert AbstractCanTransportInterface.filler_byte.fget(self.mock_can_transport_interface) \
+               == self.mock_can_transport_interface.segmenter.filler_byte
+
+    @pytest.mark.parametrize("value", ["something", Mock()])
+    def test_filler_byte__set(self, value):
+        AbstractCanTransportInterface.filler_byte.fset(self.mock_can_transport_interface, value)
+        assert self.mock_can_transport_interface.segmenter.filler_byte == value
+
+    # flow_control_parameters_generator
+
+    def test_flow_control_parameters_generator__get(self):
+        self.mock_can_transport_interface._AbstractCanTransportInterface__flow_control_parameters_generator = Mock()
+        assert (AbstractCanTransportInterface.flow_control_parameters_generator.fget(self.mock_can_transport_interface)
+                == self.mock_can_transport_interface._AbstractCanTransportInterface__flow_control_parameters_generator)
+
+    @pytest.mark.parametrize("value", ["something", Mock()])
+    @patch(f"{SCRIPT_LOCATION}.isinstance")
+    def test_flow_control_parameters_generator__set(self, mock_isinstance, value):
+        mock_isinstance.return_value = True
+        assert AbstractCanTransportInterface.flow_control_parameters_generator.fset(self.mock_can_transport_interface,
+                                                                                    value) is None
+        assert (self.mock_can_transport_interface._AbstractCanTransportInterface__flow_control_parameters_generator
+                == value)
+        mock_isinstance.assert_called_once_with(value, AbstractFlowControlParametersGenerator)
+
+    @pytest.mark.parametrize("value", ["something", Mock()])
+    @patch(f"{SCRIPT_LOCATION}.isinstance")
+    def test_flow_control_parameters_generator__set__type_error(self, mock_isinstance, value):
+        mock_isinstance.return_value = False
+        with pytest.raises(TypeError):
+            AbstractCanTransportInterface.flow_control_parameters_generator.fset(self.mock_can_transport_interface,
+                                                                                 value)
+        mock_isinstance.assert_called_once_with(value, AbstractFlowControlParametersGenerator)
 
     # n_as
 
@@ -688,60 +530,225 @@ class TestAbstractCanTransportInterface:
         assert (AbstractCanTransportInterface.n_cr_measured.fget(self.mock_can_transport_interface)
                 == self.mock_can_transport_interface._AbstractCanTransportInterface__n_cr_measured)
 
-    # dlc
+    # _update_n_ar_measured
 
-    def test_dlc__get(self):
-        assert AbstractCanTransportInterface.dlc.fget(self.mock_can_transport_interface) \
-               == self.mock_can_transport_interface.segmenter.dlc
-
-    @pytest.mark.parametrize("value", ["something", Mock()])
-    def test_dlc__set(self, value):
-        AbstractCanTransportInterface.dlc.fset(self.mock_can_transport_interface, value)
-        assert self.mock_can_transport_interface.segmenter.dlc == value
-
-    # use_data_optimization
-
-    def test_use_data_optimization__get(self):
-        assert AbstractCanTransportInterface.use_data_optimization.fget(self.mock_can_transport_interface) \
-               == self.mock_can_transport_interface.segmenter.use_data_optimization
-
-    @pytest.mark.parametrize("value", ["something", Mock()])
-    def test_use_data_optimization__set(self, value):
-        AbstractCanTransportInterface.use_data_optimization.fset(self.mock_can_transport_interface, value)
-        assert self.mock_can_transport_interface.segmenter.use_data_optimization == value
-
-    # filler_byte
-
-    def test_filler_byte__get(self):
-        assert AbstractCanTransportInterface.filler_byte.fget(self.mock_can_transport_interface) \
-               == self.mock_can_transport_interface.segmenter.filler_byte
-
-    @pytest.mark.parametrize("value", ["something", Mock()])
-    def test_filler_byte__set(self, value):
-        AbstractCanTransportInterface.filler_byte.fset(self.mock_can_transport_interface, value)
-        assert self.mock_can_transport_interface.segmenter.filler_byte == value
-
-    # flow_control_parameters_generator
-
-    def test_flow_control_parameters_generator__get(self):
-        self.mock_can_transport_interface._AbstractCanTransportInterface__flow_control_parameters_generator = Mock()
-        assert (AbstractCanTransportInterface.flow_control_parameters_generator.fget(self.mock_can_transport_interface)
-                == self.mock_can_transport_interface._AbstractCanTransportInterface__flow_control_parameters_generator)
-
-    @pytest.mark.parametrize("value", ["something", Mock()])
+    @pytest.mark.parametrize("value", [Mock(), "some value"])
     @patch(f"{SCRIPT_LOCATION}.isinstance")
-    def test_flow_control_parameters_generator__set(self, mock_isinstance, value):
-        mock_isinstance.return_value = True
-        assert AbstractCanTransportInterface.flow_control_parameters_generator.fset(self.mock_can_transport_interface,
-                                                                                    value) is None
-        assert (self.mock_can_transport_interface._AbstractCanTransportInterface__flow_control_parameters_generator
-                == value)
-        mock_isinstance.assert_called_once_with(value, AbstractFlowControlParametersGenerator)
-
-    @pytest.mark.parametrize("value", ["something", Mock()])
-    @patch(f"{SCRIPT_LOCATION}.isinstance")
-    def test_flow_control_parameters_generator__set__type_error(self, mock_isinstance, value):
+    def test_update_n_ar_measured__type_error(self, mock_isinstance, value):
         mock_isinstance.return_value = False
         with pytest.raises(TypeError):
-            AbstractCanTransportInterface.flow_control_parameters_generator.fset(self.mock_can_transport_interface, value)
-        mock_isinstance.assert_called_once_with(value, AbstractFlowControlParametersGenerator)
+            AbstractCanTransportInterface._update_n_ar_measured(self.mock_can_transport_interface, value)
+        mock_isinstance.assert_called_once_with(value, (int, float))
+
+    @pytest.mark.parametrize("value", [-1, -0.0001])
+    @patch(f"{SCRIPT_LOCATION}.isinstance")
+    def test_update_n_ar_measured__value_error(self, mock_isinstance, value):
+        mock_isinstance.return_value = True
+        with pytest.raises(ValueError):
+            AbstractCanTransportInterface._update_n_ar_measured(self.mock_can_transport_interface, value)
+        mock_isinstance.assert_called_once_with(value, (int, float))
+
+    @pytest.mark.parametrize("value", [0, AbstractCanTransportInterface.N_AR_TIMEOUT])
+    def test_update_n_ar_measured__no_warning(self, value):
+        self.mock_can_transport_interface.n_ar_timeout = AbstractCanTransportInterface.N_AR_TIMEOUT
+        assert AbstractCanTransportInterface._update_n_ar_measured(self.mock_can_transport_interface, value) is None
+        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_ar_measured == value
+        self.mock_warn.assert_not_called()
+
+    @pytest.mark.parametrize("value, n_ar_timeout", [
+        (AbstractCanTransportInterface.N_AR_TIMEOUT + 1, AbstractCanTransportInterface.N_AR_TIMEOUT),
+        (AbstractCanTransportInterface.N_AR_TIMEOUT - 1, AbstractCanTransportInterface.N_AR_TIMEOUT // 2),
+    ])
+    def test_update_n_ar_measured__warning(self, value, n_ar_timeout):
+        self.mock_can_transport_interface.n_ar_timeout = n_ar_timeout
+        assert AbstractCanTransportInterface._update_n_ar_measured(self.mock_can_transport_interface, value) is None
+        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_ar_measured == value
+        self.mock_warn.assert_called_once()
+        
+    # _update_n_as_measured
+
+    @pytest.mark.parametrize("value", [Mock(), "some value"])
+    @patch(f"{SCRIPT_LOCATION}.isinstance")
+    def test_update_n_as_measured__type_error(self, mock_isinstance, value):
+        mock_isinstance.return_value = False
+        with pytest.raises(TypeError):
+            AbstractCanTransportInterface._update_n_as_measured(self.mock_can_transport_interface, value)
+        mock_isinstance.assert_called_once_with(value, (int, float))
+
+    @pytest.mark.parametrize("value", [-1, -0.0001])
+    @patch(f"{SCRIPT_LOCATION}.isinstance")
+    def test_update_n_as_measured__value_error(self, mock_isinstance, value):
+        mock_isinstance.return_value = True
+        with pytest.raises(ValueError):
+            AbstractCanTransportInterface._update_n_as_measured(self.mock_can_transport_interface, value)
+        mock_isinstance.assert_called_once_with(value, (int, float))
+
+    @pytest.mark.parametrize("value", [0, AbstractCanTransportInterface.N_AS_TIMEOUT])
+    def test_update_n_as_measured__no_warning(self, value):
+        self.mock_can_transport_interface.n_as_timeout = AbstractCanTransportInterface.N_AS_TIMEOUT
+        assert AbstractCanTransportInterface._update_n_as_measured(self.mock_can_transport_interface, value) is None
+        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_as_measured == value
+        self.mock_warn.assert_not_called()
+
+    @pytest.mark.parametrize("value, n_as_timeout", [
+        (AbstractCanTransportInterface.N_AS_TIMEOUT + 1, AbstractCanTransportInterface.N_AS_TIMEOUT),
+        (AbstractCanTransportInterface.N_AS_TIMEOUT - 1, AbstractCanTransportInterface.N_AS_TIMEOUT // 2),
+    ])
+    def test_update_n_as_measured__warning(self, value, n_as_timeout):
+        self.mock_can_transport_interface.n_as_timeout = n_as_timeout
+        assert AbstractCanTransportInterface._update_n_as_measured(self.mock_can_transport_interface, value) is None
+        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_as_measured == value
+        self.mock_warn.assert_called_once()
+
+    # _update_n_bs_measured
+
+    @pytest.mark.parametrize("message_record", [
+        Mock(), "not a message"
+    ])
+    @patch(f"{SCRIPT_LOCATION}.isinstance")
+    def test_update_n_bs_measured__type_error(self, mock_isinstance, message_record):
+        mock_isinstance.return_value = False
+        with pytest.raises(TypeError):
+            AbstractCanTransportInterface._update_n_bs_measured(self.mock_can_transport_interface,
+                                                                message_record=message_record)
+        mock_isinstance.assert_called_once_with(message_record, UdsMessageRecord)
+
+    @pytest.mark.parametrize("message_record", [
+        Mock(direction=TransmissionDirection.RECEIVED), Mock(direction="not transmitted")
+    ])
+    @patch(f"{SCRIPT_LOCATION}.isinstance")
+    def test_update_n_bs_measured__value_error(self, mock_isinstance, message_record):
+        mock_isinstance.return_value = True
+        with pytest.raises(ValueError):
+            AbstractCanTransportInterface._update_n_bs_measured(self.mock_can_transport_interface,
+                                                                message_record=message_record)
+        mock_isinstance.assert_called_once_with(message_record, UdsMessageRecord)
+
+    def test_update_n_bs_measured__1_record(self):
+        mock_message_record = Mock(spec=UdsMessageRecord,
+                                   direction=TransmissionDirection.TRANSMITTED,
+                                   packets_records=(Mock(spec=CanPacketRecord),))
+        assert AbstractCanTransportInterface._update_n_bs_measured(self.mock_can_transport_interface,
+                                                                   message_record=mock_message_record) is None
+        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_bs_measured is None
+
+    @pytest.mark.parametrize("message_record, expected_n_bs_measurements", [
+        (Mock(spec=UdsMessageRecord, direction=TransmissionDirection.TRANSMITTED, packets_records=(
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FIRST_FRAME,
+                     transmission_time=datetime(year=1234, month=1, day=2)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
+                     transmission_time=datetime(year=1234, month=1, day=2, microsecond=1000)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                     transmission_time=datetime(year=1234, month=1, day=2, microsecond=3000)))),
+         (1,)),
+        (Mock(spec=UdsMessageRecord, direction=TransmissionDirection.TRANSMITTED, packets_records=(
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FIRST_FRAME,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=12,
+                                                microsecond=987654)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
+                                                microsecond=154)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
+                                                microsecond=57000)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
+                                                microsecond=58954)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
+                                                microsecond=58955)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
+                                                microsecond=868955)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=14,
+                                                microsecond=955)),
+        )),
+         (12.5, 56.846, 0.001)),
+    ])
+    def test_update_n_bs_measured__multiple_records(self, message_record, expected_n_bs_measurements):
+        assert AbstractCanTransportInterface._update_n_bs_measured(self.mock_can_transport_interface,
+                                                                   message_record=message_record) is None
+        assert (self.mock_can_transport_interface._AbstractCanTransportInterface__n_bs_measured
+                == expected_n_bs_measurements)
+
+    # _update_n_cr_measured
+
+    @pytest.mark.parametrize("message_record", [
+        Mock(), "not a message"
+    ])
+    @patch(f"{SCRIPT_LOCATION}.isinstance")
+    def test_update_n_cr_measured__type_error(self, mock_isinstance, message_record):
+        mock_isinstance.return_value = False
+        with pytest.raises(TypeError):
+            AbstractCanTransportInterface._update_n_cr_measured(self.mock_can_transport_interface,
+                                                                message_record=message_record)
+        mock_isinstance.assert_called_once_with(message_record, UdsMessageRecord)
+
+    @pytest.mark.parametrize("message_record", [
+        Mock(direction=TransmissionDirection.TRANSMITTED), Mock(direction="not received")
+    ])
+    @patch(f"{SCRIPT_LOCATION}.isinstance")
+    def test_update_n_cr_measured__value_error(self, mock_isinstance, message_record):
+        mock_isinstance.return_value = True
+        with pytest.raises(ValueError):
+            AbstractCanTransportInterface._update_n_cr_measured(self.mock_can_transport_interface,
+                                                                message_record=message_record)
+        mock_isinstance.assert_called_once_with(message_record, UdsMessageRecord)
+
+    def test_update_n_cr_measured__1_record(self):
+        mock_message_record = Mock(spec=UdsMessageRecord,
+                                   direction=TransmissionDirection.RECEIVED,
+                                   packets_records=(Mock(spec=CanPacketRecord),))
+        assert AbstractCanTransportInterface._update_n_cr_measured(self.mock_can_transport_interface,
+                                                                   message_record=mock_message_record) is None
+        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_cr_measured is None
+
+    @pytest.mark.parametrize("message, expected_n_cr_measurements", [
+        (Mock(spec=UdsMessageRecord, direction=TransmissionDirection.RECEIVED, packets_records=(
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FIRST_FRAME,
+                     transmission_time=datetime(year=1234, month=1, day=2)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
+                     transmission_time=datetime(year=1234, month=1, day=2, microsecond=1000)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                     transmission_time=datetime(year=1234, month=1, day=2, microsecond=3000)))),
+         (2,)),
+        (Mock(spec=UdsMessageRecord, direction=TransmissionDirection.RECEIVED, packets_records=(
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FIRST_FRAME,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=12,
+                                                microsecond=987654)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
+                                                microsecond=154)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
+                                                microsecond=57000)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
+                                                microsecond=58954)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.FLOW_CONTROL,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
+                                                microsecond=58955)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=13,
+                                                microsecond=868955)),
+                Mock(spec=CanPacketRecord, packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                     transmission_time=datetime(year=2024, month=9, day=22, hour=14, minute=43, second=14,
+                                                microsecond=955)),
+        )),
+         (1.954, 810.0, 132)),
+    ])
+    def test_update_n_cr_measured__multiple_records(self, message, expected_n_cr_measurements):
+        assert AbstractCanTransportInterface._update_n_cr_measured(self.mock_can_transport_interface,
+                                                                   message_record=message) is None
+        assert (self.mock_can_transport_interface._AbstractCanTransportInterface__n_cr_measured
+                == expected_n_cr_measurements)
+
+    # clear_measurements
+
+    def test_clear_measurements(self):
+        assert AbstractCanTransportInterface.clear_measurements(self.mock_can_transport_interface) is None
+        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_ar_measured is None
+        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_as_measured is None
+        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_bs_measured is None
+        assert self.mock_can_transport_interface._AbstractCanTransportInterface__n_cr_measured is None

--- a/tests/software_tests/can/transport_interface/test_python_can.py
+++ b/tests/software_tests/can/transport_interface/test_python_can.py
@@ -83,8 +83,16 @@ class TestPyCanTransportInterface:
     # __init__
 
     @pytest.mark.parametrize("network_manager, addressing_information, configuration_params", [
-        (Mock(), Mock(), {}),
-        (Mock(spec=BusABC), Mock(spec=CanAddressingInformation), {"param1": Mock(), "param2": Mock(), "dlc": 8}),
+        (
+            Mock(),
+            Mock(),
+            {}
+        ),
+        (
+            Mock(spec=BusABC),
+            Mock(spec=CanAddressingInformation),
+            {"network_manager_receives_own_frames": False, "param1": Mock(), "param2": Mock(), "dlc": 8}
+        ),
     ])
     def test_init(self, network_manager, addressing_information, configuration_params):
         assert PyCanTransportInterface.__init__(self=self.mock_can_transport_interface,
@@ -97,9 +105,11 @@ class TestPyCanTransportInterface:
                 == self.mock_async_buffered_reader.return_value)
         assert self.mock_can_transport_interface._PyCanTransportInterface__notifier is None
         assert self.mock_can_transport_interface._PyCanTransportInterface__async_notifier is None
-        self.mock_abstract_can_ti_init.assert_called_once_with(network_manager=network_manager,
-                                                               addressing_information=addressing_information,
-                                                               **configuration_params)
+        self.mock_abstract_can_ti_init.assert_called_once_with(
+            network_manager=network_manager,
+            addressing_information=addressing_information,
+            network_manager_receives_own_frames=configuration_params.pop("network_manager_receives_own_frames", True),
+            **configuration_params)
         self.mock_buffered_reader.assert_called_once()
         self.mock_async_buffered_reader.assert_called_once()
 

--- a/tests/software_tests/transport_interface/test_abstract_transport_interface.py
+++ b/tests/software_tests/transport_interface/test_abstract_transport_interface.py
@@ -14,11 +14,17 @@ class TestAbstractTransportInterface:
 
     # __init__
 
-    @pytest.mark.parametrize("network_manager", [Mock(), "some network manager"])
-    def test_init__valid(self, network_manager):
-        assert AbstractTransportInterface.__init__(self=self.mock_transport_interface,
-                                                   network_manager=network_manager) is None
+    @pytest.mark.parametrize("network_manager, network_manager_receives_own_frames", [
+        (Mock(), Mock()),
+        ("some network manager", False),
+    ])
+    def test_init__valid(self, network_manager, network_manager_receives_own_frames):
+        assert AbstractTransportInterface.__init__(
+            self=self.mock_transport_interface,
+            network_manager=network_manager,
+            network_manager_receives_own_frames=network_manager_receives_own_frames) is None
         assert self.mock_transport_interface.network_manager == network_manager
+        assert self.mock_transport_interface.network_manager_receives_own_frames == network_manager_receives_own_frames
 
     # addressing_information
 
@@ -59,3 +65,18 @@ class TestAbstractTransportInterface:
         with pytest.raises(ValueError):
             AbstractTransportInterface.network_manager.fset(self.mock_transport_interface, value)
         self.mock_transport_interface.is_supported_network_manager.assert_called_with(value)
+
+    # network_manager_receives_own_frames
+
+    def test_network_manager_receives_own_frames__get(self):
+        self.mock_transport_interface._AbstractTransportInterface__network_manager_receives_own_frames = Mock()
+        assert (AbstractTransportInterface.network_manager_receives_own_frames.fget(self.mock_transport_interface)
+                == self.mock_transport_interface._AbstractTransportInterface__network_manager_receives_own_frames)
+
+    @pytest.mark.parametrize("value", [Mock(), True, False])
+    def test_network_manager_receives_own_frames__set(self, value):
+        assert (AbstractTransportInterface.network_manager_receives_own_frames.fset(
+            self.mock_transport_interface, value) is None)
+        assert (self.mock_transport_interface._AbstractTransportInterface__network_manager_receives_own_frames
+                == bool(value))
+        

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -32,6 +32,7 @@ class AbstractPythonCanTests(ABC):
             CAN cables connection
     """
 
+    RECEIVE_OWN_FRAMES: bool = True
     MAKE_TIMING_CHECKS: bool = True
     TASK_TIMING_TOLERANCE: TimeMillisecondsAlias = 30
     WAIT_AFTER_TEST_CASE: TimeMillisecondsAlias = 250.
@@ -224,6 +225,7 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.tx_physical_params
@@ -302,6 +304,7 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.tx_physical_params
@@ -389,6 +392,7 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.rx_physical_params
@@ -477,6 +481,7 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.rx_physical_params
@@ -563,6 +568,7 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.rx_physical_params
@@ -643,6 +649,7 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.rx_physical_params
@@ -692,8 +699,10 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         :param example_can_addressing_information: Example Addressing Information of a CAN Node.
         :param message: UDS message to send.
         """
-        can_transport_interface = PyCanTransportInterface(network_manager=self.can_interface_1,
-                                                          addressing_information=example_can_addressing_information)
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
+            addressing_information=example_can_addressing_information)
         datetime_before_send = datetime.now()
         message_record = can_transport_interface.send_message(message)
         datetime_after_send = datetime.now()
@@ -728,8 +737,10 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         :param example_can_addressing_information: Example Addressing Information of a CAN Node.
         :param message: UDS message to send.
         """
-        can_transport_interface = PyCanTransportInterface(network_manager=self.can_interface_1,
-                                                          addressing_information=example_can_addressing_information)
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
+            addressing_information=example_can_addressing_information)
         datetime_before_send = datetime.now()
         message_record = await can_transport_interface.async_send_message(message)
         datetime_after_send = datetime.now()
@@ -774,10 +785,13 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         :param timeout: Timeout to pass to receive method [ms].
         :param send_after: Time when to send CAN frame after call of receive method [ms].
         """
-        can_transport_interface = PyCanTransportInterface(network_manager=self.can_interface_1,
-                                                          addressing_information=example_can_addressing_information)
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
+            addressing_information=example_can_addressing_information)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         self.send_message(can_transport_interface=can_transport_interface_2nd_node,
                           message=message,
@@ -825,10 +839,13 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         :param timeout: Timeout value to pass to receive message method [ms].
         :param send_after: Time when to send CAN frame after call of receive method [ms].
         """
-        can_transport_interface = PyCanTransportInterface(network_manager=self.can_interface_1,
-                                                          addressing_information=example_can_addressing_information)
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
+            addressing_information=example_can_addressing_information)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         send_message_task = asyncio.create_task(
             self.async_send_message(can_transport_interface=can_transport_interface_2nd_node,
@@ -876,10 +893,13 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         :param timeout: Timeout to pass to receive method [ms].
         :param send_after: Time when to send CAN frame after call of receive method [ms].
         """
-        can_transport_interface = PyCanTransportInterface(network_manager=self.can_interface_1,
-                                                          addressing_information=example_can_addressing_information)
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
+            addressing_information=example_can_addressing_information)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         self.send_message(can_transport_interface=can_transport_interface_2nd_node,
                           message=message,
@@ -924,10 +944,13 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         :param timeout: Timeout value to pass to receive message method [ms].
         :param send_after: Time when to send CAN frame after call of receive method [ms].
         """
-        can_transport_interface = PyCanTransportInterface(network_manager=self.can_interface_1,
-                                                          addressing_information=example_can_addressing_information)
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
+            addressing_information=example_can_addressing_information)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         send_message_task = asyncio.create_task(self.async_send_message(
             can_transport_interface=can_transport_interface_2nd_node,
@@ -974,10 +997,12 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information,
             n_bs_timeout=timeout)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
             flow_status=CanFlowStatus.ContinueToSend,
@@ -1041,10 +1066,12 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information,
             n_bs_timeout=timeout)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
             flow_status=CanFlowStatus.ContinueToSend,
@@ -1106,10 +1133,12 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information,
             n_bs_timeout=timeout)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
             flow_status=CanFlowStatus.ContinueToSend,
@@ -1154,10 +1183,12 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information,
             n_bs_timeout=timeout)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
             flow_status=CanFlowStatus.ContinueToSend,
@@ -1206,11 +1237,14 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         :param send_after: Time when to send First Frame after call of receive method [ms].
         :param delay: Time distance to use for sending Consecutive Frames [ms].
         """
-        can_transport_interface = PyCanTransportInterface(network_manager=self.can_interface_1,
-                                                          addressing_information=example_can_addressing_information,
-                                                          n_br=0)
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
         for i, packet in enumerate(packets):
@@ -1261,10 +1295,13 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         :param send_after: Time when to send First Frame after call of receive method [ms].
         :param delay: Time distance to use for sending Consecutive Frames [ms].
         """
-        can_transport_interface = PyCanTransportInterface(network_manager=self.can_interface_1,
-                                                          addressing_information=example_can_addressing_information)
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
+            addressing_information=example_can_addressing_information)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
 
@@ -1317,11 +1354,14 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         :param send_after: Time when to send First Frame after call of receive method [ms].
         :param delay: Time distance to use for sending Consecutive Frames [ms].
         """
-        can_transport_interface = PyCanTransportInterface(network_manager=self.can_interface_1,
-                                                          addressing_information=example_can_addressing_information,
-                                                          n_br=0)
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
         self.send_packet(can_transport_interface=can_transport_interface_2nd_node,
@@ -1370,10 +1410,13 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         :param send_after: Time when to send First Frame after call of receive method [ms].
         :param delay: Time distance to use for sending Consecutive Frames [ms].
         """
-        can_transport_interface = PyCanTransportInterface(network_manager=self.can_interface_1,
-                                                          addressing_information=example_can_addressing_information)
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
+            addressing_information=example_can_addressing_information)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
 
@@ -1445,9 +1488,11 @@ class AbstractUseCaseTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface_1 = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         can_transport_interface_2 = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information.get_other_end())
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.tx_physical_params
@@ -1524,9 +1569,11 @@ class AbstractUseCaseTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface_1 = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         can_transport_interface_2 = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information.get_other_end())
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.tx_physical_params
@@ -1600,11 +1647,13 @@ class AbstractUseCaseTests(AbstractPythonCanTests, ABC):
                                                                                   repeat_wait=repeat_wait)
         can_transport_interface_1 = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information,
             n_br=n_br,
             flow_control_parameters_generator=flow_control_parameters_generator)
         can_transport_interface_2 = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end(),
             n_cs=n_cs)
 
@@ -1665,11 +1714,13 @@ class AbstractUseCaseTests(AbstractPythonCanTests, ABC):
                                                                                   repeat_wait=repeat_wait)
         can_transport_interface_1 = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information,
             n_br=n_br,
             flow_control_parameters_generator=flow_control_parameters_generator)
         can_transport_interface_2 = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end(),
             n_cs=n_cs)
 
@@ -1734,6 +1785,7 @@ class AbstractErrorGuessingTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.tx_physical_params
@@ -1802,6 +1854,7 @@ class AbstractErrorGuessingTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.rx_physical_params
@@ -1870,6 +1923,7 @@ class AbstractErrorGuessingTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.rx_physical_params
@@ -1948,6 +2002,7 @@ class AbstractErrorGuessingTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.rx_physical_params
@@ -2023,6 +2078,7 @@ class AbstractErrorGuessingTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.tx_physical_params
@@ -2099,6 +2155,7 @@ class AbstractErrorGuessingTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=parametrized_can_addressing_information)
         if addressing_type == AddressingType.PHYSICAL:
             addressing_params = parametrized_can_addressing_information.tx_physical_params
@@ -2155,10 +2212,12 @@ class AbstractErrorGuessingTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information,
             n_bs_timeout=timeout)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
             flow_status=CanFlowStatus.Overflow)
@@ -2194,10 +2253,12 @@ class AbstractErrorGuessingTests(AbstractPythonCanTests, ABC):
         """
         can_transport_interface = PyCanTransportInterface(
             network_manager=self.can_interface_1,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information,
             n_bs_timeout=timeout)
         can_transport_interface_2nd_node = PyCanTransportInterface(
             network_manager=self.can_interface_2,
+            network_manager_receives_own_frames=self.RECEIVE_OWN_FRAMES,
             addressing_information=example_can_addressing_information.get_other_end())
         flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
             flow_status=CanFlowStatus.Overflow)

--- a/tests/system_tests/can/python_can/test_python_can_kvaser.py
+++ b/tests/system_tests/can/python_can/test_python_can_kvaser.py
@@ -9,8 +9,17 @@ from .python_can import (
 )
 
 
-class KvaserConfig(AbstractPythonCanTests):
-    """Configuration for Python CAN Transport Interface tests with Kvaser CAN interfaces."""
+# Receive Own Frames
+
+
+class KvaserConfig_ReceiveOwnFrames(AbstractPythonCanTests):
+    """
+    Configuration for Python CAN Transport Interface tests with Kvaser CAN interfaces.
+
+    Interfaces receive own CAN Frames.
+    """
+
+    RECEIVE_OWN_FRAMES = True
 
     def _define_interfaces(self):
         """Configure CAN bus objects that manage CAN interfaces."""
@@ -23,26 +32,65 @@ class KvaserConfig(AbstractPythonCanTests):
                                    fd=True,
                                    receive_own_messages=True)
 
-class TestKvaserCanPacket(AbstractCanPacketTests, KvaserConfig):
+class TestKvaserCanPacket_ReceiveOwnFrames(AbstractCanPacketTests, KvaserConfig_ReceiveOwnFrames):
     """CAN packets related system tests for Python CAN Transport Interface."""
 
     # TODO: https://github.com/mdabrowski1990/uds/issues/228 - set MAKE_TIMING_CHECKS to true when resolved
     MAKE_TIMING_CHECKS: bool = False
 
 
-class TestKvaserMessage(AbstractMessageTests, KvaserConfig):
+class TestKvaserMessage_ReceiveOwnFrames(AbstractMessageTests, KvaserConfig_ReceiveOwnFrames):
     """UDS message related system tests for Python CAN Transport Interface."""
 
     # TODO: https://github.com/mdabrowski1990/uds/issues/228 - set MAKE_TIMING_CHECKS to true when resolved
     MAKE_TIMING_CHECKS: bool = False
 
 
-class TestKvaserUseCase(AbstractUseCaseTests, KvaserConfig):
+class TestKvaserUseCase_ReceiveOwnFrames(AbstractUseCaseTests, KvaserConfig_ReceiveOwnFrames):
     """Use case based system tests for Python CAN Transport Interface."""
 
 
-class TestKvaserErrorGuessing(AbstractErrorGuessingTests, KvaserConfig):
+class TestKvaserErrorGuessing_ReceiveOwnFrames(AbstractErrorGuessingTests, KvaserConfig_ReceiveOwnFrames):
     """Error guessing system tests for Python CAN Transport Interface."""
 
     # TODO: https://github.com/mdabrowski1990/uds/issues/228 - set MAKE_TIMING_CHECKS to true when resolved
     MAKE_TIMING_CHECKS: bool = False
+
+
+# Do Not Receive Own Frames
+
+
+class KvaserConfig_DoNotReceiveOwnFrames(AbstractPythonCanTests):
+    """
+    Configuration for Python CAN Transport Interface tests with Kvaser CAN interfaces.
+
+    Interfaces do not receive own CAN Frames.
+    """
+
+    RECEIVE_OWN_FRAMES = False
+
+    def _define_interfaces(self):
+        """Configure CAN bus objects that manage CAN interfaces."""
+        self.can_interface_1 = Bus(interface="kvaser",
+                                   channel=0,
+                                   fd=True,
+                                   receive_own_messages=False)
+        self.can_interface_2 = Bus(interface="kvaser",
+                                   channel=1,
+                                   fd=True,
+                                   receive_own_messages=False)
+
+class TestKvaserCanPacket_DoNotReceiveOwnFrames(AbstractCanPacketTests, KvaserConfig_DoNotReceiveOwnFrames):
+    """CAN packets related system tests for Python CAN Transport Interface."""
+
+
+class TestKvaserMessage_DoNotReceiveOwnFrames(AbstractMessageTests, KvaserConfig_DoNotReceiveOwnFrames):
+    """UDS message related system tests for Python CAN Transport Interface."""
+
+
+class TestKvaserUseCase_DoNotReceiveOwnFrames(AbstractUseCaseTests, KvaserConfig_DoNotReceiveOwnFrames):
+    """Use case based system tests for Python CAN Transport Interface."""
+
+
+class TestKvaserErrorGuessing_DoNotReceiveOwnFrames(AbstractErrorGuessingTests, KvaserConfig_DoNotReceiveOwnFrames):
+    """Error guessing system tests for Python CAN Transport Interface."""

--- a/uds/can/transport_interface/python_can.py
+++ b/uds/can/transport_interface/python_can.py
@@ -36,15 +36,20 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
     def __init__(self,
                  network_manager: BusABC,
                  addressing_information: AbstractCanAddressingInformation,
+                 network_manager_receives_own_frames: bool = True,
                  **configuration_params: Any) -> None:
         """
         Create Transport Interface that uses python-can package to control CAN bus.
 
         :param network_manager: Python-can bus object for handling CAN network.
-
-            .. warning:: Bus must have capability of observing transmitted frames.
-
         :param addressing_information: Addressing Information of UDS entity simulated by this CAN Transport Interface.
+        :param network_manager_receives_own_frames: Whether provided network manager receives own frames.
+
+            .. warning:: It is recommended to have this flag set and switch it to False only when network manager does
+                not receive own frames.
+                When this flag is False, CAN Frames transmission time is altered which affects accuracy of all
+                measured timing parameters.
+
         :param configuration_params: Additional configuration parameters.
 
             - :parameter n_as_timeout: Timeout value for :ref:`N_As <knowledge-base-can-n-as>` time parameter.
@@ -62,6 +67,7 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         """
         super().__init__(network_manager=network_manager,
                          addressing_information=addressing_information,
+                         network_manager_receives_own_frames=network_manager_receives_own_frames,
                          **configuration_params)
         self.__frames_buffer = BufferedReader()
         self.__async_frames_buffer = AsyncBufferedReader()

--- a/uds/transport_interface/abstract_transport_interface.py
+++ b/uds/transport_interface/abstract_transport_interface.py
@@ -21,13 +21,16 @@ class AbstractTransportInterface(ABC):
     """
 
     def __init__(self,
-                 network_manager: Any) -> None:
+                 network_manager: Any,
+                 network_manager_receives_own_frames: bool) -> None:
         """
         Create Transport Interface (an object for handling UDS Transport and Network layers).
 
         :param network_manager: An object that handles the network (Physical and Data layers of OSI Model).
+        :param network_manager_receives_own_frames: Whether provided network manager receives own frames.
         """
         self.network_manager = network_manager
+        self.network_manager_receives_own_frames = network_manager_receives_own_frames
 
     @property
     @abstractmethod
@@ -77,6 +80,20 @@ class AbstractTransportInterface(ABC):
         if hasattr(self, "_AbstractTransportInterface__network_manager"):
             raise ReassignmentError("Value of 'network_manager' attribute cannot be changed once assigned.")
         self.__network_manager = value
+
+    @property
+    def network_manager_receives_own_frames(self) -> bool:
+        """Get flag that informs whether configured network manager receives own frames."""
+        return self.__network_manager_receives_own_frames
+
+    @network_manager_receives_own_frames.setter
+    def network_manager_receives_own_frames(self, value: bool) -> None:
+        """
+        Set flag whether configured network manager receives own frames.
+
+        :param value: Value to set.
+        """
+        self.__network_manager_receives_own_frames = bool(value)
 
     @staticmethod
     @abstractmethod


### PR DESCRIPTION
# Description
- add an option to all Transport Interfaces that Network Manager does not receive own frames
- add handling to python-can Transport Interface when own frames are not received


# How Has This Been Tested?
<!--- Please shortly describe how you tested your code. -->
- add System Tests


# Process
<!--- If you are familiar with the process, leave the line below. If not, please describe what you did, so we could help you deliver your changed according to our quality policies -->
I know the [process](https://github.com/mdabrowski1990/uds/wiki/Software-Development-Life-Cycle) and did my best to follow it
