### PR TITLE
Fix for P6Client and P6*Client timeouts

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,10 +38,9 @@ jobs:
         run: |
           pytest tests/software_tests --cov-report=term-missing --cov=uds -m "integration"
 
-# TODO: uncomment when performance tests are added
-#      - name: Execute performance tests with coverage report [pytest]
-#        run: |
-#          pytest tests/software_tests --cov-report=term-missing --cov=uds -m "performance"
+      - name: Execute performance tests with coverage report [pytest]
+        run: |
+          pytest tests/software_tests --cov-report=term-missing --cov=uds -m "performance"
 
 
   code_coverage:
@@ -113,7 +112,17 @@ jobs:
           files: coverage.xml
           flags: integration-tests-branch
 
-# TODO: add performance tests upload when added
+      - name: Execute performance tests with instruction coverage [pytest]
+        run: |
+          pytest tests/software_tests --cov-report=xml --cov=uds -m "performance"
+
+      - name: Upload performance tests report with instruction coverage [CodeCov]
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          flags: performance-tests
 
 
   static_code_analysis:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,37 +39,6 @@ jobs:
           pytest tests/software_tests --cov-report=term-missing --cov=uds -m "integration"
 
 
-  performance_tests:  # separated from the other dynamic tests due to long execution
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install project dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools
-          pip install -r requirements.txt
-
-      - name: Install external packages used for dynamic tests
-        run: |
-          pip install .[test]
-
-      - name: Execute performance tests with coverage report [pytest]
-        run: |
-          pytest tests/software_tests --cov-report=term-missing --cov=uds -m "performance"
-
-
   code_coverage:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,6 +39,37 @@ jobs:
           pytest tests/software_tests --cov-report=term-missing --cov=uds -m "integration"
 
 
+  performance_tests:  # separated from the other dynamic tests due to long execution
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install project dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          pip install -r requirements.txt
+
+      - name: Install external packages used for dynamic tests
+        run: |
+          pip install .[test]
+
+      - name: Execute performance tests with coverage report [pytest]
+        run: |
+          pytest tests/software_tests --cov-report=term-missing --cov=uds -m "performance"
+
+
   code_coverage:
     runs-on: ubuntu-latest
 
@@ -162,6 +193,7 @@ jobs:
         run: |
           pip-audit
 
+
   sorting_imports:
     runs-on: ubuntu-latest
 
@@ -188,6 +220,7 @@ jobs:
           isort uds -c -v
           isort tests -c -v
           isort examples -c -v
+
 
   documentation_checks:
     runs-on: windows-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,10 +38,6 @@ jobs:
         run: |
           pytest tests/software_tests --cov-report=term-missing --cov=uds -m "integration"
 
-      - name: Execute performance tests with coverage report [pytest]
-        run: |
-          pytest tests/software_tests --cov-report=term-missing --cov=uds -m "performance"
-
 
   code_coverage:
     runs-on: ubuntu-latest
@@ -111,18 +107,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: integration-tests-branch
-
-      - name: Execute performance tests with instruction coverage [pytest]
-        run: |
-          pytest tests/software_tests --cov-report=xml --cov=uds -m "performance"
-
-      - name: Upload performance tests report with instruction coverage [CodeCov]
-        uses: codecov/codecov-action@v5
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
-          flags: performance-tests
 
 
   static_code_analysis:

--- a/examples/can/python-can/kvaser/receive_message.py
+++ b/examples/can/python-can/kvaser/receive_message.py
@@ -30,7 +30,7 @@ def main():
                                      addressing_information=addressing_information)
 
     # receive UDS message
-    received_message_record = can_ti.receive_message(timeout=1000)  # timeout=1000 [ms]
+    received_message_record = can_ti.receive_message(start_timeout=1000)  # timeout=1000 [ms]
 
     # show received message
     print(received_message_record)

--- a/examples/can/python-can/kvaser/receive_message_asyncio.py
+++ b/examples/can/python-can/kvaser/receive_message_asyncio.py
@@ -32,7 +32,7 @@ async def main():
                                      addressing_information=addressing_information)
 
     # receive UDS message
-    received_message_record = await can_ti.async_receive_message(timeout=1000)  # timeout=1000 [ms]
+    received_message_record = await can_ti.async_receive_message(start_timeout=1000)  # timeout=1000 [ms]
 
     # show received message
     print(received_message_record)

--- a/examples/can/python-can/kvaser/send_and_receive_message.py
+++ b/examples/can/python-can/kvaser/send_and_receive_message.py
@@ -60,7 +60,7 @@ def main():
 
     # send and receive message
     timer.start()
-    received_message_record = can_ti_2.receive_message(timeout=1000)  # timeout=1000 [ms]
+    received_message_record = can_ti_2.receive_message(start_timeout=1000)  # timeout=1000 [ms]
 
     # wait till message is received
     while not timer.finished.is_set():

--- a/examples/can/python-can/kvaser/send_and_receive_message_asyncio.py
+++ b/examples/can/python-can/kvaser/send_and_receive_message_asyncio.py
@@ -50,7 +50,7 @@ async def main():
     message = UdsMessage(addressing_type=AddressingType.PHYSICAL, payload=[0x62, 0x10, 0x00, *range(100)])
 
     # send and receive message
-    receive_message_task = asyncio.create_task(can_ti_2.async_receive_message(timeout=1000))  # timeout=1000 ms
+    receive_message_task = asyncio.create_task(can_ti_2.async_receive_message(start_timeout=1000))  # timeout=1000 ms
     sent_message_record = await can_ti_1.async_send_message(message)
     received_message_record = await receive_message_task
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,15 +19,13 @@ from uds.utilities import RawBytesAlias
 
 @fixture
 def performance_tolerance_ms():
-    """Acceptable timing tolerance for performance tests."""
-    return 5
-
+    """Acceptable time tolerance for a single measurement (performance tests)."""
+    return 50
 
 @fixture
-def asyncio_tolerance_ms():
-    """Acceptable timing tolerance for asyncio tests using `wait` or `wait_for` functions."""
-    return 20
-
+def mean_performance_tolerance_ms(performance_tolerance_ms):
+    """Acceptable mean time tolerance for multiple measurement (performance tests)."""
+    return performance_tolerance_ms / 4.
 
 # Common
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,16 @@ from uds.utilities import RawBytesAlias
 # Performance tests related
 
 @fixture
-def task_tolerance_ms():
-    return 2
+def performance_tolerance_ms():
+    """Acceptable timing tolerance for performance tests."""
+    return 5
+
+
+@fixture
+def asyncio_tolerance_ms():
+    """Acceptable timing tolerance for asyncio tests using `wait` or `wait_for` functions."""
+    return 20
+
 
 # Common
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,12 @@ from uds.can.addressing import (
 )
 from uds.utilities import RawBytesAlias
 
+# Performance tests related
+
+@fixture
+def task_tolerance_ms():
+    return 2
+
 # Common
 
 @fixture(params=[

--- a/tests/prospector_profile.yaml
+++ b/tests/prospector_profile.yaml
@@ -23,6 +23,7 @@ pylint:
     max-public-methods: 30
     max-parents: 15
     max-branches: 12
+    max-locals: 20
 
   disable:
     - django-not-available

--- a/tests/software_tests/can/transport_interface/test_python_can.py
+++ b/tests/software_tests/can/transport_interface/test_python_can.py
@@ -1,6 +1,6 @@
-from asyncio.exceptions import TimeoutError as AsyncioTimeoutError
 from asyncio import get_running_loop
 from asyncio import sleep as asyncio_sleep
+from asyncio.exceptions import TimeoutError as AsyncioTimeoutError
 from datetime import datetime
 from random import randint
 from time import perf_counter, sleep

--- a/tests/software_tests/can/transport_interface/test_python_can.py
+++ b/tests/software_tests/can/transport_interface/test_python_can.py
@@ -1,4 +1,4 @@
-from asyncio import TimeoutError as AsyncioTimeoutError
+from asyncio.exceptions import TimeoutError as AsyncioTimeoutError
 from asyncio import get_running_loop
 from asyncio import sleep as asyncio_sleep
 from datetime import datetime

--- a/tests/software_tests/can/transport_interface/test_python_can.py
+++ b/tests/software_tests/can/transport_interface/test_python_can.py
@@ -1629,7 +1629,7 @@ class TestPyCanTransportInterface:
                                                 __le__=mock_is_timeout_reached)
         self.mock_can_packet_type_is_initial_packet_type.return_value = True
         assert (await PyCanTransportInterface.async_receive_message(self.mock_can_transport_interface,
-                                                                    timeout=timeout,
+                                                                    start_timeout=timeout,
                                                                     loop=mock_loop)
                 == self.mock_can_transport_interface._async_message_receive_start.return_value)
         self.mock_can_transport_interface._PyCanTransportInterface__setup_async_notifier.assert_called_once_with(

--- a/tests/software_tests/can/transport_interface/test_python_can.py
+++ b/tests/software_tests/can/transport_interface/test_python_can.py
@@ -1,5 +1,6 @@
 from random import choice, randint
-from time import time
+from time import sleep, perf_counter
+from asyncio import sleep as asyncio_sleep
 
 import pytest
 from mock import AsyncMock, MagicMock, Mock, call, patch
@@ -18,6 +19,8 @@ from uds.can.transport_interface.python_can import (
     PyCanTransportInterface,
     TransmissionDirection,
     UdsMessage,
+AsyncBufferedReader,
+MessageTransmissionNotStartedError
 )
 
 SCRIPT_LOCATION = "uds.can.transport_interface.python_can"
@@ -1667,48 +1670,228 @@ class TestPyCanTransportInterface:
 @pytest.mark.performance
 class TestPyCanTransportInterfacePerformance:
 
+    REPETITIONS = 20
+
     def setup_method(self):
         self.mock_can_transport_interface = MagicMock(spec=PyCanTransportInterface,
                                                       _PyCanTransportInterface__rx_frames_buffer=Mock(),
                                                       _PyCanTransportInterface__tx_frames_buffer=Mock(),
                                                       _PyCanTransportInterface__async_rx_frames_buffer=Mock(),
                                                       _PyCanTransportInterface__async_tx_frames_buffer=Mock())
+        self._patcher_warn = patch(f"{SCRIPT_LOCATION}.warn")
+        self.mock_warn = self._patcher_warn.start()
+        self._patcher_get_running_loop = patch(f"{SCRIPT_LOCATION}.get_running_loop")
+        self.mock_get_running_loop = self._patcher_get_running_loop.start()
 
+    def teardown_method(self):
+        self._patcher_warn.stop()
+        self._patcher_get_running_loop.stop()
+
+    # _wait_for_packet
+
+    # TODO
+
+    # _async_wait_for_packet
+
+    @pytest.mark.parametrize("rep", range(REPETITIONS))
+    @pytest.mark.parametrize("timeout", [10, 75])
+    @pytest.mark.asyncio
+    async def test_async_wait_for_packet__timeout(self, asyncio_tolerance_ms, rep,
+                                                  timeout):
+        async def _get_message():
+            await asyncio_sleep(2*timeout)
+            return Mock()
+        mock_buffer = Mock(spec=AsyncBufferedReader,
+                           get_message=_get_message)
+        self.mock_can_transport_interface.addressing_information.is_input_packet.return_value = Mock()
+        timestamp_before = perf_counter()
+        with pytest.raises(TimeoutError):
+            await PyCanTransportInterface._async_wait_for_packet(self.mock_can_transport_interface,
+                                                                 buffer=mock_buffer,
+                                                                 timeout=timeout)
+        timestamp_after = perf_counter()
+        execution_time_ms = (timestamp_after - timestamp_before) * 1000.
+        assert timeout <= execution_time_ms
+
+
+    # _receive_cf_packets_block
+
+    @pytest.mark.parametrize("rep", range(REPETITIONS))
+    @pytest.mark.parametrize("n_cr_timeout", [10, 75])
+    @patch(f"{SCRIPT_LOCATION}.CanPacketType.is_initial_packet_type")
+    def test_receive_cf_packets_block__n_cr_timeout(self, mock_is_initial_packet_type,
+                                                    performance_tolerance_ms, rep,
+                                                    n_cr_timeout):
+        def _get_packet_record(*args, **kwargs):
+            sleep((performance_tolerance_ms / 1000.) / 4.)
+            return Mock(spec=CanPacketRecord,
+                        packet_type=Mock())
+
+        mock_is_initial_packet_type.return_value = False
+        self.mock_can_transport_interface.receive_packet.side_effect = _get_packet_record
+        self.mock_can_transport_interface.n_cr_timeout = n_cr_timeout
+        timestamp_before = perf_counter()
+        with pytest.raises(TimeoutError):
+            PyCanTransportInterface._receive_cf_packets_block(self.mock_can_transport_interface,
+                                                              sequence_number=Mock(),
+                                                              block_size=float("inf"),
+                                                              remaining_data_length=float("inf"),
+                                                              timestamp_end=None)
+        timestamp_after = perf_counter()
+        execution_time_ms = (timestamp_after - timestamp_before) * 1000.
+        assert (n_cr_timeout
+                <= execution_time_ms
+                <= n_cr_timeout + performance_tolerance_ms)
+
+    @pytest.mark.parametrize("rep", range(REPETITIONS))
+    @pytest.mark.parametrize("timeout_end", [10, 75])
+    @patch(f"{SCRIPT_LOCATION}.CanPacketType.is_initial_packet_type")
+    def test_receive_cf_packets_block__end_timeout(self, mock_is_initial_packet_type,
+                                                         performance_tolerance_ms, rep,
+                                                         timeout_end):
+        current_sn = 0
+
+        def _get_packet_record(*args, **kwargs):
+            nonlocal current_sn
+            current_sn = (current_sn + 1) & 0xF
+            sleep((performance_tolerance_ms / 1000.) / 4.)
+            return Mock(spec=CanPacketRecord,
+                        packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                        sequence_number=current_sn,
+                        payload=[0x12])
+
+        mock_is_initial_packet_type.return_value = False
+        self.mock_can_transport_interface.receive_packet.side_effect = _get_packet_record
+        self.mock_can_transport_interface.n_cr_timeout = 1000
+        sequence_number = 1
+        timestamp_end = perf_counter() + timeout_end / 1000.
+        with pytest.raises(TimeoutError):
+            PyCanTransportInterface._receive_cf_packets_block(self.mock_can_transport_interface,
+                                                              sequence_number=sequence_number,
+                                                              block_size=float("inf"),
+                                                              remaining_data_length=float("inf"),
+                                                              timestamp_end=timestamp_end)
+        timestamp_after = perf_counter()
+        assert (timestamp_end
+                <= timestamp_after
+                <= timestamp_end + performance_tolerance_ms / 1000.)
+
+    # _async_receive_cf_packets_block
+
+    @pytest.mark.parametrize("rep", range(REPETITIONS))
+    @pytest.mark.parametrize("n_cr_timeout", [10, 75])
+    @patch(f"{SCRIPT_LOCATION}.CanPacketType.is_initial_packet_type")
+    @pytest.mark.asyncio
+    async def test_async_receive_cf_packets_block__n_cr_timeout(self, mock_is_initial_packet_type,
+                                                                performance_tolerance_ms, rep,
+                                                                n_cr_timeout):
+        def _get_packet_record(*args, **kwargs):
+            sleep((performance_tolerance_ms / 1000.) / 4.)
+            return Mock(spec=CanPacketRecord,
+                        packet_type=Mock())
+
+        mock_is_initial_packet_type.return_value = False
+        self.mock_can_transport_interface.async_receive_packet.side_effect = _get_packet_record
+        self.mock_can_transport_interface.n_cr_timeout = n_cr_timeout
+        mock_loop = Mock()
+        timestamp_before = perf_counter()
+        with pytest.raises(TimeoutError):
+            await PyCanTransportInterface._async_receive_cf_packets_block(self.mock_can_transport_interface,
+                                                                          sequence_number=Mock(),
+                                                                          block_size=float("inf"),
+                                                                          remaining_data_length=float("inf"),
+                                                                          timestamp_end=None,
+                                                                          loop=mock_loop)
+        timestamp_after = perf_counter()
+        execution_time_ms = (timestamp_after - timestamp_before) * 1000.
+        assert (n_cr_timeout
+                <= execution_time_ms
+                <= n_cr_timeout + performance_tolerance_ms)
+
+    @pytest.mark.parametrize("rep", range(REPETITIONS))
+    @pytest.mark.parametrize("timeout_end", [10, 75])
+    @patch(f"{SCRIPT_LOCATION}.CanPacketType.is_initial_packet_type")
+    @pytest.mark.asyncio
+    async def test_async_receive_cf_packets_block__end_timeout(self, mock_is_initial_packet_type,
+                                                               performance_tolerance_ms, rep,
+                                                               timeout_end):
+        current_sn = 0
+
+        def _get_packet_record(*args, **kwargs):
+            nonlocal current_sn
+            current_sn = (current_sn + 1) & 0xF
+            sleep((performance_tolerance_ms / 1000.) / 4.)
+            return Mock(spec=CanPacketRecord,
+                        packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                        sequence_number=current_sn,
+                        payload=[0x12])
+
+        mock_is_initial_packet_type.return_value = False
+        self.mock_can_transport_interface.async_receive_packet.side_effect = _get_packet_record
+        self.mock_can_transport_interface.n_cr_timeout = 1000
+        sequence_number = 1
+        mock_loop = Mock()
+        timestamp_end = perf_counter() + timeout_end / 1000.
+        with pytest.raises(TimeoutError):
+            await PyCanTransportInterface._async_receive_cf_packets_block(self.mock_can_transport_interface,
+                                                                          sequence_number=sequence_number,
+                                                                          block_size=float("inf"),
+                                                                          remaining_data_length=float("inf"),
+                                                                          timestamp_end=timestamp_end,
+                                                                          loop=mock_loop)
+        timestamp_after = perf_counter()
+        assert (timestamp_end
+                <= timestamp_after
+                <= timestamp_end + performance_tolerance_ms / 1000.)
 
     # receive_message
 
-    @pytest.mark.parametrize("start_timeout", [50, 100])
+    @pytest.mark.parametrize("rep", range(REPETITIONS))
+    @pytest.mark.parametrize("start_timeout", [10, 75])
     @patch(f"{SCRIPT_LOCATION}.CanPacketType.is_initial_packet_type")
-    def test_receive_message__start_timeout(self, mock_is_initial_packet_type, task_tolerance_ms, start_timeout):
+    def test_receive_message__start_timeout(self, mock_is_initial_packet_type,
+                                            performance_tolerance_ms, rep,
+                                            start_timeout):
+        def _get_packet_record(*args, **kwargs):
+            sleep((performance_tolerance_ms / 1000.) / 4.)
+            return Mock(spec=CanPacketRecord)
+
         mock_is_initial_packet_type.return_value = False
-        self.mock_can_transport_interface.receive_packet.return_value = Mock()
-        timestamp_before = time()
+        self.mock_can_transport_interface.receive_packet.side_effect = _get_packet_record
+        timestamp_before = perf_counter()
         with pytest.raises(TimeoutError):
             PyCanTransportInterface.receive_message(self.mock_can_transport_interface,
                                                     start_timeout=start_timeout)
-        timestamp_after = time()
+        timestamp_after = perf_counter()
         execution_time_ms = (timestamp_after - timestamp_before) * 1000.
         assert (start_timeout
                 <= execution_time_ms
-                <= start_timeout + task_tolerance_ms)
+                <= start_timeout + performance_tolerance_ms)
 
     # async_receive_message
 
-    @pytest.mark.parametrize("start_timeout", [50, 100])
+    @pytest.mark.parametrize("rep", range(REPETITIONS))
+    @pytest.mark.parametrize("start_timeout", [10, 75])
     @patch(f"{SCRIPT_LOCATION}.CanPacketType.is_initial_packet_type")
     @pytest.mark.asyncio
-    async def test_async_receive_message__start_timeout(self, mock_is_initial_packet_type, task_tolerance_ms, start_timeout):
+    async def test_async_receive_message__start_timeout(self, mock_is_initial_packet_type,
+                                                        performance_tolerance_ms, rep,
+                                                        start_timeout):
+        def _get_packet_record(*args, **kwargs):
+            sleep((performance_tolerance_ms / 1000.) / 4.)
+            return Mock(spec=CanPacketRecord)
+
         mock_is_initial_packet_type.return_value = False
-        self.mock_can_transport_interface.async_receive_packet.return_value = Mock()
-        timestamp_before = time()
-        with pytest.raises(TimeoutError):
+        self.mock_can_transport_interface.async_receive_packet.side_effect = _get_packet_record
+        timestamp_before = perf_counter()
+        with pytest.raises(MessageTransmissionNotStartedError):
             await PyCanTransportInterface.async_receive_message(self.mock_can_transport_interface,
                                                                 start_timeout=start_timeout)
-        timestamp_after = time()
+        timestamp_after = perf_counter()
         execution_time_ms = (timestamp_after - timestamp_before) * 1000.
         assert (start_timeout
                 <= execution_time_ms
-                <= start_timeout + task_tolerance_ms)
+                <= start_timeout + performance_tolerance_ms)
 
 
 

--- a/tests/software_tests/can/transport_interface/test_python_can.py
+++ b/tests/software_tests/can/transport_interface/test_python_can.py
@@ -1,6 +1,6 @@
-from random import choice, randint, random
-from time import sleep, perf_counter
 from asyncio import sleep as asyncio_sleep
+from random import choice, randint
+from time import perf_counter, sleep
 
 import pytest
 from mock import AsyncMock, MagicMock, Mock, call, patch
@@ -11,16 +11,17 @@ from uds.can import DEFAULT_FILLER_BYTE, CanAddressingInformation, DefaultFlowCo
 from uds.can.transport_interface.python_can import (
     AbstractCanTransportInterface,
     AbstractEventLoop,
+    AsyncBufferedReader,
+    BufferedReader,
     BusABC,
     CanFlowStatus,
     CanPacket,
     CanPacketRecord,
     CanPacketType,
+    MessageTransmissionNotStartedError,
     PyCanTransportInterface,
     TransmissionDirection,
     UdsMessage,
-AsyncBufferedReader,
-MessageTransmissionNotStartedError
 )
 
 SCRIPT_LOCATION = "uds.can.transport_interface.python_can"
@@ -1703,7 +1704,7 @@ class TestPyCanTransportInterfacePerformance:
             sleep(0.005)
             return Mock()
 
-        mock_buffer = Mock(spec=AsyncBufferedReader,
+        mock_buffer = Mock(spec=BufferedReader,
                            get_message=_get_message)
         self.mock_can_transport_interface.addressing_information.is_input_packet.return_value = None
 

--- a/tests/software_tests/can/transport_interface/test_python_can.py
+++ b/tests/software_tests/can/transport_interface/test_python_can.py
@@ -1693,22 +1693,6 @@ class TestPyCanTransportInterfacePerformance:
         self._patcher_datetime.stop()
         self._pather_can_packet_record.stop()
 
-    # _send_cf_packets_block
-
-    # TODO
-
-    # _async_send_cf_packets_block
-
-    # TODO
-
-    # _wait_for_flow_control
-
-    # TODO
-
-    # _async_wait_for_flow_control
-
-    # TODO
-
     # _wait_for_packet
 
     @pytest.mark.parametrize("timeout", [10, 75])

--- a/tests/software_tests/can/transport_interface/test_python_can.py
+++ b/tests/software_tests/can/transport_interface/test_python_can.py
@@ -2238,11 +2238,11 @@ class TestPyCanTransportInterfacePerformance:
         execution_times = []
         for _ in range(self.REPETITIONS):
             timestamp_before = perf_counter()
-            timestamp_end = timestamp_before + end_timeout / 1000.
             with pytest.raises(TimeoutError):
-                PyCanTransportInterface._receive_consecutive_frames(self.mock_can_transport_interface,
-                                                                    first_frame=mock_first_frame,
-                                                                    timestamp_end=timestamp_end)
+                PyCanTransportInterface._receive_consecutive_frames(
+                    self.mock_can_transport_interface,
+                    first_frame=mock_first_frame,
+                    timestamp_end=timestamp_before + end_timeout / 1000.)
             timestamp_after = perf_counter()
             execution_time_ms = (timestamp_after - timestamp_before) * 1000.
             execution_times.append(execution_time_ms)
@@ -2288,12 +2288,12 @@ class TestPyCanTransportInterfacePerformance:
         execution_times = []
         for _ in range(self.REPETITIONS):
             timestamp_before = perf_counter()
-            timestamp_end = timestamp_before + end_timeout / 1000.
             with pytest.raises(TimeoutError):
-                await PyCanTransportInterface._async_receive_consecutive_frames(self.mock_can_transport_interface,
-                                                                                first_frame=mock_first_frame,
-                                                                                timestamp_end=timestamp_end,
-                                                                                loop=get_running_loop())
+                await PyCanTransportInterface._async_receive_consecutive_frames(
+                    self.mock_can_transport_interface,
+                    first_frame=mock_first_frame,
+                    timestamp_end=timestamp_before + end_timeout / 1000.,
+                    loop=get_running_loop())
             timestamp_after = perf_counter()
             execution_time_ms = (timestamp_after - timestamp_before) * 1000.
             execution_times.append(execution_time_ms)

--- a/tests/software_tests/client/test_client.py
+++ b/tests/software_tests/client/test_client.py
@@ -30,8 +30,8 @@ class TestClient:
         # patching
         self._patcher_warn = patch(f"{SCRIPT_LOCATION}.warn")
         self.mock_warn = self._patcher_warn.start()
-        self._patcher_monotonic = patch(f"{SCRIPT_LOCATION}.monotonic")
-        self.mock_monotonic = self._patcher_monotonic.start()
+        self._patcher_perf_counter = patch(f"{SCRIPT_LOCATION}.perf_counter")
+        self.mock_perf_counter = self._patcher_perf_counter.start()
         self._patcher_thread = patch(f"{SCRIPT_LOCATION}.Thread")
         self.mock_thread = self._patcher_thread.start()
         self._patcher_event = patch(f"{SCRIPT_LOCATION}.Event")
@@ -43,7 +43,7 @@ class TestClient:
 
     def teardown_method(self):
         self._patcher_warn.stop()
-        self._patcher_monotonic.stop()
+        self._patcher_perf_counter.stop()
         self._patcher_thread.stop()
         self._patcher_event.stop()
         self._patcher_tester_present.stop()

--- a/tests/system_tests/abstract_system_tests.py
+++ b/tests/system_tests/abstract_system_tests.py
@@ -15,7 +15,7 @@ class BaseSystemTests(ABC):
     """Base implementation for all system tests suites."""
 
     MAKE_TIMING_CHECKS: bool = True
-    TASK_TIMING_TOLERANCE: TimeMillisecondsAlias = 30
+    TASK_TIMING_TOLERANCE: TimeMillisecondsAlias = 20
     TIMESTAMP_TOLERANCE: TimeMillisecondsAlias = 1
 
     sent_message: Optional[UdsMessageRecord]

--- a/tests/system_tests/abstract_system_tests.py
+++ b/tests/system_tests/abstract_system_tests.py
@@ -3,8 +3,8 @@ __all__ = ['BaseSystemTests']
 import asyncio
 from abc import ABC
 from threading import Timer
-from typing import List, Optional
 from time import sleep
+from typing import List, Optional
 
 from uds.message import UdsMessage, UdsMessageRecord
 from uds.packet import AbstractPacket, AbstractPacketRecord
@@ -44,9 +44,11 @@ class BaseSystemTests(ABC):
         if self._timers:
             for _timer in self._timers:
                 _timer.join(self.TASK_TIMING_TOLERANCE / 1000.)
-                del _timer
             self._timers = []
-            sleep(self.TIMESTAMP_TOLERANCE / 1000.)
+            sleep(self.TASK_TIMING_TOLERANCE / 1000.)
+            for _timer in self._timers:
+                _timer.join()
+                del _timer
 
     def send_packet(self,
                     transport_interface: AbstractTransportInterface,

--- a/tests/system_tests/abstract_system_tests.py
+++ b/tests/system_tests/abstract_system_tests.py
@@ -88,8 +88,8 @@ class BaseSystemTests(ABC):
 
     def receive_message(self,
                         transport_interface: AbstractTransportInterface,
-                        start_timeout: TimeMillisecondsAlias,
-                        end_timeout: TimeMillisecondsAlias,
+                        start_timeout: Optional[TimeMillisecondsAlias],
+                        end_timeout: Optional[TimeMillisecondsAlias],
                         delay: TimeMillisecondsAlias) -> Timer:
         """
         Receive UDS message over Transport Interface.

--- a/tests/system_tests/abstract_system_tests.py
+++ b/tests/system_tests/abstract_system_tests.py
@@ -4,6 +4,7 @@ import asyncio
 from abc import ABC
 from threading import Timer
 from typing import List, Optional
+from time import sleep
 
 from uds.message import UdsMessage, UdsMessageRecord
 from uds.packet import AbstractPacket, AbstractPacketRecord
@@ -15,7 +16,7 @@ class BaseSystemTests(ABC):
     """Base implementation for all system tests suites."""
 
     MAKE_TIMING_CHECKS: bool = True
-    TASK_TIMING_TOLERANCE: TimeMillisecondsAlias = 20
+    TASK_TIMING_TOLERANCE: TimeMillisecondsAlias = 30
     TIMESTAMP_TOLERANCE: TimeMillisecondsAlias = 1
 
     sent_message: Optional[UdsMessageRecord]
@@ -45,6 +46,7 @@ class BaseSystemTests(ABC):
                 _timer.join(self.TASK_TIMING_TOLERANCE / 1000.)
                 del _timer
             self._timers = []
+            sleep(self.TIMESTAMP_TOLERANCE / 1000.)
 
     def send_packet(self,
                     transport_interface: AbstractTransportInterface,

--- a/tests/system_tests/abstract_system_tests.py
+++ b/tests/system_tests/abstract_system_tests.py
@@ -88,7 +88,8 @@ class BaseSystemTests(ABC):
 
     def receive_message(self,
                         transport_interface: AbstractTransportInterface,
-                        timeout: TimeMillisecondsAlias,
+                        start_timeout: TimeMillisecondsAlias,
+                        end_timeout: TimeMillisecondsAlias,
                         delay: TimeMillisecondsAlias) -> Timer:
         """
         Receive UDS message over Transport Interface.
@@ -96,14 +97,16 @@ class BaseSystemTests(ABC):
         .. note:: The result (UDS message record) will be available be in `self.sent_message` attribute.
 
         :param transport_interface: Transport Interface to use for transmission.
-        :param timeout: Maximal time (in milliseconds) to wait for UDS message transmission to start.
+        :param start_timeout: Maximal time (in milliseconds) to wait for UDS message transmission to start.
+        :param end_timeout: Maximal time (in milliseconds) to wait for UDS message transmission to finish.
         :param delay: Time [ms] after which the reception will be started.
 
         :return: Timer object with scheduled task.
         """
 
         def _receive_message():
-            self.received_message = transport_interface.receive_message(timeout)
+            self.received_message = transport_interface.receive_message(start_timeout=start_timeout,
+                                                                        end_timeout=end_timeout)
 
         timer = Timer(interval=delay/1000., function=_receive_message)
         self._timers.append(timer)

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -2,7 +2,7 @@ import asyncio
 from abc import ABC, abstractmethod
 from datetime import datetime
 from threading import Timer
-from time import sleep, time, perf_counter
+from time import perf_counter, sleep, time
 from typing import Optional
 
 import pytest

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -603,653 +603,666 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
 class AbstractMessageTests(AbstractPythonCanTests, ABC):
     """Common implementation of system tests related to sending and receiving UDS (DoCAN) messages."""
 
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    def test_send_message__sf(self, example_can_addressing_information, message):
-        """
-        Check for a simple synchronous UDS message sending.
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # def test_send_message__sf(self, example_can_addressing_information, message):
+    #     """
+    #     Check for a simple synchronous UDS message sending.
+    #
+    #     Procedure:
+    #     1. Send a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: UDS message record returned.
+    #     2. Validate transmitted UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     time_before_send = time()
+    #     message_record = can_transport_interface.send_message(message)
+    #     time_after_send = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start == message_record.transmission_end
+    #     assert len(message_record.packets_records) == 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+    #     # timing parameters
+    #     assert can_transport_interface.n_bs_measured is None
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start
+    #                 == message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_send_message__sf(self, example_can_addressing_information, message):
+    #     """
+    #     Check for a simple asynchronous UDS message sending.
+    #
+    #     Procedure:
+    #     1. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: UDS message record returned.
+    #     2. Validate transmitted UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     time_before_send = time()
+    #     message_record = await can_transport_interface.async_send_message(message)
+    #     time_after_send = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start == message_record.transmission_end
+    #     assert len(message_record.packets_records) == 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+    #     # timing parameters
+    #     assert can_transport_interface.n_bs_measured is None
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start
+    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, send_after", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 950),  # ms
+    #     (50, 20),
+    # ])
+    # def test_receive_message__sf(self, example_can_addressing_information,
+    #                              message, start_timeout, send_after):
+    #     """
+    #     Check for receiving of a UDS message (carried by Single Frame packet).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
+    #         UDS message (Single Frame).
+    #     2. Call method to receive message via Transport Interface with timeout set just after UDS message
+    #         reaches CAN bus.
+    #         Expected: UDS message is received.
+    #     3. Validate received UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the received UDS message.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     self.send_message(transport_interface=can_transport_interface_2nd_node,
+    #                       message=message,
+    #                       delay=send_after)
+    #     time_before_receive = time()
+    #     message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
+    #                                                                          end_timeout=start_timeout + 1000.)
+    #     time_after_receive = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start == message_record.transmission_end
+    #     assert len(message_record.packets_records) == 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start
+    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, send_after", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 950),  # ms
+    #     (50, 20),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_receive_message__sf(self, example_can_addressing_information,
+    #                                          message, start_timeout, send_after):
+    #     """
+    #     Check for asynchronous receiving of a UDS message (carried by Single Frame packet).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
+    #         UDS message (Single Frame).
+    #     2. Call async method to receive message via Transport Interface with timeout set just after UDS message
+    #         reaches CAN bus.
+    #         Expected: UDS message is received.
+    #     3. Validate received UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the received UDS message.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     send_message_task = asyncio.create_task(
+    #         self.async_send_message(transport_interface=can_transport_interface_2nd_node,
+    #                                 message=message,
+    #                                 delay=send_after))
+    #     time_before_receive = time()
+    #     message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
+    #                                                                          end_timeout=start_timeout + 1000.)
+    #     time_after_receive = time()
+    #     await send_message_task
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start == message_record.transmission_end
+    #     assert len(message_record.packets_records) == 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start
+    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, send_after", [
+    #     (1000, 1010),  # ms
+    #     (50, 60),
+    # ])
+    # def test_receive_message__sf__start_timeout(self, example_can_addressing_information,
+    #                                             message, start_timeout, send_after):
+    #     """
+    #     Check for a timeout during receiving of a UDS message.
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
+    #     2. Call method to receive message via Transport Interface with timeout set just before UDS message
+    #         reaches CAN bus.
+    #         Expected: Timeout exception is raised.
+    #     3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
+    #         Expected: Message is received.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     self.send_message(transport_interface=can_transport_interface_2nd_node,
+    #                       message=message,
+    #                       delay=send_after)
+    #     time_before_receive = time()
+    #     with pytest.raises(TimeoutError):
+    #         can_transport_interface.receive_message(start_timeout=start_timeout,
+    #                                                 end_timeout=start_timeout + 1000.)
+    #     time_after_receive = time()
+    #     # receive message later
+    #     message_record = can_transport_interface.receive_message(
+    #         start_timeout=(send_after - start_timeout) * 10,
+    #         end_timeout=(send_after - start_timeout) * 10 + 1000.)
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #         assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, send_after", [
+    #     (1000, 1010),  # ms
+    #     (50, 60),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_receive_message__sf__timeout(self, example_can_addressing_information,
+    #                                                   message, start_timeout, send_after):
+    #     """
+    #     Check for a timeout during asynchronous receiving of a UDS message.
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
+    #     2. Call async method to receive message via Transport Interface with timeout set before any CAN packet
+    #         reaches CAN bus.
+    #         Expected: Timeout exception is raised.
+    #     3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
+    #         Expected: Message is received.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     send_message_task = asyncio.create_task(self.async_send_message(
+    #         transport_interface=can_transport_interface_2nd_node,
+    #         message=message,
+    #         delay=send_after))
+    #     time_before_receive = time()
+    #     with pytest.raises(TimeoutError):
+    #         await can_transport_interface.async_receive_message(start_timeout=start_timeout,
+    #                                                             end_timeout=start_timeout + 1000.)
+    #     time_after_receive = time()
+    #     # receive message later
+    #     message_record = await can_transport_interface.async_receive_message(
+    #         start_timeout=(send_after - start_timeout) * 10,
+    #         end_timeout=(send_after - start_timeout) * 10 + 1000.)
+    #     await send_message_task
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #         assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("timeout, send_after", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 950),  # ms
+    #     (50, 20),
+    # ])
+    # def test_send_message__multi_packets(self, example_can_addressing_information,
+    #                                      message, timeout, send_after):
+    #     """
+    #     Check for a synchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+    #     2. Send a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: UDS message record returned.
+    #     3. Validate transmitted UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                      packet=flow_control_packet,
+    #                      delay=send_after)
+    #     time_before_send = time()
+    #     message_record = can_transport_interface.send_message(message)
+    #     time_after_send = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     assert len(message_record.packets_records) > 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
+    #                for following_packet in message_record.packets_records[2:])
+    #     # timing parameters
+    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
+    #     assert len(can_transport_interface.n_bs_measured) == 1
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+    #         assert (send_after - self.TASK_TIMING_TOLERANCE
+    #                 <= can_transport_interface.n_bs_measured[0]
+    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("timeout, send_after", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 950),  # ms
+    #     (50, 20),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_send_message__multi_packets(self, example_can_addressing_information,
+    #                                                  message, timeout, send_after):
+    #     """
+    #     Check for an asynchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: UDS message record returned.
+    #     3. Validate transmitted UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     send_packet_task = asyncio.create_task(self.async_send_packet(
+    #         transport_interface=can_transport_interface_2nd_node,
+    #         packet=flow_control_packet,
+    #         delay=send_after))
+    #     time_before_send = time()
+    #     message_record = await can_transport_interface.async_send_message(message)
+    #     time_after_send = time()
+    #     await send_packet_task
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     assert len(message_record.packets_records) > 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
+    #                for following_packet in message_record.packets_records[2:])
+    #     # timing parameters
+    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
+    #     assert len(can_transport_interface.n_bs_measured) == 1
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+    #         assert (send_after - self.TASK_TIMING_TOLERANCE
+    #                 <= can_transport_interface.n_bs_measured[0]
+    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("timeout, send_after", [
+    #     (1000, 1010),  # ms
+    #     (50, 60),
+    # ])
+    # def test_send_message__multi_packets__timeout(self, example_can_addressing_information,
+    #                                               message, timeout, send_after):
+    #     """
+    #     Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+    #     2. Send a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                      packet=flow_control_packet,
+    #                      delay=send_after)
+    #     time_before_receive = time()
+    #     with pytest.raises(TimeoutError):
+    #         can_transport_interface.send_message(message)
+    #     time_after_receive = time()
+    #     # timing parameters
+    #     receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #     assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+    #             < receiving_time_ms
+    #             < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("timeout, send_after", [
+    #     (1000, 1010),  # ms
+    #     (50, 60),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_send_message__multi_packets__timeout(self, example_can_addressing_information,
+    #                                                           message, timeout, send_after):
+    #     """
+    #     Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     send_packet_task = asyncio.create_task(self.async_send_packet(
+    #         transport_interface=can_transport_interface_2nd_node,
+    #         packet=flow_control_packet,
+    #         delay=send_after))
+    #     time_before_receive = time()
+    #     with pytest.raises(TimeoutError):
+    #         await can_transport_interface.async_send_message(message)
+    #     time_after_receive = time()
+    #     await send_packet_task
+    #     # timing parameters
+    #     receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #     assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+    #             < receiving_time_ms
+    #             < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 2000, 950, 20),  # ms
+    #     (50, 2000, 20, 50),
+    # ])
+    # def test_receive_message__multi_packets(self, example_can_addressing_information,
+    #                                         message, start_timeout, end_timeout, send_after, delay):
+    #     """
+    #     Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+    #         UDS message (First Frame and then Consecutive Frames).
+    #     2. Call method to receive message via Transport Interface.
+    #         Expected: UDS message is received.
+    #     3. Validate received UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the received UDS message.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_br=0)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #     for i, packet in enumerate(packets):
+    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                          packet=packet,
+    #                          delay=send_after + i * delay)
+    #     time_before_receive = time()
+    #     message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
+    #                                                              end_timeout=end_timeout)
+    #     time_after_receive = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert len(message_record.packets_records) == len(packets) + 1, \
+    #         "All packets (including Flow Control) are stored"
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 2000, 950, 20),  # ms
+    #     (50, 2000, 20, 50),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
+    #                                                     message, start_timeout, end_timeout, send_after, delay):
+    #     """
+    #     Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+    #         UDS message (First Frame and then Consecutive Frames).
+    #     2. Call async method to receive message via Transport Interface.
+    #         Expected: UDS message is received.
+    #     3. Validate received UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the received UDS message.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #
+    #     async def _send_message():
+    #         for packet in packets:
+    #             await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                                          packet=packet,
+    #                                          delay=send_after if packet == packets[0] else delay)
+    #
+    #     send_message_task = asyncio.create_task(_send_message())
+    #     time_before_receive = time()
+    #     message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
+    #                                                                          end_timeout=end_timeout)
+    #     time_after_receive = time()
+    #     await send_message_task
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert len(message_record.packets_records) == len(packets) + 1, \
+    #         "All packets (including Flow Control) are stored"
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
 
-        Procedure:
-        1. Send a UDS message using Transport Interface (via CAN Interface).
-            Expected: UDS message record returned.
-        2. Validate transmitted UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        time_before_send = time()
-        message_record = can_transport_interface.send_message(message)
-        time_after_send = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.TRANSMITTED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start == message_record.transmission_end
-        assert len(message_record.packets_records) == 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-        # timing parameters
-        assert can_transport_interface.n_bs_measured is None
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start
-                    == message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_send_message__sf(self, example_can_addressing_information, message):
-        """
-        Check for a simple asynchronous UDS message sending.
-
-        Procedure:
-        1. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-            Expected: UDS message record returned.
-        2. Validate transmitted UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        time_before_send = time()
-        message_record = await can_transport_interface.async_send_message(message)
-        time_after_send = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.TRANSMITTED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start == message_record.transmission_end
-        assert len(message_record.packets_records) == 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-        # timing parameters
-        assert can_transport_interface.n_bs_measured is None
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start
-                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950),  # ms
-        (50, 20),
-    ])
-    def test_receive_message__sf(self, example_can_addressing_information,
-                                 message, timeout, send_after):
-        """
-        Check for receiving of a UDS message (carried by Single Frame packet).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
-            UDS message (Single Frame).
-        2. Call method to receive message via Transport Interface with timeout set just after UDS message
-            reaches CAN bus.
-            Expected: UDS message is received.
-        3. Validate received UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the received UDS message.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param timeout: Timeout to pass to receive method [ms].
-        :param send_after: Time when to send CAN frame after call of receive method [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        self.send_message(transport_interface=can_transport_interface_2nd_node,
-                          message=message,
-                          delay=send_after)
-        time_before_receive = time()
-        message_record = can_transport_interface.receive_message(start_timeout=timeout)
-        time_after_receive = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start == message_record.transmission_end
-        assert len(message_record.packets_records) == 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start
-                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950),  # ms
-        (50, 20),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_receive_message__sf(self, example_can_addressing_information,
-                                             message, timeout, send_after):
-        """
-        Check for asynchronous receiving of a UDS message (carried by Single Frame packet).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
-            UDS message (Single Frame).
-        2. Call async method to receive message via Transport Interface with timeout set just after UDS message
-            reaches CAN bus.
-            Expected: UDS message is received.
-        3. Validate received UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the received UDS message.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param timeout: Timeout value to pass to receive message method [ms].
-        :param send_after: Time when to send CAN frame after call of receive method [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        send_message_task = asyncio.create_task(
-            self.async_send_message(transport_interface=can_transport_interface_2nd_node,
-                                    message=message,
-                                    delay=send_after))
-
-        time_before_receive = time()
-        message_record = await can_transport_interface.async_receive_message(start_timeout=timeout)
-        time_after_receive = time()
-        await send_message_task
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start == message_record.transmission_end
-        assert len(message_record.packets_records) == 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start
-                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after", [
-        (1000, 1005),  # ms
-        (50, 55),
-    ])
-    def test_receive_message__sf__timeout(self, example_can_addressing_information,
-                                          message, timeout, send_after):
-        """
-        Check for a timeout during receiving of a UDS message.
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
-        2. Call method to receive message via Transport Interface with timeout set just before UDS message
-            reaches CAN bus.
-            Expected: Timeout exception is raised.
-        3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
-            Expected: Message is received.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param timeout: Timeout to pass to receive method [ms].
-        :param send_after: Time when to send CAN frame after call of receive method [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        self.send_message(transport_interface=can_transport_interface_2nd_node,
-                          message=message,
-                          delay=send_after)
-        time_before_receive = time()
-        with pytest.raises(TimeoutError):
-            can_transport_interface.receive_message(start_timeout=timeout)
-        time_after_receive = time()
-        # receive message later
-        message_record = can_transport_interface.receive_message(start_timeout=(send_after - timeout) * 10)
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-            assert timeout <= receiving_time_ms < timeout + self.TASK_TIMING_TOLERANCE
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after", [
-        (1000, 1005),  # ms
-        (50, 55),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_receive_message__sf__timeout(self, example_can_addressing_information,
-                                                      message, timeout, send_after):
-        """
-        Check for a timeout during asynchronous receiving of a UDS message.
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
-        2. Call async method to receive message via Transport Interface with timeout set before any CAN packet
-            reaches CAN bus.
-            Expected: Timeout exception is raised.
-        3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
-            Expected: Message is received.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param timeout: Timeout value to pass to receive message method [ms].
-        :param send_after: Time when to send CAN frame after call of receive method [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        send_message_task = asyncio.create_task(self.async_send_message(
-            transport_interface=can_transport_interface_2nd_node,
-            message=message,
-            delay=send_after))
-        time_before_receive = time()
-        with pytest.raises(TimeoutError):
-            await can_transport_interface.async_receive_message(start_timeout=timeout)
-        time_after_receive = time()
-        # receive message later
-        message_record = await can_transport_interface.async_receive_message(start_timeout=(send_after - timeout) * 10)
-        await send_message_task
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-            assert timeout <= receiving_time_ms < timeout + self.TASK_TIMING_TOLERANCE
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950),  # ms
-        (50, 20),
-    ])
-    def test_send_message__multi_packets(self, example_can_addressing_information,
-                                         message, timeout, send_after):
-        """
-        Check for a synchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-        2. Send a UDS message using Transport Interface (via CAN Interface).
-            Expected: UDS message record returned.
-        3. Validate transmitted UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                         packet=flow_control_packet,
-                         delay=send_after)
-        time_before_send = time()
-        message_record = can_transport_interface.send_message(message)
-        time_after_send = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.TRANSMITTED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        assert len(message_record.packets_records) > 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-                   and following_packet.direction == TransmissionDirection.TRANSMITTED
-                   for following_packet in message_record.packets_records[2:])
-        # timing parameters
-        assert isinstance(can_transport_interface.n_bs_measured, tuple)
-        assert len(can_transport_interface.n_bs_measured) == 1
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-            assert (send_after - self.TASK_TIMING_TOLERANCE
-                    <= can_transport_interface.n_bs_measured[0]
-                    <= send_after + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950),  # ms
-        (50, 20),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_send_message__multi_packets(self, example_can_addressing_information,
-                                                     message, timeout, send_after):
-        """
-        Check for an asynchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-            Expected: UDS message record returned.
-        3. Validate transmitted UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        send_packet_task = asyncio.create_task(self.async_send_packet(
-            transport_interface=can_transport_interface_2nd_node,
-            packet=flow_control_packet,
-            delay=send_after))
-        time_before_send = time()
-        message_record = await can_transport_interface.async_send_message(message)
-        time_after_send = time()
-        await send_packet_task
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.TRANSMITTED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        assert len(message_record.packets_records) > 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-                   and following_packet.direction == TransmissionDirection.TRANSMITTED
-                   for following_packet in message_record.packets_records[2:])
-        # timing parameters
-        assert isinstance(can_transport_interface.n_bs_measured, tuple)
-        assert len(can_transport_interface.n_bs_measured) == 1
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-            assert (send_after - self.TASK_TIMING_TOLERANCE
-                    <= can_transport_interface.n_bs_measured[0]
-                    <= send_after + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after", [
-        (1000, 1010),  # ms
-        (50, 60),
-    ])
-    def test_send_message__multi_packets__timeout(self, example_can_addressing_information,
-                                                  message, timeout, send_after):
-        """
-        Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-        2. Send a UDS message using Transport Interface (via CAN Interface).
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                         packet=flow_control_packet,
-                         delay=send_after)
-        time_before_receive = time()
-        with pytest.raises(TimeoutError):
-            can_transport_interface.send_message(message)
-        time_after_receive = time()
-        # timing parameters
-        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-        assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-                < receiving_time_ms
-                < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after", [
-        (1000, 1010),  # ms
-        (50, 60),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_send_message__multi_packets__timeout(self, example_can_addressing_information,
-                                                              message, timeout, send_after):
-        """
-        Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        send_packet_task = asyncio.create_task(self.async_send_packet(
-            transport_interface=can_transport_interface_2nd_node,
-            packet=flow_control_packet,
-            delay=send_after))
-        time_before_receive = time()
-        with pytest.raises(TimeoutError):
-            await can_transport_interface.async_send_message(message)
-        time_after_receive = time()
-        await send_packet_task
-        # timing parameters
-        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-        assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-                < receiving_time_ms
-                < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after, delay", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950, 20),  # ms
-        (50, 20, 50),
-    ])
-    def test_receive_message__multi_packets(self, example_can_addressing_information,
-                                            message, timeout, send_after, delay):
-        """
-        Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-            UDS message (First Frame and then Consecutive Frames).
-        2. Call method to receive message via Transport Interface.
-            Expected: UDS message is received.
-        3. Validate received UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the received UDS message.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param timeout: Timeout value to pass to receive message method [ms].
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_br=0)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-        for i, packet in enumerate(packets):
-            self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                             packet=packet,
-                             delay=send_after + i * delay)
-        time_before_receive = time()
-        message_record = can_transport_interface.receive_message(start_timeout=timeout)
-        time_after_receive = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert len(message_record.packets_records) == len(packets) + 1, \
-            "All packets (including Flow Control) are stored"
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after, delay", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950, 20),  # ms
-        (50, 20, 50),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
-                                                        message, timeout, send_after, delay):
-        """
-        Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-            UDS message (First Frame and then Consecutive Frames).
-        2. Call async method to receive message via Transport Interface.
-            Expected: UDS message is received.
-        3. Validate received UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the received UDS message.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param timeout: Timeout value to pass to receive message method [ms].
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-
-        async def _send_message():
-            for packet in packets:
-                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
-                                             packet=packet,
-                                             delay=send_after if packet == packets[0] else delay)
-
-        send_message_task = asyncio.create_task(_send_message())
-        time_before_receive = time()
-        message_record = await can_transport_interface.async_receive_message(start_timeout=timeout)
-        time_after_receive = time()
-        await send_message_task
-        assert isinstance(message_record, UdsMessageRecord)
-        assert len(message_record.packets_records) == len(packets) + 1, \
-            "All packets (including Flow Control) are stored"
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    # TODO: continue rework here
 
     @pytest.mark.parametrize("message", [
         UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
@@ -1340,153 +1353,153 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
             await can_transport_interface.async_receive_message(start_timeout=timeout)
         await send_message_task
 
-    @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
-        (
-            UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-            0, 0, 0, 0
-        ),
-        (
-            UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
-            2, 25, 5, 120
-        ),
-        (
-            UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
-                       addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
-                       addressing_type=AddressingType.PHYSICAL),
-            0, 0, 2, 5,
-        ),
-    ])
-    def test_full_duplex(self, example_can_addressing_information,
-                         tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
-        """
-        Check for a full-duplex communication during synchronous UDS message sending.
-
-        Procedure:
-        1. Schedule receiving messages on both Transport Interfaces.
-        2. Schedule sending messages on both Transport Interfaces.
-        3. Wait till all tasks are finished (messages are sent and received).
-        4. Validate UDS message record attributes.
-            Expected: Attributes of received UDS message records are in line with messages attributes scheduled for
-                the transmission.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param tx_message: UDS message to send on interface 1 and receive on interface 2.
-        :param rx_message: UDS message to send on interface 2 and receive on interface 1.
-        :param tx_block_size: Block Size parameter value for interface 1.
-        :param tx_st_min: STmin parameter value for interface 1.
-        :param rx_block_size: Block Size parameter value for interface 2.
-        :param rx_st_min: STmin parameter value for interface 2.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
-                                                                                    st_min=tx_st_min))
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end(),
-            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
-                                                                                    st_min=rx_st_min))
-        timer_1 = self.receive_message(transport_interface=can_transport_interface_2nd_node,
-                                       delay=0,
-                                       timeout=50)
-        timer_2 = self.send_message(transport_interface=can_transport_interface_2nd_node,
-                                    message=rx_message,
-                                    delay=10)
-        timer_3 = self.send_message(transport_interface=can_transport_interface,
-                                    message=tx_message,
-                                    delay=10)
-        received_rx_message_record = can_transport_interface.receive_message(start_timeout=50)
-        while not all([timer_1.finished.is_set(), timer_2.finished.is_set(), timer_3.finished.is_set()]):
-            sleep(self.TASK_TIMING_TOLERANCE / 1000.)
-        received_tx_message_record = self.received_message
-        assert isinstance(received_tx_message_record, UdsMessageRecord)
-        assert isinstance(received_rx_message_record, UdsMessageRecord)
-        assert received_tx_message_record.payload == tx_message.payload
-        assert received_tx_message_record.addressing_type == tx_message.addressing_type
-        assert received_rx_message_record.payload == rx_message.payload
-        assert received_rx_message_record.addressing_type == rx_message.addressing_type
-
-    @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
-        (
-            UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-            0, 0, 0, 0
-        ),
-        (
-            UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
-            2, 25, 5, 120
-        ),
-        (
-            UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
-                       addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
-                       addressing_type=AddressingType.PHYSICAL),
-            0, 0, 2, 5,
-        ),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_full_duplex(self, example_can_addressing_information,
-                                     tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
-        """
-        Check for a full-duplex communication during asynchronous UDS message sending.
-
-        Procedure:
-        1. Schedule receiving messages on both Transport Interfaces.
-        2. Schedule sending messages on both Transport Interfaces.
-        3. Wait till all tasks are finished (messages are sent and received).
-        4. Validate UDS message record attributes.
-            Expected: Attributes of received UDS message records are in line with the transmitted UDS messages records.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param tx_message: UDS message to send on interface 1 and receive on interface 2.
-        :param rx_message: UDS message to send on interface 2 and receive on interface 1.
-        :param tx_block_size: Block Size parameter value for interface 1.
-        :param tx_st_min: STmin parameter value for interface 1.
-        :param rx_block_size: Block Size parameter value for interface 2.
-        :param rx_st_min: STmin parameter value for interface 2.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
-                                                                                    st_min=tx_st_min))
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end(),
-            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
-                                                                                    st_min=rx_st_min))
-        received_rx_message_task = asyncio.create_task(
-            can_transport_interface.async_receive_message(start_timeout=50))
-        received_tx_message_task = asyncio.create_task(
-            can_transport_interface_2nd_node.async_receive_message(start_timeout=50))
-        sent_tx_message_task = asyncio.create_task(
-            can_transport_interface.async_send_message(message=tx_message))
-        sent_rx_message_task = asyncio.create_task(
-            can_transport_interface_2nd_node.async_send_message(message=rx_message))
-        tasks = [received_tx_message_task,
-                 received_rx_message_task,
-                 sent_tx_message_task,
-                 sent_rx_message_task]
-        await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
-        received_tx_message_record = await received_tx_message_task
-        received_rx_message_record = await received_rx_message_task
-        sent_tx_message_record = await sent_tx_message_task
-        sent_rx_message_record = await sent_rx_message_task
-        assert isinstance(received_tx_message_record, UdsMessageRecord)
-        assert isinstance(received_rx_message_record, UdsMessageRecord)
-        assert isinstance(sent_tx_message_record, UdsMessageRecord)
-        assert isinstance(sent_rx_message_record, UdsMessageRecord)
-        assert received_tx_message_record.payload == sent_tx_message_record.payload == tx_message.payload
-        assert (received_tx_message_record.addressing_type == sent_tx_message_record.addressing_type
-                == tx_message.addressing_type)
-        assert received_rx_message_record.payload == sent_rx_message_record.payload == rx_message.payload
-        assert (received_rx_message_record.addressing_type == sent_rx_message_record.addressing_type
-                == rx_message.addressing_type)
+    # @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
+    #     (
+    #         UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    #         0, 0, 0, 0
+    #     ),
+    #     (
+    #         UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
+    #         2, 25, 5, 120
+    #     ),
+    #     (
+    #         UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
+    #                    addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
+    #                    addressing_type=AddressingType.PHYSICAL),
+    #         0, 0, 2, 5,
+    #     ),
+    # ])
+    # def test_full_duplex(self, example_can_addressing_information,
+    #                      tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
+    #     """
+    #     Check for a full-duplex communication during synchronous UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule receiving messages on both Transport Interfaces.
+    #     2. Schedule sending messages on both Transport Interfaces.
+    #     3. Wait till all tasks are finished (messages are sent and received).
+    #     4. Validate UDS message record attributes.
+    #         Expected: Attributes of received UDS message records are in line with messages attributes scheduled for
+    #             the transmission.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param tx_message: UDS message to send on interface 1 and receive on interface 2.
+    #     :param rx_message: UDS message to send on interface 2 and receive on interface 1.
+    #     :param tx_block_size: Block Size parameter value for interface 1.
+    #     :param tx_st_min: STmin parameter value for interface 1.
+    #     :param rx_block_size: Block Size parameter value for interface 2.
+    #     :param rx_st_min: STmin parameter value for interface 2.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
+    #                                                                                 st_min=tx_st_min))
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end(),
+    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
+    #                                                                                 st_min=rx_st_min))
+    #     timer_1 = self.receive_message(transport_interface=can_transport_interface_2nd_node,
+    #                                    delay=0,
+    #                                    timeout=50)
+    #     timer_2 = self.send_message(transport_interface=can_transport_interface_2nd_node,
+    #                                 message=rx_message,
+    #                                 delay=10)
+    #     timer_3 = self.send_message(transport_interface=can_transport_interface,
+    #                                 message=tx_message,
+    #                                 delay=10)
+    #     received_rx_message_record = can_transport_interface.receive_message(start_timeout=50)
+    #     while not all([timer_1.finished.is_set(), timer_2.finished.is_set(), timer_3.finished.is_set()]):
+    #         sleep(self.TASK_TIMING_TOLERANCE / 1000.)
+    #     received_tx_message_record = self.received_message
+    #     assert isinstance(received_tx_message_record, UdsMessageRecord)
+    #     assert isinstance(received_rx_message_record, UdsMessageRecord)
+    #     assert received_tx_message_record.payload == tx_message.payload
+    #     assert received_tx_message_record.addressing_type == tx_message.addressing_type
+    #     assert received_rx_message_record.payload == rx_message.payload
+    #     assert received_rx_message_record.addressing_type == rx_message.addressing_type
+    #
+    # @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
+    #     (
+    #         UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    #         0, 0, 0, 0
+    #     ),
+    #     (
+    #         UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
+    #         2, 25, 5, 120
+    #     ),
+    #     (
+    #         UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
+    #                    addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
+    #                    addressing_type=AddressingType.PHYSICAL),
+    #         0, 0, 2, 5,
+    #     ),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_full_duplex(self, example_can_addressing_information,
+    #                                  tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
+    #     """
+    #     Check for a full-duplex communication during asynchronous UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule receiving messages on both Transport Interfaces.
+    #     2. Schedule sending messages on both Transport Interfaces.
+    #     3. Wait till all tasks are finished (messages are sent and received).
+    #     4. Validate UDS message record attributes.
+    #         Expected: Attributes of received UDS message records are in line with the transmitted UDS messages records.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param tx_message: UDS message to send on interface 1 and receive on interface 2.
+    #     :param rx_message: UDS message to send on interface 2 and receive on interface 1.
+    #     :param tx_block_size: Block Size parameter value for interface 1.
+    #     :param tx_st_min: STmin parameter value for interface 1.
+    #     :param rx_block_size: Block Size parameter value for interface 2.
+    #     :param rx_st_min: STmin parameter value for interface 2.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
+    #                                                                                 st_min=tx_st_min))
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end(),
+    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
+    #                                                                                 st_min=rx_st_min))
+    #     received_rx_message_task = asyncio.create_task(
+    #         can_transport_interface.async_receive_message(start_timeout=50))
+    #     received_tx_message_task = asyncio.create_task(
+    #         can_transport_interface_2nd_node.async_receive_message(start_timeout=50))
+    #     sent_tx_message_task = asyncio.create_task(
+    #         can_transport_interface.async_send_message(message=tx_message))
+    #     sent_rx_message_task = asyncio.create_task(
+    #         can_transport_interface_2nd_node.async_send_message(message=rx_message))
+    #     tasks = [received_tx_message_task,
+    #              received_rx_message_task,
+    #              sent_tx_message_task,
+    #              sent_rx_message_task]
+    #     await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+    #     received_tx_message_record = await received_tx_message_task
+    #     received_rx_message_record = await received_rx_message_task
+    #     sent_tx_message_record = await sent_tx_message_task
+    #     sent_rx_message_record = await sent_rx_message_task
+    #     assert isinstance(received_tx_message_record, UdsMessageRecord)
+    #     assert isinstance(received_rx_message_record, UdsMessageRecord)
+    #     assert isinstance(sent_tx_message_record, UdsMessageRecord)
+    #     assert isinstance(sent_rx_message_record, UdsMessageRecord)
+    #     assert received_tx_message_record.payload == sent_tx_message_record.payload == tx_message.payload
+    #     assert (received_tx_message_record.addressing_type == sent_tx_message_record.addressing_type
+    #             == tx_message.addressing_type)
+    #     assert received_rx_message_record.payload == sent_rx_message_record.payload == rx_message.payload
+    #     assert (received_rx_message_record.addressing_type == sent_rx_message_record.addressing_type
+    #             == rx_message.addressing_type)
 
 
 class AbstractUseCaseTests(AbstractPythonCanTests, ABC):

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -603,800 +603,798 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
 class AbstractMessageTests(AbstractPythonCanTests, ABC):
     """Common implementation of system tests related to sending and receiving UDS (DoCAN) messages."""
 
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    def test_send_message__sf(self, example_can_addressing_information, message):
-        """
-        Check for a simple synchronous UDS message sending.
-
-        Procedure:
-        1. Send a UDS message using Transport Interface (via CAN Interface).
-            Expected: UDS message record returned.
-        2. Validate transmitted UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        time_before_send = time()
-        message_record = can_transport_interface.send_message(message)
-        time_after_send = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.TRANSMITTED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start == message_record.transmission_end
-        assert len(message_record.packets_records) == 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-        # timing parameters
-        assert can_transport_interface.n_bs_measured is None
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start
-                    == message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_send_message__sf(self, example_can_addressing_information, message):
-        """
-        Check for a simple asynchronous UDS message sending.
-
-        Procedure:
-        1. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-            Expected: UDS message record returned.
-        2. Validate transmitted UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        time_before_send = time()
-        message_record = await can_transport_interface.async_send_message(message)
-        time_after_send = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.TRANSMITTED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start == message_record.transmission_end
-        assert len(message_record.packets_records) == 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-        # timing parameters
-        assert can_transport_interface.n_bs_measured is None
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start
-                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950),  # ms
-        (50, 20),
-    ])
-    def test_receive_message__sf(self, example_can_addressing_information,
-                                 message, timeout, send_after):
-        """
-        Check for receiving of a UDS message (carried by Single Frame packet).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
-            UDS message (Single Frame).
-        2. Call method to receive message via Transport Interface with timeout set just after UDS message
-            reaches CAN bus.
-            Expected: UDS message is received.
-        3. Validate received UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the received UDS message.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param timeout: Maximal time (in milliseconds) to wait for the message transmission.
-        :param send_after: Time when to send CAN frame after call of receive method [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        self.send_message(transport_interface=can_transport_interface_2nd_node,
-                          message=message,
-                          delay=send_after)
-        time_before_receive = time()
-        message_record = can_transport_interface.receive_message(start_timeout=timeout,
-                                                                 end_timeout=timeout)
-        time_after_receive = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start == message_record.transmission_end
-        assert len(message_record.packets_records) == 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start
-                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    @pytest.mark.parametrize("timeout, send_after", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950),  # ms
-        (50, 20),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_receive_message__sf(self, example_can_addressing_information,
-                                             message, timeout, send_after):
-        """
-        Check for asynchronous receiving of a UDS message (carried by Single Frame packet).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
-            UDS message (Single Frame).
-        2. Call async method to receive message via Transport Interface with timeout set just after UDS message
-            reaches CAN bus.
-            Expected: UDS message is received.
-        3. Validate received UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the received UDS message.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param timeout: Maximal time (in milliseconds) to wait for the message transmission.
-        :param send_after: Time when to send CAN frame after call of receive method [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        send_message_task = asyncio.create_task(
-            self.async_send_message(transport_interface=can_transport_interface_2nd_node,
-                                    message=message,
-                                    delay=send_after))
-        time_before_receive = time()
-        message_record = await can_transport_interface.async_receive_message(start_timeout=timeout,
-                                                                             end_timeout=timeout)
-        time_after_receive = time()
-        await send_message_task
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start == message_record.transmission_end
-        assert len(message_record.packets_records) == 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start
-                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    @pytest.mark.parametrize("start_timeout, send_after", [
-        (1000, 1010),  # ms
-        (50, 60),
-    ])
-    def test_receive_message__sf__start_timeout(self, example_can_addressing_information,
-                                                message, start_timeout, send_after):
-        """
-        Check for a timeout during receiving of a UDS message.
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
-        2. Call method to receive message via Transport Interface with timeout set just before UDS message
-            reaches CAN bus.
-            Expected: Timeout exception is raised.
-        3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
-            Expected: Message is received.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-        :param send_after: Time when to send CAN frame after call of receive method [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        self.send_message(transport_interface=can_transport_interface_2nd_node,
-                          message=message,
-                          delay=send_after)
-        time_before_receive = time()
-        with pytest.raises(TimeoutError):
-            can_transport_interface.receive_message(start_timeout=start_timeout)
-        time_after_receive = time()
-        # receive message later
-        message_record = can_transport_interface.receive_message(
-            start_timeout=(send_after - start_timeout) * 10)
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-            assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    ])
-    @pytest.mark.parametrize("start_timeout, send_after", [
-        (1000, 1010),  # ms
-        (50, 60),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_receive_message__sf__start_timeout(self, example_can_addressing_information,
-                                                            message, start_timeout, send_after):
-        """
-        Check for a timeout during asynchronous receiving of a UDS message.
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
-        2. Call async method to receive message via Transport Interface with timeout set before any CAN packet
-            reaches CAN bus.
-            Expected: Timeout exception is raised.
-        3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
-            Expected: Message is received.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-        :param send_after: Time when to send CAN frame after call of receive method [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        send_message_task = asyncio.create_task(self.async_send_message(
-            transport_interface=can_transport_interface_2nd_node,
-            message=message,
-            delay=send_after))
-        time_before_receive = time()
-        with pytest.raises(TimeoutError):
-            await can_transport_interface.async_receive_message(start_timeout=start_timeout)
-        time_after_receive = time()
-        # receive message later
-        message_record = await can_transport_interface.async_receive_message(
-            start_timeout=(send_after - start_timeout) * 10)
-        await send_message_task
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-            assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("n_bs_timeout, send_after", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950),  # ms
-        (50, 20),
-    ])
-    def test_send_message__multi_packets(self, example_can_addressing_information,
-                                         message, n_bs_timeout, send_after):
-        """
-        Check for a synchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-        2. Send a UDS message using Transport Interface (via CAN Interface).
-            Expected: UDS message record returned.
-        3. Validate transmitted UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=n_bs_timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                         packet=flow_control_packet,
-                         delay=send_after)
-        time_before_send = time()
-        message_record = can_transport_interface.send_message(message)
-        time_after_send = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.TRANSMITTED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        assert len(message_record.packets_records) > 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-                   and following_packet.direction == TransmissionDirection.TRANSMITTED
-                   for following_packet in message_record.packets_records[2:])
-        # timing parameters
-        assert isinstance(can_transport_interface.n_bs_measured, tuple)
-        assert len(can_transport_interface.n_bs_measured) == 1
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-            assert (send_after - self.TASK_TIMING_TOLERANCE
-                    <= can_transport_interface.n_bs_measured[0]
-                    <= send_after + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("n_bs_timeout, send_after", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950),  # ms
-        (50, 20),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_send_message__multi_packets(self, example_can_addressing_information,
-                                                     message, n_bs_timeout, send_after):
-        """
-        Check for an asynchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-            Expected: UDS message record returned.
-        3. Validate transmitted UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=n_bs_timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        send_packet_task = asyncio.create_task(self.async_send_packet(
-            transport_interface=can_transport_interface_2nd_node,
-            packet=flow_control_packet,
-            delay=send_after))
-        time_before_send = time()
-        message_record = await can_transport_interface.async_send_message(message)
-        time_after_send = time()
-        await send_packet_task
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.TRANSMITTED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        assert len(message_record.packets_records) > 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-                   and following_packet.direction == TransmissionDirection.TRANSMITTED
-                   for following_packet in message_record.packets_records[2:])
-        # timing parameters
-        assert isinstance(can_transport_interface.n_bs_measured, tuple)
-        assert len(can_transport_interface.n_bs_measured) == 1
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-            assert (send_after - self.TASK_TIMING_TOLERANCE
-                    <= can_transport_interface.n_bs_measured[0]
-                    <= send_after + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("n_bs_timeout, send_after", [
-        (1000, 1010),  # ms
-        (50, 60),
-    ])
-    def test_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
-                                                       message, n_bs_timeout, send_after):
-        """
-        Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-        2. Send a UDS message using Transport Interface (via CAN Interface).
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=n_bs_timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                         packet=flow_control_packet,
-                         delay=send_after)
-        time_before_receive = time()
-        with pytest.raises(TimeoutError):
-            can_transport_interface.send_message(message)
-        time_after_receive = time()
-        # timing parameters
-        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-        assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-                < receiving_time_ms
-                < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("n_bs_timeout, send_after", [
-        (1000, 1010),  # ms
-        (50, 60),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
-                                                                   message, n_bs_timeout, send_after):
-        """
-        Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=n_bs_timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        send_packet_task = asyncio.create_task(self.async_send_packet(
-            transport_interface=can_transport_interface_2nd_node,
-            packet=flow_control_packet,
-            delay=send_after))
-        time_before_receive = time()
-        with pytest.raises(TimeoutError):
-            await can_transport_interface.async_send_message(message)
-        time_after_receive = time()
-        await send_packet_task
-        # timing parameters
-        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-        assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-                < receiving_time_ms
-                < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 2000, 950, 20),  # ms
-        (50, 1500, 20, 50),
-    ])
-    def test_receive_message__multi_packets(self, example_can_addressing_information,
-                                            message, start_timeout, end_timeout, send_after, delay):
-        """
-        Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-            UDS message (First Frame and then Consecutive Frames).
-        2. Call method to receive message via Transport Interface.
-            Expected: UDS message is received.
-        3. Validate received UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the received UDS message.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_br=0)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-        for i, packet in enumerate(packets):
-            self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                             packet=packet,
-                             delay=send_after + i * delay)
-        time_before_receive = time()
-        message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
-                                                                 end_timeout=end_timeout)
-        time_after_receive = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert len(message_record.packets_records) == len(packets) + 1, \
-            "All packets (including Flow Control) are stored"
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 2000, 950, 20),  # ms
-        (50, 2000, 20, 50),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
-                                                        message, start_timeout, end_timeout, send_after, delay):
-        """
-        Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-            UDS message (First Frame and then Consecutive Frames).
-        2. Call async method to receive message via Transport Interface.
-            Expected: UDS message is received.
-        3. Validate received UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the received UDS message.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-
-        async def _send_message():
-            for packet in packets:
-                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
-                                             packet=packet,
-                                             delay=send_after if packet == packets[0] else delay)
-
-        send_message_task = asyncio.create_task(_send_message())
-        time_before_receive = time()
-        message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
-                                                                             end_timeout=end_timeout)
-        time_after_receive = time()
-        await send_message_task
-        assert isinstance(message_record, UdsMessageRecord)
-        assert len(message_record.packets_records) == len(packets) + 1, \
-            "All packets (including Flow Control) are stored"
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("start_timeout, send_after, delay", [
-        (1000, 50, 20),  # ms
-        (50, 0, 50),
-    ])
-    def test_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
-                                                          message, start_timeout, send_after, delay):
-        """
-        Check for a timeout during receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carries part of received
-            UDS message (First Frame and then Consecutive Frames with one Consecutive Frame missing).
-        2. Call method to receive message via Transport Interface.
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_br=0)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-        self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                         packet=packets[0],
-                         delay=send_after)
-        for i, cf_packet in enumerate(packets[1:-1], start=1):
-            self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                             packet=cf_packet,
-                             delay=send_after + i * delay)
-        with pytest.raises(TimeoutError):
-            can_transport_interface.receive_message(start_timeout=start_timeout)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("start_timeout, send_after, delay", [
-        (1000, 50, 20),  # ms
-        (50, 0, 50),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
-                                                                      message, start_timeout, send_after, delay):
-        """
-        Check for a timeout during asynchronous receiving of a UDS message (carried by First Frame and
-        Consecutive Frame packets).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-            UDS message (First Frame and then Consecutive Frames).
-        2. Call async method to receive message via Transport Interface.
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-
-        async def _send_message():
-            for packet in packets[:-1]:
-                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
-                                             packet=packet,
-                                             delay=send_after if packet == packets[0] else delay)
-
-        send_message_task = asyncio.create_task(_send_message())
-        with pytest.raises(TimeoutError):
-            await can_transport_interface.async_receive_message(start_timeout=start_timeout)
-        await send_message_task
-
-    # TODO: add end timeout
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("end_timeout, send_after, delay", [
-        (1000, 50, 20),  # ms
-        (2500, 0, 50),
-    ])
-    def test_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
-                                                         message, end_timeout, send_after, delay):
-        """
-        Check for an end message timeout during synchronous multi packet (FF + CF) UDS message reception.
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-            UDS message (First Frame and then Consecutive Frames).
-        2. Call method to receive message via Transport Interface with timeout set before the entire segmented
-            UDS message is transmitted.
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param end_timeout: Maximal time (in milliseconds) to wait for the end of a message transmission.
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_br=0)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-        for i, packet in enumerate(packets):
-            self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                             packet=packet,
-                             delay=send_after + i * delay)
-        time_before_receive = time()
-        with pytest.raises(TimeoutError):
-            can_transport_interface.receive_message(start_timeout=2 * send_after + 50,
-                                                    end_timeout=end_timeout)
-        time_after_receive = time()
-        # timing parameters
-        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-        assert (end_timeout - self.TASK_TIMING_TOLERANCE
-                < receiving_time_ms
-                < end_timeout + self.TASK_TIMING_TOLERANCE)
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # def test_send_message__sf(self, example_can_addressing_information, message):
+    #     """
+    #     Check for a simple synchronous UDS message sending.
+    #
+    #     Procedure:
+    #     1. Send a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: UDS message record returned.
+    #     2. Validate transmitted UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     time_before_send = time()
+    #     message_record = can_transport_interface.send_message(message)
+    #     time_after_send = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start == message_record.transmission_end
+    #     assert len(message_record.packets_records) == 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+    #     # timing parameters
+    #     assert can_transport_interface.n_bs_measured is None
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start
+    #                 == message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_send_message__sf(self, example_can_addressing_information, message):
+    #     """
+    #     Check for a simple asynchronous UDS message sending.
+    #
+    #     Procedure:
+    #     1. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: UDS message record returned.
+    #     2. Validate transmitted UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     time_before_send = time()
+    #     message_record = await can_transport_interface.async_send_message(message)
+    #     time_after_send = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start == message_record.transmission_end
+    #     assert len(message_record.packets_records) == 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+    #     # timing parameters
+    #     assert can_transport_interface.n_bs_measured is None
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start
+    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # @pytest.mark.parametrize("timeout, send_after", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 950),  # ms
+    #     (50, 20),
+    # ])
+    # def test_receive_message__sf(self, example_can_addressing_information,
+    #                              message, timeout, send_after):
+    #     """
+    #     Check for receiving of a UDS message (carried by Single Frame packet).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
+    #         UDS message (Single Frame).
+    #     2. Call method to receive message via Transport Interface with timeout set just after UDS message
+    #         reaches CAN bus.
+    #         Expected: UDS message is received.
+    #     3. Validate received UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the received UDS message.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param timeout: Maximal time (in milliseconds) to wait for the message transmission.
+    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     self.send_message(transport_interface=can_transport_interface_2nd_node,
+    #                       message=message,
+    #                       delay=send_after)
+    #     time_before_receive = time()
+    #     message_record = can_transport_interface.receive_message(start_timeout=timeout,
+    #                                                              end_timeout=timeout)
+    #     time_after_receive = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start == message_record.transmission_end
+    #     assert len(message_record.packets_records) == 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start
+    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # @pytest.mark.parametrize("timeout, send_after", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 950),  # ms
+    #     (50, 20),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_receive_message__sf(self, example_can_addressing_information,
+    #                                          message, timeout, send_after):
+    #     """
+    #     Check for asynchronous receiving of a UDS message (carried by Single Frame packet).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
+    #         UDS message (Single Frame).
+    #     2. Call async method to receive message via Transport Interface with timeout set just after UDS message
+    #         reaches CAN bus.
+    #         Expected: UDS message is received.
+    #     3. Validate received UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the received UDS message.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param timeout: Maximal time (in milliseconds) to wait for the message transmission.
+    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     send_message_task = asyncio.create_task(
+    #         self.async_send_message(transport_interface=can_transport_interface_2nd_node,
+    #                                 message=message,
+    #                                 delay=send_after))
+    #     time_before_receive = time()
+    #     message_record = await can_transport_interface.async_receive_message(start_timeout=timeout,
+    #                                                                          end_timeout=timeout)
+    #     time_after_receive = time()
+    #     await send_message_task
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start == message_record.transmission_end
+    #     assert len(message_record.packets_records) == 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start
+    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, send_after", [
+    #     (1000, 1010),  # ms
+    #     (50, 60),
+    # ])
+    # def test_receive_message__sf__start_timeout(self, example_can_addressing_information,
+    #                                             message, start_timeout, send_after):
+    #     """
+    #     Check for a timeout during receiving of a UDS message.
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
+    #     2. Call method to receive message via Transport Interface with timeout set just before UDS message
+    #         reaches CAN bus.
+    #         Expected: Timeout exception is raised.
+    #     3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
+    #         Expected: Message is received.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     self.send_message(transport_interface=can_transport_interface_2nd_node,
+    #                       message=message,
+    #                       delay=send_after)
+    #     time_before_receive = time()
+    #     with pytest.raises(TimeoutError):
+    #         can_transport_interface.receive_message(start_timeout=start_timeout)
+    #     time_after_receive = time()
+    #     # receive message later
+    #     message_record = can_transport_interface.receive_message(
+    #         start_timeout=(send_after - start_timeout) * 10)
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #         assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, send_after", [
+    #     (1000, 1010),  # ms
+    #     (50, 60),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_receive_message__sf__start_timeout(self, example_can_addressing_information,
+    #                                                         message, start_timeout, send_after):
+    #     """
+    #     Check for a timeout during asynchronous receiving of a UDS message.
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
+    #     2. Call async method to receive message via Transport Interface with timeout set before any CAN packet
+    #         reaches CAN bus.
+    #         Expected: Timeout exception is raised.
+    #     3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
+    #         Expected: Message is received.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     send_message_task = asyncio.create_task(self.async_send_message(
+    #         transport_interface=can_transport_interface_2nd_node,
+    #         message=message,
+    #         delay=send_after))
+    #     time_before_receive = time()
+    #     with pytest.raises(TimeoutError):
+    #         await can_transport_interface.async_receive_message(start_timeout=start_timeout)
+    #     time_after_receive = time()
+    #     # receive message later
+    #     message_record = await can_transport_interface.async_receive_message(
+    #         start_timeout=(send_after - start_timeout) * 10)
+    #     await send_message_task
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #         assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 950),  # ms
+    #     (50, 20),
+    # ])
+    # def test_send_message__multi_packets(self, example_can_addressing_information,
+    #                                      message, n_bs_timeout, send_after):
+    #     """
+    #     Check for a synchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+    #     2. Send a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: UDS message record returned.
+    #     3. Validate transmitted UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=n_bs_timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                      packet=flow_control_packet,
+    #                      delay=send_after)
+    #     time_before_send = time()
+    #     message_record = can_transport_interface.send_message(message)
+    #     time_after_send = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     assert len(message_record.packets_records) > 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
+    #                for following_packet in message_record.packets_records[2:])
+    #     # timing parameters
+    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
+    #     assert len(can_transport_interface.n_bs_measured) == 1
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+    #         assert (send_after - self.TASK_TIMING_TOLERANCE
+    #                 <= can_transport_interface.n_bs_measured[0]
+    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 950),  # ms
+    #     (50, 20),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_send_message__multi_packets(self, example_can_addressing_information,
+    #                                                  message, n_bs_timeout, send_after):
+    #     """
+    #     Check for an asynchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: UDS message record returned.
+    #     3. Validate transmitted UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=n_bs_timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     send_packet_task = asyncio.create_task(self.async_send_packet(
+    #         transport_interface=can_transport_interface_2nd_node,
+    #         packet=flow_control_packet,
+    #         delay=send_after))
+    #     time_before_send = time()
+    #     message_record = await can_transport_interface.async_send_message(message)
+    #     time_after_send = time()
+    #     await send_packet_task
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     assert len(message_record.packets_records) > 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
+    #                for following_packet in message_record.packets_records[2:])
+    #     # timing parameters
+    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
+    #     assert len(can_transport_interface.n_bs_measured) == 1
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+    #         assert (send_after - self.TASK_TIMING_TOLERANCE
+    #                 <= can_transport_interface.n_bs_measured[0]
+    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
+    #     (1000, 1010),  # ms
+    #     (50, 60),
+    # ])
+    # def test_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
+    #                                                    message, n_bs_timeout, send_after):
+    #     """
+    #     Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+    #     2. Send a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=n_bs_timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                      packet=flow_control_packet,
+    #                      delay=send_after)
+    #     time_before_receive = time()
+    #     with pytest.raises(TimeoutError):
+    #         can_transport_interface.send_message(message)
+    #     time_after_receive = time()
+    #     # timing parameters
+    #     receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #     assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+    #             < receiving_time_ms
+    #             < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
+    #     (1000, 1010),  # ms
+    #     (50, 60),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
+    #                                                                message, n_bs_timeout, send_after):
+    #     """
+    #     Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=n_bs_timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     send_packet_task = asyncio.create_task(self.async_send_packet(
+    #         transport_interface=can_transport_interface_2nd_node,
+    #         packet=flow_control_packet,
+    #         delay=send_after))
+    #     time_before_receive = time()
+    #     with pytest.raises(TimeoutError):
+    #         await can_transport_interface.async_send_message(message)
+    #     time_after_receive = time()
+    #     await send_packet_task
+    #     # timing parameters
+    #     receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #     assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+    #             < receiving_time_ms
+    #             < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 2000, 950, 20),  # ms
+    #     (50, 1500, 20, 50),
+    # ])
+    # def test_receive_message__multi_packets(self, example_can_addressing_information,
+    #                                         message, start_timeout, end_timeout, send_after, delay):
+    #     """
+    #     Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+    #         UDS message (First Frame and then Consecutive Frames).
+    #     2. Call method to receive message via Transport Interface.
+    #         Expected: UDS message is received.
+    #     3. Validate received UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the received UDS message.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_br=0)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #     for i, packet in enumerate(packets):
+    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                          packet=packet,
+    #                          delay=send_after + i * delay)
+    #     time_before_receive = time()
+    #     message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
+    #                                                              end_timeout=end_timeout)
+    #     time_after_receive = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert len(message_record.packets_records) == len(packets) + 1, \
+    #         "All packets (including Flow Control) are stored"
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 2000, 950, 20),  # ms
+    #     (50, 2000, 20, 50),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
+    #                                                     message, start_timeout, end_timeout, send_after, delay):
+    #     """
+    #     Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+    #         UDS message (First Frame and then Consecutive Frames).
+    #     2. Call async method to receive message via Transport Interface.
+    #         Expected: UDS message is received.
+    #     3. Validate received UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the received UDS message.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #
+    #     async def _send_message():
+    #         for packet in packets:
+    #             await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                                          packet=packet,
+    #                                          delay=send_after if packet == packets[0] else delay)
+    #
+    #     send_message_task = asyncio.create_task(_send_message())
+    #     time_before_receive = time()
+    #     message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
+    #                                                                          end_timeout=end_timeout)
+    #     time_after_receive = time()
+    #     await send_message_task
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert len(message_record.packets_records) == len(packets) + 1, \
+    #         "All packets (including Flow Control) are stored"
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, send_after, delay", [
+    #     (1000, 50, 20),  # ms
+    #     (50, 0, 50),
+    # ])
+    # def test_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
+    #                                                       message, start_timeout, send_after, delay):
+    #     """
+    #     Check for a timeout during receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carries part of received
+    #         UDS message (First Frame and then Consecutive Frames with one Consecutive Frame missing).
+    #     2. Call method to receive message via Transport Interface.
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_br=0)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                      packet=packets[0],
+    #                      delay=send_after)
+    #     for i, cf_packet in enumerate(packets[1:-1], start=1):
+    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                          packet=cf_packet,
+    #                          delay=send_after + i * delay)
+    #     with pytest.raises(TimeoutError):
+    #         can_transport_interface.receive_message(start_timeout=start_timeout)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, send_after, delay", [
+    #     (1000, 50, 20),  # ms
+    #     (50, 0, 50),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
+    #                                                                   message, start_timeout, send_after, delay):
+    #     """
+    #     Check for a timeout during asynchronous receiving of a UDS message (carried by First Frame and
+    #     Consecutive Frame packets).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+    #         UDS message (First Frame and then Consecutive Frames).
+    #     2. Call async method to receive message via Transport Interface.
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #
+    #     async def _send_message():
+    #         for packet in packets[:-1]:
+    #             await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                                          packet=packet,
+    #                                          delay=send_after if packet == packets[0] else delay)
+    #
+    #     send_message_task = asyncio.create_task(_send_message())
+    #     with pytest.raises(TimeoutError):
+    #         await can_transport_interface.async_receive_message(start_timeout=start_timeout)
+    #     await send_message_task
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("end_timeout, send_after, delay", [
+    #     (1000, 50, 20),  # ms
+    #     (2500, 10, 50),
+    # ])
+    # def test_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
+    #                                                      message, end_timeout, send_after, delay):
+    #     """
+    #     Check for an end message timeout during synchronous multi packet (FF + CF) UDS message reception.
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+    #         UDS message (First Frame and then Consecutive Frames).
+    #     2. Call method to receive message via Transport Interface with timeout set before the entire segmented
+    #         UDS message is transmitted.
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param end_timeout: Maximal time (in milliseconds) to wait for the end of a message transmission.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_br=0)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #     for i, packet in enumerate(packets):
+    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                          packet=packet,
+    #                          delay=send_after + i * delay)
+    #     time_before_receive = time()
+    #     with pytest.raises(TimeoutError):
+    #         can_transport_interface.receive_message(start_timeout=2 * send_after + 50,
+    #                                                 end_timeout=end_timeout)
+    #     time_after_receive = time()
+    #     # timing parameters
+    #     receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #     assert (end_timeout
+    #             < receiving_time_ms
+    #             < end_timeout + self.TASK_TIMING_TOLERANCE)
 
     @pytest.mark.parametrize("message", [
         UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
@@ -1404,7 +1402,7 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
     ])
     @pytest.mark.parametrize("end_timeout, send_after, delay", [
         (1000, 50, 20),  # ms
-        (2500, 0, 50),
+        (2500, 10, 50),
     ])
     @pytest.mark.asyncio
     async def test_async_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
@@ -1447,161 +1445,165 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
             await can_transport_interface.async_receive_message(start_timeout=2 * send_after + 50,
                                                                 end_timeout=end_timeout)
         time_after_receive = time()
-        await send_message_task
+        send_message_task.cancel()
+        try:
+            await send_message_task
+        except asyncio.CancelledError:
+            ...
         # timing parameters
         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-        assert (end_timeout - self.TASK_TIMING_TOLERANCE
+        assert (end_timeout
                 < receiving_time_ms
                 < end_timeout + self.TASK_TIMING_TOLERANCE)
 
-    @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
-        (
-            UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-            0, 0, 0, 0
-        ),
-        (
-            UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
-            2, 25, 5, 120
-        ),
-        (
-            UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
-                       addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
-                       addressing_type=AddressingType.PHYSICAL),
-            0, 0, 2, 5,
-        ),
-    ])
-    def test_full_duplex(self, example_can_addressing_information,
-                         tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
-        """
-        Check for a full-duplex communication during synchronous UDS message sending.
-
-        Procedure:
-        1. Schedule receiving messages on both Transport Interfaces.
-        2. Schedule sending messages on both Transport Interfaces.
-        3. Wait till all tasks are finished (messages are sent and received).
-        4. Validate UDS message record attributes.
-            Expected: Attributes of received UDS message records are in line with messages attributes scheduled for
-                the transmission.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param tx_message: UDS message to send on interface 1 and receive on interface 2.
-        :param rx_message: UDS message to send on interface 2 and receive on interface 1.
-        :param tx_block_size: Block Size parameter value for interface 1.
-        :param tx_st_min: STmin parameter value for interface 1.
-        :param rx_block_size: Block Size parameter value for interface 2.
-        :param rx_st_min: STmin parameter value for interface 2.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
-                                                                                    st_min=tx_st_min))
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end(),
-            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
-                                                                                    st_min=rx_st_min))
-        timer_1 = self.receive_message(transport_interface=can_transport_interface_2nd_node,
-                                       delay=0,
-                                       start_timeout=50,
-                                       end_timeout=None)
-        timer_2 = self.send_message(transport_interface=can_transport_interface_2nd_node,
-                                    message=rx_message,
-                                    delay=10)
-        timer_3 = self.send_message(transport_interface=can_transport_interface,
-                                    message=tx_message,
-                                    delay=10)
-        received_rx_message_record = can_transport_interface.receive_message(start_timeout=50)
-        while not all([timer_1.finished.is_set(), timer_2.finished.is_set(), timer_3.finished.is_set()]):
-            sleep(self.TASK_TIMING_TOLERANCE / 1000.)
-        received_tx_message_record = self.received_message
-        assert isinstance(received_tx_message_record, UdsMessageRecord)
-        assert isinstance(received_rx_message_record, UdsMessageRecord)
-        assert received_tx_message_record.payload == tx_message.payload
-        assert received_tx_message_record.addressing_type == tx_message.addressing_type
-        assert received_rx_message_record.payload == rx_message.payload
-        assert received_rx_message_record.addressing_type == rx_message.addressing_type
-
-    @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
-        (
-            UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-            0, 0, 0, 0
-        ),
-        (
-            UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
-            2, 25, 5, 120
-        ),
-        (
-            UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
-                       addressing_type=AddressingType.PHYSICAL),
-            UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
-                       addressing_type=AddressingType.PHYSICAL),
-            0, 0, 2, 5,
-        ),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_full_duplex(self, example_can_addressing_information,
-                                     tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
-        """
-        Check for a full-duplex communication during asynchronous UDS message sending.
-
-        Procedure:
-        1. Schedule receiving messages on both Transport Interfaces.
-        2. Schedule sending messages on both Transport Interfaces.
-        3. Wait till all tasks are finished (messages are sent and received).
-        4. Validate UDS message record attributes.
-            Expected: Attributes of received UDS message records are in line with the transmitted UDS messages records.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param tx_message: UDS message to send on interface 1 and receive on interface 2.
-        :param rx_message: UDS message to send on interface 2 and receive on interface 1.
-        :param tx_block_size: Block Size parameter value for interface 1.
-        :param tx_st_min: STmin parameter value for interface 1.
-        :param rx_block_size: Block Size parameter value for interface 2.
-        :param rx_st_min: STmin parameter value for interface 2.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
-                                                                                    st_min=tx_st_min))
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end(),
-            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
-                                                                                    st_min=rx_st_min))
-        received_rx_message_task = asyncio.create_task(
-            can_transport_interface.async_receive_message(start_timeout=50))
-        received_tx_message_task = asyncio.create_task(
-            can_transport_interface_2nd_node.async_receive_message(start_timeout=50))
-        sent_tx_message_task = asyncio.create_task(
-            can_transport_interface.async_send_message(message=tx_message))
-        sent_rx_message_task = asyncio.create_task(
-            can_transport_interface_2nd_node.async_send_message(message=rx_message))
-        tasks = [received_tx_message_task,
-                 received_rx_message_task,
-                 sent_tx_message_task,
-                 sent_rx_message_task]
-        await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
-        received_tx_message_record = await received_tx_message_task
-        received_rx_message_record = await received_rx_message_task
-        sent_tx_message_record = await sent_tx_message_task
-        sent_rx_message_record = await sent_rx_message_task
-        assert isinstance(received_tx_message_record, UdsMessageRecord)
-        assert isinstance(received_rx_message_record, UdsMessageRecord)
-        assert isinstance(sent_tx_message_record, UdsMessageRecord)
-        assert isinstance(sent_rx_message_record, UdsMessageRecord)
-        assert received_tx_message_record.payload == sent_tx_message_record.payload == tx_message.payload
-        assert (received_tx_message_record.addressing_type == sent_tx_message_record.addressing_type
-                == tx_message.addressing_type)
-        assert received_rx_message_record.payload == sent_rx_message_record.payload == rx_message.payload
-        assert (received_rx_message_record.addressing_type == sent_rx_message_record.addressing_type
-                == rx_message.addressing_type)
+    # @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
+    #     (
+    #         UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    #         0, 0, 0, 0
+    #     ),
+    #     (
+    #         UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
+    #         2, 25, 5, 120
+    #     ),
+    #     (
+    #         UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
+    #                    addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
+    #                    addressing_type=AddressingType.PHYSICAL),
+    #         0, 0, 2, 5,
+    #     ),
+    # ])
+    # def test_full_duplex(self, example_can_addressing_information,
+    #                      tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
+    #     """
+    #     Check for a full-duplex communication during synchronous UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule receiving messages on both Transport Interfaces.
+    #     2. Schedule sending messages on both Transport Interfaces.
+    #     3. Wait till all tasks are finished (messages are sent and received).
+    #     4. Validate UDS message record attributes.
+    #         Expected: Attributes of received UDS message records are in line with messages attributes scheduled for
+    #             the transmission.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param tx_message: UDS message to send on interface 1 and receive on interface 2.
+    #     :param rx_message: UDS message to send on interface 2 and receive on interface 1.
+    #     :param tx_block_size: Block Size parameter value for interface 1.
+    #     :param tx_st_min: STmin parameter value for interface 1.
+    #     :param rx_block_size: Block Size parameter value for interface 2.
+    #     :param rx_st_min: STmin parameter value for interface 2.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
+    #                                                                                 st_min=tx_st_min))
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end(),
+    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
+    #                                                                                 st_min=rx_st_min))
+    #     timer_1 = self.receive_message(transport_interface=can_transport_interface_2nd_node,
+    #                                    delay=0,
+    #                                    start_timeout=50,
+    #                                    end_timeout=None)
+    #     timer_2 = self.send_message(transport_interface=can_transport_interface_2nd_node,
+    #                                 message=rx_message,
+    #                                 delay=10)
+    #     timer_3 = self.send_message(transport_interface=can_transport_interface,
+    #                                 message=tx_message,
+    #                                 delay=10)
+    #     received_rx_message_record = can_transport_interface.receive_message(start_timeout=50)
+    #     while not all([timer_1.finished.is_set(), timer_2.finished.is_set(), timer_3.finished.is_set()]):
+    #         sleep(self.TASK_TIMING_TOLERANCE / 1000.)
+    #     received_tx_message_record = self.received_message
+    #     assert isinstance(received_tx_message_record, UdsMessageRecord)
+    #     assert isinstance(received_rx_message_record, UdsMessageRecord)
+    #     assert received_tx_message_record.payload == tx_message.payload
+    #     assert received_tx_message_record.addressing_type == tx_message.addressing_type
+    #     assert received_rx_message_record.payload == rx_message.payload
+    #     assert received_rx_message_record.addressing_type == rx_message.addressing_type
+    #
+    # @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
+    #     (
+    #         UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    #         0, 0, 0, 0
+    #     ),
+    #     (
+    #         UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
+    #         2, 25, 5, 120
+    #     ),
+    #     (
+    #         UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
+    #                    addressing_type=AddressingType.PHYSICAL),
+    #         UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
+    #                    addressing_type=AddressingType.PHYSICAL),
+    #         0, 0, 2, 5,
+    #     ),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_full_duplex(self, example_can_addressing_information,
+    #                                  tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
+    #     """
+    #     Check for a full-duplex communication during asynchronous UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule receiving messages on both Transport Interfaces.
+    #     2. Schedule sending messages on both Transport Interfaces.
+    #     3. Wait till all tasks are finished (messages are sent and received).
+    #     4. Validate UDS message record attributes.
+    #         Expected: Attributes of received UDS message records are in line with the transmitted UDS messages records.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param tx_message: UDS message to send on interface 1 and receive on interface 2.
+    #     :param rx_message: UDS message to send on interface 2 and receive on interface 1.
+    #     :param tx_block_size: Block Size parameter value for interface 1.
+    #     :param tx_st_min: STmin parameter value for interface 1.
+    #     :param rx_block_size: Block Size parameter value for interface 2.
+    #     :param rx_st_min: STmin parameter value for interface 2.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
+    #                                                                                 st_min=tx_st_min))
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end(),
+    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
+    #                                                                                 st_min=rx_st_min))
+    #     received_rx_message_task = asyncio.create_task(
+    #         can_transport_interface.async_receive_message(start_timeout=50))
+    #     received_tx_message_task = asyncio.create_task(
+    #         can_transport_interface_2nd_node.async_receive_message(start_timeout=50))
+    #     sent_tx_message_task = asyncio.create_task(
+    #         can_transport_interface.async_send_message(message=tx_message))
+    #     sent_rx_message_task = asyncio.create_task(
+    #         can_transport_interface_2nd_node.async_send_message(message=rx_message))
+    #     tasks = [received_tx_message_task,
+    #              received_rx_message_task,
+    #              sent_tx_message_task,
+    #              sent_rx_message_task]
+    #     await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+    #     received_tx_message_record = await received_tx_message_task
+    #     received_rx_message_record = await received_rx_message_task
+    #     sent_tx_message_record = await sent_tx_message_task
+    #     sent_rx_message_record = await sent_rx_message_task
+    #     assert isinstance(received_tx_message_record, UdsMessageRecord)
+    #     assert isinstance(received_rx_message_record, UdsMessageRecord)
+    #     assert isinstance(sent_tx_message_record, UdsMessageRecord)
+    #     assert isinstance(sent_rx_message_record, UdsMessageRecord)
+    #     assert received_tx_message_record.payload == sent_tx_message_record.payload == tx_message.payload
+    #     assert (received_tx_message_record.addressing_type == sent_tx_message_record.addressing_type
+    #             == tx_message.addressing_type)
+    #     assert received_rx_message_record.payload == sent_rx_message_record.payload == rx_message.payload
+    #     assert (received_rx_message_record.addressing_type == sent_rx_message_record.addressing_type
+    #             == rx_message.addressing_type)
 
 
 class AbstractUseCaseTests(AbstractPythonCanTests, ABC):

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -1352,8 +1352,8 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         UdsMessage(payload=[0x62, 0x12, 0x34] + [*range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
     ])
     @pytest.mark.parametrize("end_timeout, send_after, delay", [
-        (1000, 50, 20),  # ms
-        (2500, 10, 50),
+        (100, 50, 20),  # ms
+        (1500, 10, 50),
     ])
     def test_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
                                                          message, end_timeout, send_after, delay):
@@ -1401,8 +1401,8 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
         UdsMessage(payload=[0x62, 0x12, 0x34] + [*range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
     ])
     @pytest.mark.parametrize("end_timeout, send_after, delay", [
-        (1000, 50, 20),  # ms
-        (2500, 10, 50),
+        (100, 50, 20),  # ms
+        (1500, 10, 50),
     ])
     @pytest.mark.asyncio
     async def test_async_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -603,677 +603,671 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
 class AbstractMessageTests(AbstractPythonCanTests, ABC):
     """Common implementation of system tests related to sending and receiving UDS (DoCAN) messages."""
 
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # def test_send_message__sf(self, example_can_addressing_information, message):
-    #     """
-    #     Check for a simple synchronous UDS message sending.
-    #
-    #     Procedure:
-    #     1. Send a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: UDS message record returned.
-    #     2. Validate transmitted UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     time_before_send = time()
-    #     message_record = can_transport_interface.send_message(message)
-    #     time_after_send = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start == message_record.transmission_end
-    #     assert len(message_record.packets_records) == 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-    #     # timing parameters
-    #     assert can_transport_interface.n_bs_measured is None
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start
-    #                 == message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_send_message__sf(self, example_can_addressing_information, message):
-    #     """
-    #     Check for a simple asynchronous UDS message sending.
-    #
-    #     Procedure:
-    #     1. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: UDS message record returned.
-    #     2. Validate transmitted UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     time_before_send = time()
-    #     message_record = await can_transport_interface.async_send_message(message)
-    #     time_after_send = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start == message_record.transmission_end
-    #     assert len(message_record.packets_records) == 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-    #     # timing parameters
-    #     assert can_transport_interface.n_bs_measured is None
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start
-    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, send_after", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 950),  # ms
-    #     (50, 20),
-    # ])
-    # def test_receive_message__sf(self, example_can_addressing_information,
-    #                              message, start_timeout, send_after):
-    #     """
-    #     Check for receiving of a UDS message (carried by Single Frame packet).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
-    #         UDS message (Single Frame).
-    #     2. Call method to receive message via Transport Interface with timeout set just after UDS message
-    #         reaches CAN bus.
-    #         Expected: UDS message is received.
-    #     3. Validate received UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the received UDS message.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     self.send_message(transport_interface=can_transport_interface_2nd_node,
-    #                       message=message,
-    #                       delay=send_after)
-    #     time_before_receive = time()
-    #     message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
-    #                                                                          end_timeout=start_timeout + 1000.)
-    #     time_after_receive = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start == message_record.transmission_end
-    #     assert len(message_record.packets_records) == 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start
-    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, send_after", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 950),  # ms
-    #     (50, 20),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_receive_message__sf(self, example_can_addressing_information,
-    #                                          message, start_timeout, send_after):
-    #     """
-    #     Check for asynchronous receiving of a UDS message (carried by Single Frame packet).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
-    #         UDS message (Single Frame).
-    #     2. Call async method to receive message via Transport Interface with timeout set just after UDS message
-    #         reaches CAN bus.
-    #         Expected: UDS message is received.
-    #     3. Validate received UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the received UDS message.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     send_message_task = asyncio.create_task(
-    #         self.async_send_message(transport_interface=can_transport_interface_2nd_node,
-    #                                 message=message,
-    #                                 delay=send_after))
-    #     time_before_receive = time()
-    #     message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
-    #                                                                          end_timeout=start_timeout + 1000.)
-    #     time_after_receive = time()
-    #     await send_message_task
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start == message_record.transmission_end
-    #     assert len(message_record.packets_records) == 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start
-    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, send_after", [
-    #     (1000, 1010),  # ms
-    #     (50, 60),
-    # ])
-    # def test_receive_message__sf__start_timeout(self, example_can_addressing_information,
-    #                                             message, start_timeout, send_after):
-    #     """
-    #     Check for a timeout during receiving of a UDS message.
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
-    #     2. Call method to receive message via Transport Interface with timeout set just before UDS message
-    #         reaches CAN bus.
-    #         Expected: Timeout exception is raised.
-    #     3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
-    #         Expected: Message is received.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     self.send_message(transport_interface=can_transport_interface_2nd_node,
-    #                       message=message,
-    #                       delay=send_after)
-    #     time_before_receive = time()
-    #     with pytest.raises(TimeoutError):
-    #         can_transport_interface.receive_message(start_timeout=start_timeout,
-    #                                                 end_timeout=start_timeout + 1000.)
-    #     time_after_receive = time()
-    #     # receive message later
-    #     message_record = can_transport_interface.receive_message(
-    #         start_timeout=(send_after - start_timeout) * 10,
-    #         end_timeout=(send_after - start_timeout) * 10 + 1000.)
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #         assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, send_after", [
-    #     (1000, 1010),  # ms
-    #     (50, 60),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_receive_message__sf__timeout(self, example_can_addressing_information,
-    #                                                   message, start_timeout, send_after):
-    #     """
-    #     Check for a timeout during asynchronous receiving of a UDS message.
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
-    #     2. Call async method to receive message via Transport Interface with timeout set before any CAN packet
-    #         reaches CAN bus.
-    #         Expected: Timeout exception is raised.
-    #     3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
-    #         Expected: Message is received.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     send_message_task = asyncio.create_task(self.async_send_message(
-    #         transport_interface=can_transport_interface_2nd_node,
-    #         message=message,
-    #         delay=send_after))
-    #     time_before_receive = time()
-    #     with pytest.raises(TimeoutError):
-    #         await can_transport_interface.async_receive_message(start_timeout=start_timeout,
-    #                                                             end_timeout=start_timeout + 1000.)
-    #     time_after_receive = time()
-    #     # receive message later
-    #     message_record = await can_transport_interface.async_receive_message(
-    #         start_timeout=(send_after - start_timeout) * 10,
-    #         end_timeout=(send_after - start_timeout) * 10 + 1000.)
-    #     await send_message_task
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #         assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("timeout, send_after", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 950),  # ms
-    #     (50, 20),
-    # ])
-    # def test_send_message__multi_packets(self, example_can_addressing_information,
-    #                                      message, timeout, send_after):
-    #     """
-    #     Check for a synchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-    #     2. Send a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: UDS message record returned.
-    #     3. Validate transmitted UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                      packet=flow_control_packet,
-    #                      delay=send_after)
-    #     time_before_send = time()
-    #     message_record = can_transport_interface.send_message(message)
-    #     time_after_send = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     assert len(message_record.packets_records) > 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
-    #                for following_packet in message_record.packets_records[2:])
-    #     # timing parameters
-    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
-    #     assert len(can_transport_interface.n_bs_measured) == 1
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-    #         assert (send_after - self.TASK_TIMING_TOLERANCE
-    #                 <= can_transport_interface.n_bs_measured[0]
-    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("timeout, send_after", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 950),  # ms
-    #     (50, 20),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_send_message__multi_packets(self, example_can_addressing_information,
-    #                                                  message, timeout, send_after):
-    #     """
-    #     Check for an asynchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: UDS message record returned.
-    #     3. Validate transmitted UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     send_packet_task = asyncio.create_task(self.async_send_packet(
-    #         transport_interface=can_transport_interface_2nd_node,
-    #         packet=flow_control_packet,
-    #         delay=send_after))
-    #     time_before_send = time()
-    #     message_record = await can_transport_interface.async_send_message(message)
-    #     time_after_send = time()
-    #     await send_packet_task
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     assert len(message_record.packets_records) > 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
-    #                for following_packet in message_record.packets_records[2:])
-    #     # timing parameters
-    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
-    #     assert len(can_transport_interface.n_bs_measured) == 1
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-    #         assert (send_after - self.TASK_TIMING_TOLERANCE
-    #                 <= can_transport_interface.n_bs_measured[0]
-    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("timeout, send_after", [
-    #     (1000, 1010),  # ms
-    #     (50, 60),
-    # ])
-    # def test_send_message__multi_packets__timeout(self, example_can_addressing_information,
-    #                                               message, timeout, send_after):
-    #     """
-    #     Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-    #     2. Send a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                      packet=flow_control_packet,
-    #                      delay=send_after)
-    #     time_before_receive = time()
-    #     with pytest.raises(TimeoutError):
-    #         can_transport_interface.send_message(message)
-    #     time_after_receive = time()
-    #     # timing parameters
-    #     receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #     assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-    #             < receiving_time_ms
-    #             < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("timeout, send_after", [
-    #     (1000, 1010),  # ms
-    #     (50, 60),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_send_message__multi_packets__timeout(self, example_can_addressing_information,
-    #                                                           message, timeout, send_after):
-    #     """
-    #     Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     send_packet_task = asyncio.create_task(self.async_send_packet(
-    #         transport_interface=can_transport_interface_2nd_node,
-    #         packet=flow_control_packet,
-    #         delay=send_after))
-    #     time_before_receive = time()
-    #     with pytest.raises(TimeoutError):
-    #         await can_transport_interface.async_send_message(message)
-    #     time_after_receive = time()
-    #     await send_packet_task
-    #     # timing parameters
-    #     receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #     assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-    #             < receiving_time_ms
-    #             < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 2000, 950, 20),  # ms
-    #     (50, 2000, 20, 50),
-    # ])
-    # def test_receive_message__multi_packets(self, example_can_addressing_information,
-    #                                         message, start_timeout, end_timeout, send_after, delay):
-    #     """
-    #     Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-    #         UDS message (First Frame and then Consecutive Frames).
-    #     2. Call method to receive message via Transport Interface.
-    #         Expected: UDS message is received.
-    #     3. Validate received UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the received UDS message.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_br=0)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #     for i, packet in enumerate(packets):
-    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                          packet=packet,
-    #                          delay=send_after + i * delay)
-    #     time_before_receive = time()
-    #     message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
-    #                                                              end_timeout=end_timeout)
-    #     time_after_receive = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert len(message_record.packets_records) == len(packets) + 1, \
-    #         "All packets (including Flow Control) are stored"
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 2000, 950, 20),  # ms
-    #     (50, 2000, 20, 50),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
-    #                                                     message, start_timeout, end_timeout, send_after, delay):
-    #     """
-    #     Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-    #         UDS message (First Frame and then Consecutive Frames).
-    #     2. Call async method to receive message via Transport Interface.
-    #         Expected: UDS message is received.
-    #     3. Validate received UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the received UDS message.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #
-    #     async def _send_message():
-    #         for packet in packets:
-    #             await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                                          packet=packet,
-    #                                          delay=send_after if packet == packets[0] else delay)
-    #
-    #     send_message_task = asyncio.create_task(_send_message())
-    #     time_before_receive = time()
-    #     message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
-    #                                                                          end_timeout=end_timeout)
-    #     time_after_receive = time()
-    #     await send_message_task
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert len(message_record.packets_records) == len(packets) + 1, \
-    #         "All packets (including Flow Control) are stored"
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    def test_send_message__sf(self, example_can_addressing_information, message):
+        """
+        Check for a simple synchronous UDS message sending.
 
-    # TODO: continue rework here
+        Procedure:
+        1. Send a UDS message using Transport Interface (via CAN Interface).
+            Expected: UDS message record returned.
+        2. Validate transmitted UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        time_before_send = time()
+        message_record = can_transport_interface.send_message(message)
+        time_after_send = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.TRANSMITTED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start == message_record.transmission_end
+        assert len(message_record.packets_records) == 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+        # timing parameters
+        assert can_transport_interface.n_bs_measured is None
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start
+                    == message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_send_message__sf(self, example_can_addressing_information, message):
+        """
+        Check for a simple asynchronous UDS message sending.
+
+        Procedure:
+        1. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+            Expected: UDS message record returned.
+        2. Validate transmitted UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        time_before_send = time()
+        message_record = await can_transport_interface.async_send_message(message)
+        time_after_send = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.TRANSMITTED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start == message_record.transmission_end
+        assert len(message_record.packets_records) == 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+        # timing parameters
+        assert can_transport_interface.n_bs_measured is None
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start
+                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    @pytest.mark.parametrize("timeout, send_after", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 950),  # ms
+        (50, 20),
+    ])
+    def test_receive_message__sf(self, example_can_addressing_information,
+                                 message, timeout, send_after):
+        """
+        Check for receiving of a UDS message (carried by Single Frame packet).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
+            UDS message (Single Frame).
+        2. Call method to receive message via Transport Interface with timeout set just after UDS message
+            reaches CAN bus.
+            Expected: UDS message is received.
+        3. Validate received UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the received UDS message.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param timeout: Maximal time (in milliseconds) to wait for the message transmission.
+        :param send_after: Time when to send CAN frame after call of receive method [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        self.send_message(transport_interface=can_transport_interface_2nd_node,
+                          message=message,
+                          delay=send_after)
+        time_before_receive = time()
+        message_record = can_transport_interface.receive_message(start_timeout=timeout,
+                                                                 end_timeout=timeout)
+        time_after_receive = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start == message_record.transmission_end
+        assert len(message_record.packets_records) == 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start
+                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    @pytest.mark.parametrize("timeout, send_after", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 950),  # ms
+        (50, 20),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_receive_message__sf(self, example_can_addressing_information,
+                                             message, timeout, send_after):
+        """
+        Check for asynchronous receiving of a UDS message (carried by Single Frame packet).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
+            UDS message (Single Frame).
+        2. Call async method to receive message via Transport Interface with timeout set just after UDS message
+            reaches CAN bus.
+            Expected: UDS message is received.
+        3. Validate received UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the received UDS message.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param timeout: Maximal time (in milliseconds) to wait for the message transmission.
+        :param send_after: Time when to send CAN frame after call of receive method [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        send_message_task = asyncio.create_task(
+            self.async_send_message(transport_interface=can_transport_interface_2nd_node,
+                                    message=message,
+                                    delay=send_after))
+        time_before_receive = time()
+        message_record = await can_transport_interface.async_receive_message(start_timeout=timeout,
+                                                                             end_timeout=timeout)
+        time_after_receive = time()
+        await send_message_task
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start == message_record.transmission_end
+        assert len(message_record.packets_records) == 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start
+                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, send_after", [
+        (1000, 1010),  # ms
+        (50, 60),
+    ])
+    def test_receive_message__sf__start_timeout(self, example_can_addressing_information,
+                                                message, start_timeout, send_after):
+        """
+        Check for a timeout during receiving of a UDS message.
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
+        2. Call method to receive message via Transport Interface with timeout set just before UDS message
+            reaches CAN bus.
+            Expected: Timeout exception is raised.
+        3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
+            Expected: Message is received.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send CAN frame after call of receive method [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        self.send_message(transport_interface=can_transport_interface_2nd_node,
+                          message=message,
+                          delay=send_after)
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            can_transport_interface.receive_message(start_timeout=start_timeout)
+        time_after_receive = time()
+        # receive message later
+        message_record = can_transport_interface.receive_message(
+            start_timeout=(send_after - start_timeout) * 10)
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+            assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, send_after", [
+        (1000, 1010),  # ms
+        (50, 60),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_receive_message__sf__start_timeout(self, example_can_addressing_information,
+                                                            message, start_timeout, send_after):
+        """
+        Check for a timeout during asynchronous receiving of a UDS message.
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
+        2. Call async method to receive message via Transport Interface with timeout set before any CAN packet
+            reaches CAN bus.
+            Expected: Timeout exception is raised.
+        3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
+            Expected: Message is received.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send CAN frame after call of receive method [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        send_message_task = asyncio.create_task(self.async_send_message(
+            transport_interface=can_transport_interface_2nd_node,
+            message=message,
+            delay=send_after))
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            await can_transport_interface.async_receive_message(start_timeout=start_timeout)
+        time_after_receive = time()
+        # receive message later
+        message_record = await can_transport_interface.async_receive_message(
+            start_timeout=(send_after - start_timeout) * 10)
+        await send_message_task
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+            assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
 
     @pytest.mark.parametrize("message", [
         UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
         UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
     ])
-    @pytest.mark.parametrize("timeout, send_after, delay", [
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 950),  # ms
+        (50, 20),
+    ])
+    def test_send_message__multi_packets(self, example_can_addressing_information,
+                                         message, n_bs_timeout, send_after):
+        """
+        Check for a synchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+        2. Send a UDS message using Transport Interface (via CAN Interface).
+            Expected: UDS message record returned.
+        3. Validate transmitted UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                         packet=flow_control_packet,
+                         delay=send_after)
+        time_before_send = time()
+        message_record = can_transport_interface.send_message(message)
+        time_after_send = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.TRANSMITTED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        assert len(message_record.packets_records) > 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+                   and following_packet.direction == TransmissionDirection.TRANSMITTED
+                   for following_packet in message_record.packets_records[2:])
+        # timing parameters
+        assert isinstance(can_transport_interface.n_bs_measured, tuple)
+        assert len(can_transport_interface.n_bs_measured) == 1
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+            assert (send_after - self.TASK_TIMING_TOLERANCE
+                    <= can_transport_interface.n_bs_measured[0]
+                    <= send_after + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 950),  # ms
+        (50, 20),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_send_message__multi_packets(self, example_can_addressing_information,
+                                                     message, n_bs_timeout, send_after):
+        """
+        Check for an asynchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+            Expected: UDS message record returned.
+        3. Validate transmitted UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        send_packet_task = asyncio.create_task(self.async_send_packet(
+            transport_interface=can_transport_interface_2nd_node,
+            packet=flow_control_packet,
+            delay=send_after))
+        time_before_send = time()
+        message_record = await can_transport_interface.async_send_message(message)
+        time_after_send = time()
+        await send_packet_task
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.TRANSMITTED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        assert len(message_record.packets_records) > 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+                   and following_packet.direction == TransmissionDirection.TRANSMITTED
+                   for following_packet in message_record.packets_records[2:])
+        # timing parameters
+        assert isinstance(can_transport_interface.n_bs_measured, tuple)
+        assert len(can_transport_interface.n_bs_measured) == 1
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+            assert (send_after - self.TASK_TIMING_TOLERANCE
+                    <= can_transport_interface.n_bs_measured[0]
+                    <= send_after + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        (1000, 1010),  # ms
+        (50, 60),
+    ])
+    def test_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
+                                                       message, n_bs_timeout, send_after):
+        """
+        Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+        2. Send a UDS message using Transport Interface (via CAN Interface).
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                         packet=flow_control_packet,
+                         delay=send_after)
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            can_transport_interface.send_message(message)
+        time_after_receive = time()
+        # timing parameters
+        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+        assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+                < receiving_time_ms
+                < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        (1000, 1010),  # ms
+        (50, 60),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
+                                                                   message, n_bs_timeout, send_after):
+        """
+        Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        send_packet_task = asyncio.create_task(self.async_send_packet(
+            transport_interface=can_transport_interface_2nd_node,
+            packet=flow_control_packet,
+            delay=send_after))
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            await can_transport_interface.async_send_message(message)
+        time_after_receive = time()
+        await send_packet_task
+        # timing parameters
+        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+        assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+                < receiving_time_ms
+                < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 2000, 950, 20),  # ms
+        (50, 1500, 20, 50),
+    ])
+    def test_receive_message__multi_packets(self, example_can_addressing_information,
+                                            message, start_timeout, end_timeout, send_after, delay):
+        """
+        Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call method to receive message via Transport Interface.
+            Expected: UDS message is received.
+        3. Validate received UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the received UDS message.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+        for i, packet in enumerate(packets):
+            self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                             packet=packet,
+                             delay=send_after + i * delay)
+        time_before_receive = time()
+        message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
+                                                                 end_timeout=end_timeout)
+        time_after_receive = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert len(message_record.packets_records) == len(packets) + 1, \
+            "All packets (including Flow Control) are stored"
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 2000, 950, 20),  # ms
+        (50, 2000, 20, 50),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
+                                                        message, start_timeout, end_timeout, send_after, delay):
+        """
+        Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call async method to receive message via Transport Interface.
+            Expected: UDS message is received.
+        3. Validate received UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the received UDS message.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+
+        async def _send_message():
+            for packet in packets:
+                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+                                             packet=packet,
+                                             delay=send_after if packet == packets[0] else delay)
+
+        send_message_task = asyncio.create_task(_send_message())
+        time_before_receive = time()
+        message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
+                                                                             end_timeout=end_timeout)
+        time_after_receive = time()
+        await send_message_task
+        assert isinstance(message_record, UdsMessageRecord)
+        assert len(message_record.packets_records) == len(packets) + 1, \
+            "All packets (including Flow Control) are stored"
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, send_after, delay", [
         (1000, 50, 20),  # ms
         (50, 0, 50),
     ])
-    def test_receive_message__multi_packets__timeout(self, example_can_addressing_information,
-                                                     message, timeout, send_after, delay):
+    def test_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
+                                                          message, start_timeout, send_after, delay):
         """
         Check for a timeout during receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
 
@@ -1285,7 +1279,7 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
 
         :param example_can_addressing_information: Addressing Information of receiving CAN Node.
         :param message: UDS message to transmit.
-        :param timeout: Timeout value to pass to receive message method [ms].
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
         :param send_after: Time when to send First Frame after call of receive method [ms].
         :param delay: Time distance to use for sending Consecutive Frames [ms].
         """
@@ -1305,19 +1299,19 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
                              packet=cf_packet,
                              delay=send_after + i * delay)
         with pytest.raises(TimeoutError):
-            can_transport_interface.receive_message(start_timeout=timeout)
+            can_transport_interface.receive_message(start_timeout=start_timeout)
 
     @pytest.mark.parametrize("message", [
         UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
         UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
     ])
-    @pytest.mark.parametrize("timeout, send_after, delay", [
+    @pytest.mark.parametrize("start_timeout, send_after, delay", [
         (1000, 50, 20),  # ms
         (50, 0, 50),
     ])
     @pytest.mark.asyncio
-    async def test_async_receive_message__multi_packets__timeout(self, example_can_addressing_information,
-                                                                 message, timeout, send_after, delay):
+    async def test_async_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
+                                                                      message, start_timeout, send_after, delay):
         """
         Check for a timeout during asynchronous receiving of a UDS message (carried by First Frame and
         Consecutive Frame packets).
@@ -1330,7 +1324,7 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
 
         :param example_can_addressing_information: Addressing Information of receiving CAN Node.
         :param message: UDS message to transmit.
-        :param timeout: Timeout value to pass to receive message method [ms].
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
         :param send_after: Time when to send First Frame after call of receive method [ms].
         :param delay: Time distance to use for sending Consecutive Frames [ms].
         """
@@ -1350,156 +1344,263 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
 
         send_message_task = asyncio.create_task(_send_message())
         with pytest.raises(TimeoutError):
-            await can_transport_interface.async_receive_message(start_timeout=timeout)
+            await can_transport_interface.async_receive_message(start_timeout=start_timeout)
         await send_message_task
 
-    # @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
-    #     (
-    #         UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    #         0, 0, 0, 0
-    #     ),
-    #     (
-    #         UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
-    #         2, 25, 5, 120
-    #     ),
-    #     (
-    #         UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
-    #                    addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
-    #                    addressing_type=AddressingType.PHYSICAL),
-    #         0, 0, 2, 5,
-    #     ),
-    # ])
-    # def test_full_duplex(self, example_can_addressing_information,
-    #                      tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
-    #     """
-    #     Check for a full-duplex communication during synchronous UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule receiving messages on both Transport Interfaces.
-    #     2. Schedule sending messages on both Transport Interfaces.
-    #     3. Wait till all tasks are finished (messages are sent and received).
-    #     4. Validate UDS message record attributes.
-    #         Expected: Attributes of received UDS message records are in line with messages attributes scheduled for
-    #             the transmission.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param tx_message: UDS message to send on interface 1 and receive on interface 2.
-    #     :param rx_message: UDS message to send on interface 2 and receive on interface 1.
-    #     :param tx_block_size: Block Size parameter value for interface 1.
-    #     :param tx_st_min: STmin parameter value for interface 1.
-    #     :param rx_block_size: Block Size parameter value for interface 2.
-    #     :param rx_st_min: STmin parameter value for interface 2.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
-    #                                                                                 st_min=tx_st_min))
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end(),
-    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
-    #                                                                                 st_min=rx_st_min))
-    #     timer_1 = self.receive_message(transport_interface=can_transport_interface_2nd_node,
-    #                                    delay=0,
-    #                                    timeout=50)
-    #     timer_2 = self.send_message(transport_interface=can_transport_interface_2nd_node,
-    #                                 message=rx_message,
-    #                                 delay=10)
-    #     timer_3 = self.send_message(transport_interface=can_transport_interface,
-    #                                 message=tx_message,
-    #                                 delay=10)
-    #     received_rx_message_record = can_transport_interface.receive_message(start_timeout=50)
-    #     while not all([timer_1.finished.is_set(), timer_2.finished.is_set(), timer_3.finished.is_set()]):
-    #         sleep(self.TASK_TIMING_TOLERANCE / 1000.)
-    #     received_tx_message_record = self.received_message
-    #     assert isinstance(received_tx_message_record, UdsMessageRecord)
-    #     assert isinstance(received_rx_message_record, UdsMessageRecord)
-    #     assert received_tx_message_record.payload == tx_message.payload
-    #     assert received_tx_message_record.addressing_type == tx_message.addressing_type
-    #     assert received_rx_message_record.payload == rx_message.payload
-    #     assert received_rx_message_record.addressing_type == rx_message.addressing_type
-    #
-    # @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
-    #     (
-    #         UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    #         0, 0, 0, 0
-    #     ),
-    #     (
-    #         UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
-    #         2, 25, 5, 120
-    #     ),
-    #     (
-    #         UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
-    #                    addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
-    #                    addressing_type=AddressingType.PHYSICAL),
-    #         0, 0, 2, 5,
-    #     ),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_full_duplex(self, example_can_addressing_information,
-    #                                  tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
-    #     """
-    #     Check for a full-duplex communication during asynchronous UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule receiving messages on both Transport Interfaces.
-    #     2. Schedule sending messages on both Transport Interfaces.
-    #     3. Wait till all tasks are finished (messages are sent and received).
-    #     4. Validate UDS message record attributes.
-    #         Expected: Attributes of received UDS message records are in line with the transmitted UDS messages records.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param tx_message: UDS message to send on interface 1 and receive on interface 2.
-    #     :param rx_message: UDS message to send on interface 2 and receive on interface 1.
-    #     :param tx_block_size: Block Size parameter value for interface 1.
-    #     :param tx_st_min: STmin parameter value for interface 1.
-    #     :param rx_block_size: Block Size parameter value for interface 2.
-    #     :param rx_st_min: STmin parameter value for interface 2.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
-    #                                                                                 st_min=tx_st_min))
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end(),
-    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
-    #                                                                                 st_min=rx_st_min))
-    #     received_rx_message_task = asyncio.create_task(
-    #         can_transport_interface.async_receive_message(start_timeout=50))
-    #     received_tx_message_task = asyncio.create_task(
-    #         can_transport_interface_2nd_node.async_receive_message(start_timeout=50))
-    #     sent_tx_message_task = asyncio.create_task(
-    #         can_transport_interface.async_send_message(message=tx_message))
-    #     sent_rx_message_task = asyncio.create_task(
-    #         can_transport_interface_2nd_node.async_send_message(message=rx_message))
-    #     tasks = [received_tx_message_task,
-    #              received_rx_message_task,
-    #              sent_tx_message_task,
-    #              sent_rx_message_task]
-    #     await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
-    #     received_tx_message_record = await received_tx_message_task
-    #     received_rx_message_record = await received_rx_message_task
-    #     sent_tx_message_record = await sent_tx_message_task
-    #     sent_rx_message_record = await sent_rx_message_task
-    #     assert isinstance(received_tx_message_record, UdsMessageRecord)
-    #     assert isinstance(received_rx_message_record, UdsMessageRecord)
-    #     assert isinstance(sent_tx_message_record, UdsMessageRecord)
-    #     assert isinstance(sent_rx_message_record, UdsMessageRecord)
-    #     assert received_tx_message_record.payload == sent_tx_message_record.payload == tx_message.payload
-    #     assert (received_tx_message_record.addressing_type == sent_tx_message_record.addressing_type
-    #             == tx_message.addressing_type)
-    #     assert received_rx_message_record.payload == sent_rx_message_record.payload == rx_message.payload
-    #     assert (received_rx_message_record.addressing_type == sent_rx_message_record.addressing_type
-    #             == rx_message.addressing_type)
+    # TODO: add end timeout
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("end_timeout, send_after, delay", [
+        (1000, 50, 20),  # ms
+        (2500, 0, 50),
+    ])
+    def test_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
+                                                         message, end_timeout, send_after, delay):
+        """
+        Check for an end message timeout during synchronous multi packet (FF + CF) UDS message reception.
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call method to receive message via Transport Interface with timeout set before the entire segmented
+            UDS message is transmitted.
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param end_timeout: Maximal time (in milliseconds) to wait for the end of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+        for i, packet in enumerate(packets):
+            self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                             packet=packet,
+                             delay=send_after + i * delay)
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            can_transport_interface.receive_message(start_timeout=2 * send_after + 50,
+                                                    end_timeout=end_timeout)
+        time_after_receive = time()
+        # timing parameters
+        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+        assert (end_timeout - self.TASK_TIMING_TOLERANCE
+                < receiving_time_ms
+                < end_timeout + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("end_timeout, send_after, delay", [
+        (1000, 50, 20),  # ms
+        (2500, 0, 50),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
+                                                                     message, end_timeout, send_after, delay):
+        """
+        Check for an end message timeout during asynchronous multi packet (FF + CF) UDS message reception.
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call method to receive message via Transport Interface with timeout set before the entire segmented
+            UDS message is transmitted.
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param end_timeout: Maximal time (in milliseconds) to wait for the end of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+
+        async def _send_message():
+            for packet in packets[:-1]:
+                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+                                             packet=packet,
+                                             delay=send_after if packet == packets[0] else delay)
+
+        send_message_task = asyncio.create_task(_send_message())
+
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            await can_transport_interface.async_receive_message(start_timeout=2 * send_after + 50,
+                                                                end_timeout=end_timeout)
+        time_after_receive = time()
+        await send_message_task
+        # timing parameters
+        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+        assert (end_timeout - self.TASK_TIMING_TOLERANCE
+                < receiving_time_ms
+                < end_timeout + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
+        (
+            UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+            0, 0, 0, 0
+        ),
+        (
+            UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
+            2, 25, 5, 120
+        ),
+        (
+            UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
+                       addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
+                       addressing_type=AddressingType.PHYSICAL),
+            0, 0, 2, 5,
+        ),
+    ])
+    def test_full_duplex(self, example_can_addressing_information,
+                         tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
+        """
+        Check for a full-duplex communication during synchronous UDS message sending.
+
+        Procedure:
+        1. Schedule receiving messages on both Transport Interfaces.
+        2. Schedule sending messages on both Transport Interfaces.
+        3. Wait till all tasks are finished (messages are sent and received).
+        4. Validate UDS message record attributes.
+            Expected: Attributes of received UDS message records are in line with messages attributes scheduled for
+                the transmission.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param tx_message: UDS message to send on interface 1 and receive on interface 2.
+        :param rx_message: UDS message to send on interface 2 and receive on interface 1.
+        :param tx_block_size: Block Size parameter value for interface 1.
+        :param tx_st_min: STmin parameter value for interface 1.
+        :param rx_block_size: Block Size parameter value for interface 2.
+        :param rx_st_min: STmin parameter value for interface 2.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
+                                                                                    st_min=tx_st_min))
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end(),
+            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
+                                                                                    st_min=rx_st_min))
+        timer_1 = self.receive_message(transport_interface=can_transport_interface_2nd_node,
+                                       delay=0,
+                                       timeout=50)
+        timer_2 = self.send_message(transport_interface=can_transport_interface_2nd_node,
+                                    message=rx_message,
+                                    delay=10)
+        timer_3 = self.send_message(transport_interface=can_transport_interface,
+                                    message=tx_message,
+                                    delay=10)
+        received_rx_message_record = can_transport_interface.receive_message(start_timeout=50)
+        while not all([timer_1.finished.is_set(), timer_2.finished.is_set(), timer_3.finished.is_set()]):
+            sleep(self.TASK_TIMING_TOLERANCE / 1000.)
+        received_tx_message_record = self.received_message
+        assert isinstance(received_tx_message_record, UdsMessageRecord)
+        assert isinstance(received_rx_message_record, UdsMessageRecord)
+        assert received_tx_message_record.payload == tx_message.payload
+        assert received_tx_message_record.addressing_type == tx_message.addressing_type
+        assert received_rx_message_record.payload == rx_message.payload
+        assert received_rx_message_record.addressing_type == rx_message.addressing_type
+
+    @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
+        (
+            UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+            0, 0, 0, 0
+        ),
+        (
+            UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
+            2, 25, 5, 120
+        ),
+        (
+            UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
+                       addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
+                       addressing_type=AddressingType.PHYSICAL),
+            0, 0, 2, 5,
+        ),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_full_duplex(self, example_can_addressing_information,
+                                     tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
+        """
+        Check for a full-duplex communication during asynchronous UDS message sending.
+
+        Procedure:
+        1. Schedule receiving messages on both Transport Interfaces.
+        2. Schedule sending messages on both Transport Interfaces.
+        3. Wait till all tasks are finished (messages are sent and received).
+        4. Validate UDS message record attributes.
+            Expected: Attributes of received UDS message records are in line with the transmitted UDS messages records.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param tx_message: UDS message to send on interface 1 and receive on interface 2.
+        :param rx_message: UDS message to send on interface 2 and receive on interface 1.
+        :param tx_block_size: Block Size parameter value for interface 1.
+        :param tx_st_min: STmin parameter value for interface 1.
+        :param rx_block_size: Block Size parameter value for interface 2.
+        :param rx_st_min: STmin parameter value for interface 2.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
+                                                                                    st_min=tx_st_min))
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end(),
+            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
+                                                                                    st_min=rx_st_min))
+        received_rx_message_task = asyncio.create_task(
+            can_transport_interface.async_receive_message(start_timeout=50))
+        received_tx_message_task = asyncio.create_task(
+            can_transport_interface_2nd_node.async_receive_message(start_timeout=50))
+        sent_tx_message_task = asyncio.create_task(
+            can_transport_interface.async_send_message(message=tx_message))
+        sent_rx_message_task = asyncio.create_task(
+            can_transport_interface_2nd_node.async_send_message(message=rx_message))
+        tasks = [received_tx_message_task,
+                 received_rx_message_task,
+                 sent_tx_message_task,
+                 sent_rx_message_task]
+        await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+        received_tx_message_record = await received_tx_message_task
+        received_rx_message_record = await received_rx_message_task
+        sent_tx_message_record = await sent_tx_message_task
+        sent_rx_message_record = await sent_rx_message_task
+        assert isinstance(received_tx_message_record, UdsMessageRecord)
+        assert isinstance(received_rx_message_record, UdsMessageRecord)
+        assert isinstance(sent_tx_message_record, UdsMessageRecord)
+        assert isinstance(sent_rx_message_record, UdsMessageRecord)
+        assert received_tx_message_record.payload == sent_tx_message_record.payload == tx_message.payload
+        assert (received_tx_message_record.addressing_type == sent_tx_message_record.addressing_type
+                == tx_message.addressing_type)
+        assert received_rx_message_record.payload == sent_rx_message_record.payload == rx_message.payload
+        assert (received_rx_message_record.addressing_type == sent_rx_message_record.addressing_type
+                == rx_message.addressing_type)
 
 
 class AbstractUseCaseTests(AbstractPythonCanTests, ABC):

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -603,802 +603,802 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
 class AbstractMessageTests(AbstractPythonCanTests, ABC):
     """Common implementation of system tests related to sending and receiving UDS (DoCAN) messages."""
 
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # def test_send_message__sf(self, example_can_addressing_information, message):
-    #     """
-    #     Check for a simple synchronous UDS message sending.
-    #
-    #     Procedure:
-    #     1. Send a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: UDS message record returned.
-    #     2. Validate transmitted UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     time_before_send = time()
-    #     message_record = can_transport_interface.send_message(message)
-    #     time_after_send = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start == message_record.transmission_end
-    #     assert len(message_record.packets_records) == 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-    #     # timing parameters
-    #     assert can_transport_interface.n_bs_measured is None
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start
-    #                 == message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_send_message__sf(self, example_can_addressing_information, message):
-    #     """
-    #     Check for a simple asynchronous UDS message sending.
-    #
-    #     Procedure:
-    #     1. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: UDS message record returned.
-    #     2. Validate transmitted UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     time_before_send = time()
-    #     message_record = await can_transport_interface.async_send_message(message)
-    #     time_after_send = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start == message_record.transmission_end
-    #     assert len(message_record.packets_records) == 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-    #     # timing parameters
-    #     assert can_transport_interface.n_bs_measured is None
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start
-    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # @pytest.mark.parametrize("timeout, send_after", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 950),  # ms
-    #     (50, 20),
-    # ])
-    # def test_receive_message__sf(self, example_can_addressing_information,
-    #                              message, timeout, send_after):
-    #     """
-    #     Check for receiving of a UDS message (carried by Single Frame packet).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
-    #         UDS message (Single Frame).
-    #     2. Call method to receive message via Transport Interface with timeout set just after UDS message
-    #         reaches CAN bus.
-    #         Expected: UDS message is received.
-    #     3. Validate received UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the received UDS message.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param timeout: Maximal time (in milliseconds) to wait for the message transmission.
-    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     self.send_message(transport_interface=can_transport_interface_2nd_node,
-    #                       message=message,
-    #                       delay=send_after)
-    #     time_before_receive = time()
-    #     message_record = can_transport_interface.receive_message(start_timeout=timeout,
-    #                                                              end_timeout=timeout)
-    #     time_after_receive = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start == message_record.transmission_end
-    #     assert len(message_record.packets_records) == 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start
-    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # @pytest.mark.parametrize("timeout, send_after", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 950),  # ms
-    #     (50, 20),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_receive_message__sf(self, example_can_addressing_information,
-    #                                          message, timeout, send_after):
-    #     """
-    #     Check for asynchronous receiving of a UDS message (carried by Single Frame packet).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
-    #         UDS message (Single Frame).
-    #     2. Call async method to receive message via Transport Interface with timeout set just after UDS message
-    #         reaches CAN bus.
-    #         Expected: UDS message is received.
-    #     3. Validate received UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the received UDS message.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param timeout: Maximal time (in milliseconds) to wait for the message transmission.
-    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     send_message_task = asyncio.create_task(
-    #         self.async_send_message(transport_interface=can_transport_interface_2nd_node,
-    #                                 message=message,
-    #                                 delay=send_after))
-    #     time_before_receive = time()
-    #     message_record = await can_transport_interface.async_receive_message(start_timeout=timeout,
-    #                                                                          end_timeout=timeout)
-    #     time_after_receive = time()
-    #     await send_message_task
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start == message_record.transmission_end
-    #     assert len(message_record.packets_records) == 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start
-    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, send_after", [
-    #     (1000, 1010),  # ms
-    #     (50, 60),
-    # ])
-    # def test_receive_message__sf__start_timeout(self, example_can_addressing_information,
-    #                                             message, start_timeout, send_after):
-    #     """
-    #     Check for a timeout during receiving of a UDS message.
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
-    #     2. Call method to receive message via Transport Interface with timeout set just before UDS message
-    #         reaches CAN bus.
-    #         Expected: Timeout exception is raised.
-    #     3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
-    #         Expected: Message is received.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     self.send_message(transport_interface=can_transport_interface_2nd_node,
-    #                       message=message,
-    #                       delay=send_after)
-    #     time_before_receive = time()
-    #     with pytest.raises(TimeoutError):
-    #         can_transport_interface.receive_message(start_timeout=start_timeout)
-    #     time_after_receive = time()
-    #     # receive message later
-    #     message_record = can_transport_interface.receive_message(
-    #         start_timeout=(send_after - start_timeout) * 10)
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #         assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, send_after", [
-    #     (1000, 1010),  # ms
-    #     (50, 60),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_receive_message__sf__start_timeout(self, example_can_addressing_information,
-    #                                                         message, start_timeout, send_after):
-    #     """
-    #     Check for a timeout during asynchronous receiving of a UDS message.
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
-    #     2. Call async method to receive message via Transport Interface with timeout set before any CAN packet
-    #         reaches CAN bus.
-    #         Expected: Timeout exception is raised.
-    #     3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
-    #         Expected: Message is received.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send CAN frame after call of receive method [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     send_message_task = asyncio.create_task(self.async_send_message(
-    #         transport_interface=can_transport_interface_2nd_node,
-    #         message=message,
-    #         delay=send_after))
-    #     time_before_receive = time()
-    #     with pytest.raises(TimeoutError):
-    #         await can_transport_interface.async_receive_message(start_timeout=start_timeout)
-    #     time_after_receive = time()
-    #     # receive message later
-    #     message_record = await can_transport_interface.async_receive_message(
-    #         start_timeout=(send_after - start_timeout) * 10)
-    #     await send_message_task
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #         assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 950),  # ms
-    #     (50, 20),
-    # ])
-    # def test_send_message__multi_packets(self, example_can_addressing_information,
-    #                                      message, n_bs_timeout, send_after):
-    #     """
-    #     Check for a synchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-    #     2. Send a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: UDS message record returned.
-    #     3. Validate transmitted UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=n_bs_timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                      packet=flow_control_packet,
-    #                      delay=send_after)
-    #     time_before_send = time()
-    #     message_record = can_transport_interface.send_message(message)
-    #     time_after_send = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     assert len(message_record.packets_records) > 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
-    #                for following_packet in message_record.packets_records[2:])
-    #     # timing parameters
-    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
-    #     assert len(can_transport_interface.n_bs_measured) == 1
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-    #         assert (send_after - self.TASK_TIMING_TOLERANCE
-    #                 <= can_transport_interface.n_bs_measured[0]
-    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 950),  # ms
-    #     (50, 20),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_send_message__multi_packets(self, example_can_addressing_information,
-    #                                                  message, n_bs_timeout, send_after):
-    #     """
-    #     Check for an asynchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: UDS message record returned.
-    #     3. Validate transmitted UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=n_bs_timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     send_packet_task = asyncio.create_task(self.async_send_packet(
-    #         transport_interface=can_transport_interface_2nd_node,
-    #         packet=flow_control_packet,
-    #         delay=send_after))
-    #     time_before_send = time()
-    #     message_record = await can_transport_interface.async_send_message(message)
-    #     time_after_send = time()
-    #     await send_packet_task
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     assert len(message_record.packets_records) > 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
-    #                for following_packet in message_record.packets_records[2:])
-    #     # timing parameters
-    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
-    #     assert len(can_transport_interface.n_bs_measured) == 1
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-    #         assert (send_after - self.TASK_TIMING_TOLERANCE
-    #                 <= can_transport_interface.n_bs_measured[0]
-    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
-    #     (1000, 1010),  # ms
-    #     (50, 60),
-    # ])
-    # def test_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
-    #                                                    message, n_bs_timeout, send_after):
-    #     """
-    #     Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-    #     2. Send a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=n_bs_timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                      packet=flow_control_packet,
-    #                      delay=send_after)
-    #     time_before_receive = time()
-    #     with pytest.raises(TimeoutError):
-    #         can_transport_interface.send_message(message)
-    #     time_after_receive = time()
-    #     # timing parameters
-    #     receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #     assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-    #             < receiving_time_ms
-    #             < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
-    #     (1000, 1010),  # ms
-    #     (50, 60),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
-    #                                                                message, n_bs_timeout, send_after):
-    #     """
-    #     Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=n_bs_timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     send_packet_task = asyncio.create_task(self.async_send_packet(
-    #         transport_interface=can_transport_interface_2nd_node,
-    #         packet=flow_control_packet,
-    #         delay=send_after))
-    #     time_before_receive = time()
-    #     with pytest.raises(TimeoutError):
-    #         await can_transport_interface.async_send_message(message)
-    #     time_after_receive = time()
-    #     await send_packet_task
-    #     # timing parameters
-    #     receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #     assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-    #             < receiving_time_ms
-    #             < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 2000, 950, 20),  # ms
-    #     (50, 1500, 20, 50),
-    # ])
-    # def test_receive_message__multi_packets(self, example_can_addressing_information,
-    #                                         message, start_timeout, end_timeout, send_after, delay):
-    #     """
-    #     Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-    #         UDS message (First Frame and then Consecutive Frames).
-    #     2. Call method to receive message via Transport Interface.
-    #         Expected: UDS message is received.
-    #     3. Validate received UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the received UDS message.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_br=0)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #     for i, packet in enumerate(packets):
-    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                          packet=packet,
-    #                          delay=send_after + i * delay)
-    #     time_before_receive = time()
-    #     message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
-    #                                                              end_timeout=end_timeout)
-    #     time_after_receive = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert len(message_record.packets_records) == len(packets) + 1, \
-    #         "All packets (including Flow Control) are stored"
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 2000, 950, 20),  # ms
-    #     (50, 2000, 20, 50),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
-    #                                                     message, start_timeout, end_timeout, send_after, delay):
-    #     """
-    #     Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-    #         UDS message (First Frame and then Consecutive Frames).
-    #     2. Call async method to receive message via Transport Interface.
-    #         Expected: UDS message is received.
-    #     3. Validate received UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the received UDS message.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #
-    #     async def _send_message():
-    #         for packet in packets:
-    #             await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                                          packet=packet,
-    #                                          delay=send_after if packet == packets[0] else delay)
-    #
-    #     send_message_task = asyncio.create_task(_send_message())
-    #     time_before_receive = time()
-    #     message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
-    #                                                                          end_timeout=end_timeout)
-    #     time_after_receive = time()
-    #     await send_message_task
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert len(message_record.packets_records) == len(packets) + 1, \
-    #         "All packets (including Flow Control) are stored"
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, send_after, delay", [
-    #     (1000, 50, 20),  # ms
-    #     (50, 0, 50),
-    # ])
-    # def test_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
-    #                                                       message, start_timeout, send_after, delay):
-    #     """
-    #     Check for a timeout during receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carries part of received
-    #         UDS message (First Frame and then Consecutive Frames with one Consecutive Frame missing).
-    #     2. Call method to receive message via Transport Interface.
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_br=0)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                      packet=packets[0],
-    #                      delay=send_after)
-    #     for i, cf_packet in enumerate(packets[1:-1], start=1):
-    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                          packet=cf_packet,
-    #                          delay=send_after + i * delay)
-    #     with pytest.raises(TimeoutError):
-    #         can_transport_interface.receive_message(start_timeout=start_timeout)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, send_after, delay", [
-    #     (1000, 50, 20),  # ms
-    #     (50, 0, 50),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
-    #                                                                   message, start_timeout, send_after, delay):
-    #     """
-    #     Check for a timeout during asynchronous receiving of a UDS message (carried by First Frame and
-    #     Consecutive Frame packets).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-    #         UDS message (First Frame and then Consecutive Frames).
-    #     2. Call async method to receive message via Transport Interface.
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #
-    #     async def _send_message():
-    #         for packet in packets[:-1]:
-    #             await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                                          packet=packet,
-    #                                          delay=send_after if packet == packets[0] else delay)
-    #
-    #     send_message_task = asyncio.create_task(_send_message())
-    #     with pytest.raises(TimeoutError):
-    #         await can_transport_interface.async_receive_message(start_timeout=start_timeout)
-    #     await send_message_task
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("end_timeout, send_after, delay", [
-    #     (1000, 50, 20),  # ms
-    #     (2500, 10, 50),
-    # ])
-    # def test_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
-    #                                                      message, end_timeout, send_after, delay):
-    #     """
-    #     Check for an end message timeout during synchronous multi packet (FF + CF) UDS message reception.
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-    #         UDS message (First Frame and then Consecutive Frames).
-    #     2. Call method to receive message via Transport Interface with timeout set before the entire segmented
-    #         UDS message is transmitted.
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param end_timeout: Maximal time (in milliseconds) to wait for the end of a message transmission.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_br=0)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #     for i, packet in enumerate(packets):
-    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                          packet=packet,
-    #                          delay=send_after + i * delay)
-    #     time_before_receive = time()
-    #     with pytest.raises(TimeoutError):
-    #         can_transport_interface.receive_message(start_timeout=2 * send_after + 50,
-    #                                                 end_timeout=end_timeout)
-    #     time_after_receive = time()
-    #     # timing parameters
-    #     receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #     assert (end_timeout
-    #             < receiving_time_ms
-    #             < end_timeout + self.TASK_TIMING_TOLERANCE)
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    def test_send_message__sf(self, example_can_addressing_information, message):
+        """
+        Check for a simple synchronous UDS message sending.
+
+        Procedure:
+        1. Send a UDS message using Transport Interface (via CAN Interface).
+            Expected: UDS message record returned.
+        2. Validate transmitted UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        time_before_send = time()
+        message_record = can_transport_interface.send_message(message)
+        time_after_send = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.TRANSMITTED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start == message_record.transmission_end
+        assert len(message_record.packets_records) == 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+        # timing parameters
+        assert can_transport_interface.n_bs_measured is None
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start
+                    == message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_send_message__sf(self, example_can_addressing_information, message):
+        """
+        Check for a simple asynchronous UDS message sending.
+
+        Procedure:
+        1. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+            Expected: UDS message record returned.
+        2. Validate transmitted UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        time_before_send = time()
+        message_record = await can_transport_interface.async_send_message(message)
+        time_after_send = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.TRANSMITTED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start == message_record.transmission_end
+        assert len(message_record.packets_records) == 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+        # timing parameters
+        assert can_transport_interface.n_bs_measured is None
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start
+                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    @pytest.mark.parametrize("timeout, send_after", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 950),  # ms
+        (50, 20),
+    ])
+    def test_receive_message__sf(self, example_can_addressing_information,
+                                 message, timeout, send_after):
+        """
+        Check for receiving of a UDS message (carried by Single Frame packet).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
+            UDS message (Single Frame).
+        2. Call method to receive message via Transport Interface with timeout set just after UDS message
+            reaches CAN bus.
+            Expected: UDS message is received.
+        3. Validate received UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the received UDS message.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param timeout: Maximal time (in milliseconds) to wait for the message transmission.
+        :param send_after: Time when to send CAN frame after call of receive method [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        self.send_message(transport_interface=can_transport_interface_2nd_node,
+                          message=message,
+                          delay=send_after)
+        time_before_receive = time()
+        message_record = can_transport_interface.receive_message(start_timeout=timeout,
+                                                                 end_timeout=timeout)
+        time_after_receive = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start == message_record.transmission_end
+        assert len(message_record.packets_records) == 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start
+                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    @pytest.mark.parametrize("timeout, send_after", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 950),  # ms
+        (50, 20),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_receive_message__sf(self, example_can_addressing_information,
+                                             message, timeout, send_after):
+        """
+        Check for asynchronous receiving of a UDS message (carried by Single Frame packet).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received
+            UDS message (Single Frame).
+        2. Call async method to receive message via Transport Interface with timeout set just after UDS message
+            reaches CAN bus.
+            Expected: UDS message is received.
+        3. Validate received UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the received UDS message.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param timeout: Maximal time (in milliseconds) to wait for the message transmission.
+        :param send_after: Time when to send CAN frame after call of receive method [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        send_message_task = asyncio.create_task(
+            self.async_send_message(transport_interface=can_transport_interface_2nd_node,
+                                    message=message,
+                                    delay=send_after))
+        time_before_receive = time()
+        message_record = await can_transport_interface.async_receive_message(start_timeout=timeout,
+                                                                             end_timeout=timeout)
+        time_after_receive = time()
+        await send_message_task
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start == message_record.transmission_end
+        assert len(message_record.packets_records) == 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.SINGLE_FRAME
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start
+                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, send_after", [
+        (1000, 1010),  # ms
+        (50, 60),
+    ])
+    def test_receive_message__sf__start_timeout(self, example_can_addressing_information,
+                                                message, start_timeout, send_after):
+        """
+        Check for a timeout during receiving of a UDS message.
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
+        2. Call method to receive message via Transport Interface with timeout set just before UDS message
+            reaches CAN bus.
+            Expected: Timeout exception is raised.
+        3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
+            Expected: Message is received.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send CAN frame after call of receive method [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        self.send_message(transport_interface=can_transport_interface_2nd_node,
+                          message=message,
+                          delay=send_after)
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            can_transport_interface.receive_message(start_timeout=start_timeout)
+        time_after_receive = time()
+        # receive message later
+        message_record = can_transport_interface.receive_message(
+            start_timeout=(send_after - start_timeout) * 10)
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+            assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, send_after", [
+        (1000, 1010),  # ms
+        (50, 60),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_receive_message__sf__start_timeout(self, example_can_addressing_information,
+                                                            message, start_timeout, send_after):
+        """
+        Check for a timeout during asynchronous receiving of a UDS message.
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frame that carries received UDS message.
+        2. Call async method to receive message via Transport Interface with timeout set before any CAN packet
+            reaches CAN bus.
+            Expected: Timeout exception is raised.
+        3. Call method to receive message for the second time with timeout set after UDS message reaches CAN bus.
+            Expected: Message is received.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send CAN frame after call of receive method [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        send_message_task = asyncio.create_task(self.async_send_message(
+            transport_interface=can_transport_interface_2nd_node,
+            message=message,
+            delay=send_after))
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            await can_transport_interface.async_receive_message(start_timeout=start_timeout)
+        time_after_receive = time()
+        # receive message later
+        message_record = await can_transport_interface.async_receive_message(
+            start_timeout=(send_after - start_timeout) * 10)
+        await send_message_task
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+            assert start_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 950),  # ms
+        (50, 20),
+    ])
+    def test_send_message__multi_packets(self, example_can_addressing_information,
+                                         message, n_bs_timeout, send_after):
+        """
+        Check for a synchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+        2. Send a UDS message using Transport Interface (via CAN Interface).
+            Expected: UDS message record returned.
+        3. Validate transmitted UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                         packet=flow_control_packet,
+                         delay=send_after)
+        time_before_send = time()
+        message_record = can_transport_interface.send_message(message)
+        time_after_send = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.TRANSMITTED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        assert len(message_record.packets_records) > 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+                   and following_packet.direction == TransmissionDirection.TRANSMITTED
+                   for following_packet in message_record.packets_records[2:])
+        # timing parameters
+        assert isinstance(can_transport_interface.n_bs_measured, tuple)
+        assert len(can_transport_interface.n_bs_measured) == 1
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+            assert (send_after - self.TASK_TIMING_TOLERANCE
+                    <= can_transport_interface.n_bs_measured[0]
+                    <= send_after + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 950),  # ms
+        (50, 20),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_send_message__multi_packets(self, example_can_addressing_information,
+                                                     message, n_bs_timeout, send_after):
+        """
+        Check for an asynchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+            Expected: UDS message record returned.
+        3. Validate transmitted UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        send_packet_task = asyncio.create_task(self.async_send_packet(
+            transport_interface=can_transport_interface_2nd_node,
+            packet=flow_control_packet,
+            delay=send_after))
+        time_before_send = time()
+        message_record = await can_transport_interface.async_send_message(message)
+        time_after_send = time()
+        await send_packet_task
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.TRANSMITTED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        assert len(message_record.packets_records) > 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+                   and following_packet.direction == TransmissionDirection.TRANSMITTED
+                   for following_packet in message_record.packets_records[2:])
+        # timing parameters
+        assert isinstance(can_transport_interface.n_bs_measured, tuple)
+        assert len(can_transport_interface.n_bs_measured) == 1
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+            assert (send_after - self.TASK_TIMING_TOLERANCE
+                    <= can_transport_interface.n_bs_measured[0]
+                    <= send_after + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        (1000, 1010),  # ms
+        (50, 60),
+    ])
+    def test_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
+                                                       message, n_bs_timeout, send_after):
+        """
+        Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+        2. Send a UDS message using Transport Interface (via CAN Interface).
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                         packet=flow_control_packet,
+                         delay=send_after)
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            can_transport_interface.send_message(message)
+        time_after_receive = time()
+        # timing parameters
+        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+        assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+                < receiving_time_ms
+                < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        (1000, 1010),  # ms
+        (50, 60),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
+                                                                   message, n_bs_timeout, send_after):
+        """
+        Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        send_packet_task = asyncio.create_task(self.async_send_packet(
+            transport_interface=can_transport_interface_2nd_node,
+            packet=flow_control_packet,
+            delay=send_after))
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            await can_transport_interface.async_send_message(message)
+        time_after_receive = time()
+        await send_packet_task
+        # timing parameters
+        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+        assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+                < receiving_time_ms
+                < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 2000, 950, 20),  # ms
+        (50, 1500, 20, 50),
+    ])
+    def test_receive_message__multi_packets(self, example_can_addressing_information,
+                                            message, start_timeout, end_timeout, send_after, delay):
+        """
+        Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call method to receive message via Transport Interface.
+            Expected: UDS message is received.
+        3. Validate received UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the received UDS message.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+        for i, packet in enumerate(packets):
+            self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                             packet=packet,
+                             delay=send_after + i * delay)
+        time_before_receive = time()
+        message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
+                                                                 end_timeout=end_timeout)
+        time_after_receive = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert len(message_record.packets_records) == len(packets) + 1, \
+            "All packets (including Flow Control) are stored"
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 2000, 950, 20),  # ms
+        (50, 2000, 20, 50),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
+                                                        message, start_timeout, end_timeout, send_after, delay):
+        """
+        Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call async method to receive message via Transport Interface.
+            Expected: UDS message is received.
+        3. Validate received UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the received UDS message.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+
+        async def _send_message():
+            for packet in packets:
+                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+                                             packet=packet,
+                                             delay=send_after if packet == packets[0] else delay)
+
+        send_message_task = asyncio.create_task(_send_message())
+        time_before_receive = time()
+        message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
+                                                                             end_timeout=end_timeout)
+        time_after_receive = time()
+        await send_message_task
+        assert isinstance(message_record, UdsMessageRecord)
+        assert len(message_record.packets_records) == len(packets) + 1, \
+            "All packets (including Flow Control) are stored"
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, send_after, delay", [
+        (1000, 50, 20),  # ms
+        (50, 0, 50),
+    ])
+    def test_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
+                                                          message, start_timeout, send_after, delay):
+        """
+        Check for a timeout during receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carries part of received
+            UDS message (First Frame and then Consecutive Frames with one Consecutive Frame missing).
+        2. Call method to receive message via Transport Interface.
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+        self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                         packet=packets[0],
+                         delay=send_after)
+        for i, cf_packet in enumerate(packets[1:-1], start=1):
+            self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                             packet=cf_packet,
+                             delay=send_after + i * delay)
+        with pytest.raises(TimeoutError):
+            can_transport_interface.receive_message(start_timeout=start_timeout)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, send_after, delay", [
+        (1000, 50, 20),  # ms
+        (50, 0, 50),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
+                                                                      message, start_timeout, send_after, delay):
+        """
+        Check for a timeout during asynchronous receiving of a UDS message (carried by First Frame and
+        Consecutive Frame packets).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call async method to receive message via Transport Interface.
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+            :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+
+        async def _send_message():
+            for packet in packets[:-1]:
+                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+                                             packet=packet,
+                                             delay=send_after if packet == packets[0] else delay)
+
+        send_message_task = asyncio.create_task(_send_message())
+        with pytest.raises(TimeoutError):
+            await can_transport_interface.async_receive_message(start_timeout=start_timeout)
+        await send_message_task
 
     @pytest.mark.parametrize("message", [
         UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34] + [*range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("end_timeout, send_after, delay", [
+        (1000, 50, 20),  # ms
+        (2500, 10, 50),
+    ])
+    def test_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
+                                                         message, end_timeout, send_after, delay):
+        """
+        Check for an end message timeout during synchronous multi packet (FF + CF) UDS message reception.
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call method to receive message via Transport Interface with timeout set before the entire segmented
+            UDS message is transmitted.
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param end_timeout: Maximal time (in milliseconds) to wait for the end of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+        for i, packet in enumerate(packets):
+            self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                             packet=packet,
+                             delay=send_after + i * delay)
+        time_before_receive = time()
+        with pytest.raises(TimeoutError):
+            can_transport_interface.receive_message(start_timeout=2 * send_after + 50,
+                                                    end_timeout=end_timeout)
+        time_after_receive = time()
+        # timing parameters
+        receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+        assert (end_timeout
+                < receiving_time_ms
+                < end_timeout + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34] + [*range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
     ])
     @pytest.mark.parametrize("end_timeout, send_after, delay", [
         (1000, 50, 20),  # ms
@@ -1452,158 +1452,158 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
             ...
         # timing parameters
         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-        assert (end_timeout
+        assert (end_timeout - self.TASK_TIMING_TOLERANCE  # TODO: end_timeout is desired value, but asyncio.wait_for works inconsistently
                 < receiving_time_ms
                 < end_timeout + self.TASK_TIMING_TOLERANCE)
 
-    # @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
-    #     (
-    #         UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    #         0, 0, 0, 0
-    #     ),
-    #     (
-    #         UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
-    #         2, 25, 5, 120
-    #     ),
-    #     (
-    #         UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
-    #                    addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
-    #                    addressing_type=AddressingType.PHYSICAL),
-    #         0, 0, 2, 5,
-    #     ),
-    # ])
-    # def test_full_duplex(self, example_can_addressing_information,
-    #                      tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
-    #     """
-    #     Check for a full-duplex communication during synchronous UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule receiving messages on both Transport Interfaces.
-    #     2. Schedule sending messages on both Transport Interfaces.
-    #     3. Wait till all tasks are finished (messages are sent and received).
-    #     4. Validate UDS message record attributes.
-    #         Expected: Attributes of received UDS message records are in line with messages attributes scheduled for
-    #             the transmission.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param tx_message: UDS message to send on interface 1 and receive on interface 2.
-    #     :param rx_message: UDS message to send on interface 2 and receive on interface 1.
-    #     :param tx_block_size: Block Size parameter value for interface 1.
-    #     :param tx_st_min: STmin parameter value for interface 1.
-    #     :param rx_block_size: Block Size parameter value for interface 2.
-    #     :param rx_st_min: STmin parameter value for interface 2.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
-    #                                                                                 st_min=tx_st_min))
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end(),
-    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
-    #                                                                                 st_min=rx_st_min))
-    #     timer_1 = self.receive_message(transport_interface=can_transport_interface_2nd_node,
-    #                                    delay=0,
-    #                                    start_timeout=50,
-    #                                    end_timeout=None)
-    #     timer_2 = self.send_message(transport_interface=can_transport_interface_2nd_node,
-    #                                 message=rx_message,
-    #                                 delay=10)
-    #     timer_3 = self.send_message(transport_interface=can_transport_interface,
-    #                                 message=tx_message,
-    #                                 delay=10)
-    #     received_rx_message_record = can_transport_interface.receive_message(start_timeout=50)
-    #     while not all([timer_1.finished.is_set(), timer_2.finished.is_set(), timer_3.finished.is_set()]):
-    #         sleep(self.TASK_TIMING_TOLERANCE / 1000.)
-    #     received_tx_message_record = self.received_message
-    #     assert isinstance(received_tx_message_record, UdsMessageRecord)
-    #     assert isinstance(received_rx_message_record, UdsMessageRecord)
-    #     assert received_tx_message_record.payload == tx_message.payload
-    #     assert received_tx_message_record.addressing_type == tx_message.addressing_type
-    #     assert received_rx_message_record.payload == rx_message.payload
-    #     assert received_rx_message_record.addressing_type == rx_message.addressing_type
-    #
-    # @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
-    #     (
-    #         UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
-    #         0, 0, 0, 0
-    #     ),
-    #     (
-    #         UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
-    #         2, 25, 5, 120
-    #     ),
-    #     (
-    #         UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
-    #                    addressing_type=AddressingType.PHYSICAL),
-    #         UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
-    #                    addressing_type=AddressingType.PHYSICAL),
-    #         0, 0, 2, 5,
-    #     ),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_full_duplex(self, example_can_addressing_information,
-    #                                  tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
-    #     """
-    #     Check for a full-duplex communication during asynchronous UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule receiving messages on both Transport Interfaces.
-    #     2. Schedule sending messages on both Transport Interfaces.
-    #     3. Wait till all tasks are finished (messages are sent and received).
-    #     4. Validate UDS message record attributes.
-    #         Expected: Attributes of received UDS message records are in line with the transmitted UDS messages records.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param tx_message: UDS message to send on interface 1 and receive on interface 2.
-    #     :param rx_message: UDS message to send on interface 2 and receive on interface 1.
-    #     :param tx_block_size: Block Size parameter value for interface 1.
-    #     :param tx_st_min: STmin parameter value for interface 1.
-    #     :param rx_block_size: Block Size parameter value for interface 2.
-    #     :param rx_st_min: STmin parameter value for interface 2.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
-    #                                                                                 st_min=tx_st_min))
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end(),
-    #         flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
-    #                                                                                 st_min=rx_st_min))
-    #     received_rx_message_task = asyncio.create_task(
-    #         can_transport_interface.async_receive_message(start_timeout=50))
-    #     received_tx_message_task = asyncio.create_task(
-    #         can_transport_interface_2nd_node.async_receive_message(start_timeout=50))
-    #     sent_tx_message_task = asyncio.create_task(
-    #         can_transport_interface.async_send_message(message=tx_message))
-    #     sent_rx_message_task = asyncio.create_task(
-    #         can_transport_interface_2nd_node.async_send_message(message=rx_message))
-    #     tasks = [received_tx_message_task,
-    #              received_rx_message_task,
-    #              sent_tx_message_task,
-    #              sent_rx_message_task]
-    #     await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
-    #     received_tx_message_record = await received_tx_message_task
-    #     received_rx_message_record = await received_rx_message_task
-    #     sent_tx_message_record = await sent_tx_message_task
-    #     sent_rx_message_record = await sent_rx_message_task
-    #     assert isinstance(received_tx_message_record, UdsMessageRecord)
-    #     assert isinstance(received_rx_message_record, UdsMessageRecord)
-    #     assert isinstance(sent_tx_message_record, UdsMessageRecord)
-    #     assert isinstance(sent_rx_message_record, UdsMessageRecord)
-    #     assert received_tx_message_record.payload == sent_tx_message_record.payload == tx_message.payload
-    #     assert (received_tx_message_record.addressing_type == sent_tx_message_record.addressing_type
-    #             == tx_message.addressing_type)
-    #     assert received_rx_message_record.payload == sent_rx_message_record.payload == rx_message.payload
-    #     assert (received_rx_message_record.addressing_type == sent_rx_message_record.addressing_type
-    #             == rx_message.addressing_type)
+    @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
+        (
+            UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+            0, 0, 0, 0
+        ),
+        (
+            UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
+            2, 25, 5, 120
+        ),
+        (
+            UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
+                       addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
+                       addressing_type=AddressingType.PHYSICAL),
+            0, 0, 2, 5,
+        ),
+    ])
+    def test_full_duplex(self, example_can_addressing_information,
+                         tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
+        """
+        Check for a full-duplex communication during synchronous UDS message sending.
+
+        Procedure:
+        1. Schedule receiving messages on both Transport Interfaces.
+        2. Schedule sending messages on both Transport Interfaces.
+        3. Wait till all tasks are finished (messages are sent and received).
+        4. Validate UDS message record attributes.
+            Expected: Attributes of received UDS message records are in line with messages attributes scheduled for
+                the transmission.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param tx_message: UDS message to send on interface 1 and receive on interface 2.
+        :param rx_message: UDS message to send on interface 2 and receive on interface 1.
+        :param tx_block_size: Block Size parameter value for interface 1.
+        :param tx_st_min: STmin parameter value for interface 1.
+        :param rx_block_size: Block Size parameter value for interface 2.
+        :param rx_st_min: STmin parameter value for interface 2.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
+                                                                                    st_min=tx_st_min))
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end(),
+            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
+                                                                                    st_min=rx_st_min))
+        timer_1 = self.receive_message(transport_interface=can_transport_interface_2nd_node,
+                                       delay=0,
+                                       start_timeout=50,
+                                       end_timeout=None)
+        timer_2 = self.send_message(transport_interface=can_transport_interface_2nd_node,
+                                    message=rx_message,
+                                    delay=10)
+        timer_3 = self.send_message(transport_interface=can_transport_interface,
+                                    message=tx_message,
+                                    delay=10)
+        received_rx_message_record = can_transport_interface.receive_message(start_timeout=50)
+        while not all([timer_1.finished.is_set(), timer_2.finished.is_set(), timer_3.finished.is_set()]):
+            sleep(self.TASK_TIMING_TOLERANCE / 1000.)
+        received_tx_message_record = self.received_message
+        assert isinstance(received_tx_message_record, UdsMessageRecord)
+        assert isinstance(received_rx_message_record, UdsMessageRecord)
+        assert received_tx_message_record.payload == tx_message.payload
+        assert received_tx_message_record.addressing_type == tx_message.addressing_type
+        assert received_rx_message_record.payload == rx_message.payload
+        assert received_rx_message_record.addressing_type == rx_message.addressing_type
+
+    @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
+        (
+            UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x54], addressing_type=AddressingType.FUNCTIONAL),
+            0, 0, 0, 0
+        ),
+        (
+            UdsMessage(payload=[0x22, *range(10)], addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x62, *range(15)], addressing_type=AddressingType.PHYSICAL),
+            2, 25, 5, 120
+        ),
+        (
+            UdsMessage(payload=[0x22, *range(256), *range(256), *range(256)],
+                       addressing_type=AddressingType.PHYSICAL),
+            UdsMessage(payload=[0x62, *range(256), *range(256), *range(256)],
+                       addressing_type=AddressingType.PHYSICAL),
+            0, 0, 2, 5,
+        ),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_full_duplex(self, example_can_addressing_information,
+                                     tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min):
+        """
+        Check for a full-duplex communication during asynchronous UDS message sending.
+
+        Procedure:
+        1. Schedule receiving messages on both Transport Interfaces.
+        2. Schedule sending messages on both Transport Interfaces.
+        3. Wait till all tasks are finished (messages are sent and received).
+        4. Validate UDS message record attributes.
+            Expected: Attributes of received UDS message records are in line with the transmitted UDS messages records.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param tx_message: UDS message to send on interface 1 and receive on interface 2.
+        :param rx_message: UDS message to send on interface 2 and receive on interface 1.
+        :param tx_block_size: Block Size parameter value for interface 1.
+        :param tx_st_min: STmin parameter value for interface 1.
+        :param rx_block_size: Block Size parameter value for interface 2.
+        :param rx_st_min: STmin parameter value for interface 2.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=tx_block_size,
+                                                                                    st_min=tx_st_min))
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end(),
+            flow_control_parameters_generator=DefaultFlowControlParametersGenerator(block_size=rx_block_size,
+                                                                                    st_min=rx_st_min))
+        received_rx_message_task = asyncio.create_task(
+            can_transport_interface.async_receive_message(start_timeout=50))
+        received_tx_message_task = asyncio.create_task(
+            can_transport_interface_2nd_node.async_receive_message(start_timeout=50))
+        sent_tx_message_task = asyncio.create_task(
+            can_transport_interface.async_send_message(message=tx_message))
+        sent_rx_message_task = asyncio.create_task(
+            can_transport_interface_2nd_node.async_send_message(message=rx_message))
+        tasks = [received_tx_message_task,
+                 received_rx_message_task,
+                 sent_tx_message_task,
+                 sent_rx_message_task]
+        await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+        received_tx_message_record = await received_tx_message_task
+        received_rx_message_record = await received_rx_message_task
+        sent_tx_message_record = await sent_tx_message_task
+        sent_rx_message_record = await sent_rx_message_task
+        assert isinstance(received_tx_message_record, UdsMessageRecord)
+        assert isinstance(received_rx_message_record, UdsMessageRecord)
+        assert isinstance(sent_tx_message_record, UdsMessageRecord)
+        assert isinstance(sent_rx_message_record, UdsMessageRecord)
+        assert received_tx_message_record.payload == sent_tx_message_record.payload == tx_message.payload
+        assert (received_tx_message_record.addressing_type == sent_tx_message_record.addressing_type
+                == tx_message.addressing_type)
+        assert received_rx_message_record.payload == sent_rx_message_record.payload == rx_message.payload
+        assert (received_rx_message_record.addressing_type == sent_rx_message_record.addressing_type
+                == rx_message.addressing_type)
 
 
 class AbstractUseCaseTests(AbstractPythonCanTests, ABC):

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -1506,7 +1506,8 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
                                                                                     st_min=rx_st_min))
         timer_1 = self.receive_message(transport_interface=can_transport_interface_2nd_node,
                                        delay=0,
-                                       timeout=50)
+                                       start_timeout=50,
+                                       end_timeout=None)
         timer_2 = self.send_message(transport_interface=can_transport_interface_2nd_node,
                                     message=rx_message,
                                     delay=10)

--- a/tests/system_tests/can/python_can/test_python_can_kvaser.py
+++ b/tests/system_tests/can/python_can/test_python_can_kvaser.py
@@ -22,12 +22,12 @@ class KvaserConfig(AbstractPythonCanTests):
                                    channel=1,
                                    fd=True)
 
-# Can Packet
+# Can Packets Transmission and Reception
 
 class TestKvaserCanPacket(AbstractCanPacketTests, KvaserConfig):
     """CAN packets related system tests for Python CAN Transport Interface."""
 
-# Message
+# Messages Transmission and Reception
 
 class TestKvaserMessage(AbstractMessageTests, KvaserConfig):
     """UDS message related system tests for Python CAN Transport Interface."""

--- a/tests/system_tests/client/can/python_can.py
+++ b/tests/system_tests/client/can/python_can.py
@@ -3,7 +3,7 @@ from random import choice
 from tests.conftest import make_can_addressing_information
 
 from can import Bus
-from uds.can import CanAddressingFormat, PyCanTransportInterface, DefaultFlowControlParametersGenerator
+from uds.can import CanAddressingFormat, DefaultFlowControlParametersGenerator, PyCanTransportInterface
 from uds.utilities import TimeMillisecondsAlias
 
 from ..test_client import AbstractClientTests

--- a/tests/system_tests/client/can/python_can.py
+++ b/tests/system_tests/client/can/python_can.py
@@ -3,7 +3,7 @@ from random import choice
 from tests.conftest import make_can_addressing_information
 
 from can import Bus
-from uds.can import CanAddressingFormat, PyCanTransportInterface
+from uds.can import CanAddressingFormat, PyCanTransportInterface, DefaultFlowControlParametersGenerator
 from uds.utilities import TimeMillisecondsAlias
 
 from ..test_client import AbstractClientTests
@@ -11,6 +11,9 @@ from ..test_client import AbstractClientTests
 
 class TestClientWithPythonCanKvaser(AbstractClientTests):
     """Client tests for UDS over CAN with python-can package as network manager."""
+
+    transport_interface_1: PyCanTransportInterface
+    transport_interface_2: PyCanTransportInterface
 
     TIMESTAMP_TOLERANCE: TimeMillisecondsAlias = 2  # python-can has low accuracy
 
@@ -38,3 +41,9 @@ class TestClientWithPythonCanKvaser(AbstractClientTests):
         super().teardown_method()
         self.can_interface_1.shutdown()
         self.can_interface_2.shutdown()
+
+    def configure_slow_message_reception(self):
+        """Change configuration of Transport Interfaces to reach timeouts easily."""
+        self.transport_interface_1.flow_control_parameters_generator = DefaultFlowControlParametersGenerator(
+            block_size=5,
+            st_min=100)

--- a/tests/system_tests/client/test_client.py
+++ b/tests/system_tests/client/test_client.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from time import sleep, time
+from time import perf_counter, time
 from typing import List
 
 import pytest
@@ -10,7 +10,6 @@ from uds.addressing import AddressingType, TransmissionDirection
 from uds.client import Client
 from uds.message import UdsMessage, UdsMessageRecord
 from uds.transport_interface import AbstractTransportInterface
-from uds.utilities import MessageTransmissionNotStartedError
 
 
 class AbstractClientTests(BaseSystemTests, ABC):
@@ -51,396 +50,95 @@ class AbstractClientTests(BaseSystemTests, ABC):
         del self.transport_interface_1
         del self.transport_interface_2
 
-    # @pytest.mark.parametrize("request_message, response_message", [
-    #     (UdsMessage(payload=[0x3E, 0x00],
-    #                 addressing_type=AddressingType.FUNCTIONAL),
-    #      UdsMessage(payload=[0x7E, 0x00],
-    #                 addressing_type=AddressingType.FUNCTIONAL)),
-    #     (UdsMessage(payload=[0x22, 0x10, 0x00],
-    #                 addressing_type=AddressingType.PHYSICAL),
-    #      UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
-    #                 addressing_type=AddressingType.PHYSICAL)),
-    #     (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
-    #                 addressing_type=AddressingType.PHYSICAL),
-    #      UdsMessage(payload=[0x7F, 0x2E, 0x7E],
-    #                 addressing_type=AddressingType.PHYSICAL)),
-    # ])
-    # @pytest.mark.parametrize("p2_client_timeout, p6_client_timeout, send_after", [
-    #     (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P6_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT - 30),
-    #     (100, 100, 50),
-    # ])
-    # def test_send_request_receive_responses__direct(self, request_message, response_message,
-    #                                                 p2_client_timeout, p6_client_timeout, send_after):
-    #     """
-    #     Check Client for sending UDS request and receiving direct UDS response.
-    #
-    #     Procedure:
-    #     1. Configure Client.
-    #     2. Schedule response message sending by the second Transport Interface.
-    #     3. Schedule request message reception by the second Transport Interface.
-    #     4. Send UDS request message and received UDS response by the Client.
-    #     5. Validate attributes of request and response records.
-    #         Expected: Attributes values of returned records match values of request and response messages that
-    #             were scheduled for transmission.
-    #     6. Validate timing parameters.
-    #         Expected: Measured values of P2Client and P6Client time parameters are updated and stored by Client.
-    #             Measured values of P2*Client and P6*Client time parameters are equal to None (not measured).
-    #
-    #     :param request_message: Request message to send by Client.
-    #     :param response_message: Response message to receive by Client.
-    #     :param p2_client_timeout: P2Client timeout value to configure in Client.
-    #     :param p6_client_timeout: P6Client timeout value to configure in Client.
-    #     :param send_after: Time after which response message would be sent.
-    #     """
-    #     client = Client(transport_interface=self.transport_interface_1,
-    #                     p2_client_timeout=p2_client_timeout,
-    #                     p6_client_timeout=p6_client_timeout)
-    #     self.send_message(transport_interface=self.transport_interface_2,
-    #                       message=response_message,
-    #                       delay=send_after)
-    #     self.receive_message(transport_interface=self.transport_interface_2,
-    #                          delay=0,
-    #                          start_timeout=1000,
-    #                          end_timeout=None)
-    #     time_before = time()
-    #     request_record, response_records = client.send_request_receive_responses(request=request_message)
-    #     time_after = time()
-    #     # check sent message
-    #     assert isinstance(request_record, UdsMessageRecord)
-    #     assert request_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert request_record.payload == request_message.payload
-    #     assert request_record.addressing_type == request_message.addressing_type
-    #     # check received response
-    #     assert isinstance(response_records, tuple)
-    #     assert len(response_records) == 1
-    #     response_record = response_records[0]
-    #     assert response_record.direction == TransmissionDirection.RECEIVED
-    #     assert response_record.payload == response_message.payload
-    #     assert response_record.addressing_type == response_message.addressing_type
-    #     # measured time parameters
-    #     assert (client.p2_client_measured
-    #             == (response_record.transmission_start - request_record.transmission_end).total_seconds() * 1000.)
-    #     assert (client.p6_client_measured
-    #             == (response_record.transmission_end - request_record.transmission_end).total_seconds() * 1000.)
-    #     assert client.p2_ext_client_measured is None
-    #     assert client.p6_ext_client_measured is None
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= request_record.transmission_start
-    #                 <= request_record.transmission_end
-    #                 < response_record.transmission_start
-    #                 <= response_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("request_message, response_messages", [
-    #     (UdsMessage(payload=[0x22, 0x10, 0x00],
-    #                 addressing_type=AddressingType.PHYSICAL),
-    #      (UdsMessage(payload=[0x7F, 0x22, 0x78],
-    #                  addressing_type=AddressingType.PHYSICAL),
-    #       UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
-    #                  addressing_type=AddressingType.PHYSICAL))),
-    #     (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
-    #                 addressing_type=AddressingType.PHYSICAL),
-    #      (UdsMessage(payload=[0x7F, 0x2E, 0x78],
-    #                  addressing_type=AddressingType.PHYSICAL),
-    #       UdsMessage(payload=[0x7F, 0x2E, 0x78],
-    #                  addressing_type=AddressingType.PHYSICAL),
-    #       UdsMessage(payload=[0x7F, 0x2E, 0x78],
-    #                  addressing_type=AddressingType.PHYSICAL),
-    #       UdsMessage(payload=[0x6E, 0x23, 0x45],
-    #                  addressing_type=AddressingType.PHYSICAL))),
-    # ])
-    # @pytest.mark.parametrize("p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout, "
-    #                          "start_after, delay, send_after", [
-    #     (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_EXT_CLIENT_TIMEOUT, Client.DEFAULT_P6_EXT_CLIENT_TIMEOUT,
-    #      20, 1000, 500),
-    #     (100, 1000, 5000,
-    #      50, 750, 80),
-    # ])
-    # def test_send_request_receive_responses__delayed(self, request_message, response_messages,
-    #                                                  p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout,
-    #                                                  start_after, delay, send_after):
-    #     """
-    #     Check Client for sending UDS request and receiving delayed UDS response.
-    #
-    #     Procedure:
-    #     1. Configure Client.
-    #     2. Schedule response messages (Response Pending and Final Response) sending by the second Transport Interface.
-    #     3. Schedule request message reception by the second Transport Interface.
-    #     4. Send UDS request messages and received UDS response by the Client.
-    #     5. Validate attributes of request and response records.
-    #         Expected: Attributes values of returned records match values of request and response messages that
-    #             were scheduled for transmission.
-    #     6. Validate timing parameters.
-    #         Expected: Measured values of P2Client, P2*Client and P6*Client time parameters are updated and stored by
-    #             Client. Measured value of P6Client is equal to None (not measured).
-    #
-    #     :param request_message: Request message to send by Client.
-    #     :param response_messages: Response message to receive by Client.
-    #     :param p2_client_timeout: P2Client timeout value to configure in Client.
-    #     :param p2_ext_client_timeout: P2*Client timeout value to configure in Client.
-    #     :param p6_ext_client_timeout: P6*Client timeout value to configure in Client.
-    #     :param start_after: Time after which the first Response Pending message would be sent.
-    #     :param delay: Time after which following Response Pending messages are sent.
-    #     :param send_after: Time after which the final response message would be sent.
-    #     """
-    #     client = Client(transport_interface=self.transport_interface_1,
-    #                     p2_client_timeout=p2_client_timeout,
-    #                     p6_client_timeout=p2_client_timeout,
-    #                     p2_ext_client_timeout=p2_ext_client_timeout,
-    #                     p6_ext_client_timeout=p6_ext_client_timeout)
-    #     self.send_message(transport_interface=self.transport_interface_2,
-    #                       message=response_messages[0],
-    #                       delay=start_after)
-    #     for i, response_message in enumerate(response_messages[1:-1], start=1):
-    #         self.send_message(transport_interface=self.transport_interface_2,
-    #                           message=response_message,
-    #                           delay=start_after + delay * i)
-    #     self.send_message(transport_interface=self.transport_interface_2,
-    #                       message=response_messages[-1],
-    #                       delay=start_after + delay * len(response_messages[1:-1]) + send_after)
-    #     self.receive_message(transport_interface=self.transport_interface_2,
-    #                          delay=0,
-    #                          start_timeout=10000,
-    #                          end_timeout=None)
-    #     time_before = time()
-    #     request_record, response_records = client.send_request_receive_responses(request=request_message)
-    #     time_after = time()
-    #     # check sent message
-    #     assert isinstance(request_record, UdsMessageRecord)
-    #     assert request_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert request_record.payload == request_message.payload
-    #     assert request_record.addressing_type == request_message.addressing_type
-    #     # check received response
-    #     assert isinstance(response_records, tuple)
-    #     assert len(response_records) == len(response_messages)
-    #     for i, response_record in enumerate(response_records):
-    #         assert response_record.direction == TransmissionDirection.RECEIVED
-    #         assert response_record.payload == response_messages[i].payload
-    #         assert response_record.addressing_type == response_messages[i].addressing_type
-    #     # measured time parameters
-    #     assert (client.p2_client_measured
-    #             == (response_records[0].transmission_start - request_record.transmission_end).total_seconds() * 1000.)
-    #     assert isinstance(client.p2_ext_client_measured, tuple)
-    #     assert len(client.p2_ext_client_measured) == len(response_records) - 1
-    #     for i, response_record in enumerate(response_records[1:]):
-    #         assert (client.p2_ext_client_measured[i]
-    #                 == (response_record.transmission_end - response_records[
-    #                     i].transmission_end).total_seconds() * 1000.)
-    #     assert (client.p6_ext_client_measured
-    #             == (response_records[-1].transmission_end - request_record.transmission_end).total_seconds() * 1000.)
-    #     assert client.p6_client_measured is None
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= request_record.transmission_start
-    #                 <= request_record.transmission_end
-    #                 < response_records[0].transmission_start
-    #                 <= response_records[0].transmission_end
-    #                 < response_records[-1].transmission_start
-    #                 <= response_records[-1].transmission_end
-    #                 <= datetime.fromtimestamp(time_after + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("request_message, response_message", [
-    #     (UdsMessage(payload=[0x3E, 0x00],
-    #                 addressing_type=AddressingType.FUNCTIONAL),
-    #      UdsMessage(payload=[0x7E, 0x00],
-    #                 addressing_type=AddressingType.FUNCTIONAL)),
-    #     (UdsMessage(payload=[0x22, 0x10, 0x00],
-    #                 addressing_type=AddressingType.PHYSICAL),
-    #      UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
-    #                 addressing_type=AddressingType.PHYSICAL)),
-    #     (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
-    #                 addressing_type=AddressingType.PHYSICAL),
-    #      UdsMessage(payload=[0x7F, 0x2E, 0x7E],
-    #                 addressing_type=AddressingType.PHYSICAL)),
-    # ])
-    # @pytest.mark.parametrize("p2_client_timeout, send_after", [
-    #     (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT + 30),
-    #     (200, 230),
-    # ])
-    # def test_send_request_receive_responses__p2_timeout(self, request_message, response_message,
-    #                                                     p2_client_timeout, send_after):
-    #     """
-    #     Check for a P2Client timeout.
-    #
-    #     Procedure:
-    #     1. Configure Client.
-    #     2. Schedule response message sending by the second Transport Interface just after P2Client timeout is reached.
-    #     3. Schedule request message reception by the second Transport Interface.
-    #     4. Send UDS request message and received UDS response by the Client.
-    #
-    #     :param request_message: Request message to send by Client.
-    #     :param response_message: Response message to receive by Client.
-    #     :param p2_client_timeout: P2Client timeout value to configure in Client.
-    #     :param send_after: Time after which response message would be sent.
-    #     """
-    #     client = Client(transport_interface=self.transport_interface_1,
-    #                     p2_client_timeout=p2_client_timeout,
-    #                     p6_client_timeout=2*p2_client_timeout)
-    #     self.send_message(transport_interface=self.transport_interface_2,
-    #                       message=response_message,
-    #                       delay=send_after)
-    #     self.receive_message(transport_interface=self.transport_interface_2,
-    #                          delay=0,
-    #                          start_timeout=100,
-    #                          end_timeout=None)
-    #     time_before = time()
-    #     request_record, response_records = client.send_request_receive_responses(request=request_message)
-    #     time_after = time()
-    #     # check received response
-    #     assert isinstance(request_record, UdsMessageRecord)
-    #     assert request_record.payload == request_message.payload
-    #     assert request_record.addressing_type == request_message.addressing_type
-    #     assert isinstance(response_records, tuple) and len(response_records) == 0
-    #     # measured time parameters
-    #     assert client.p2_client_measured is None
-    #     assert client.p2_ext_client_measured is None
-    #     assert client.p6_client_measured is None
-    #     assert client.p6_ext_client_measured is None
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         receiving_time_ms = (time_after - time_before) * 1000.
-    #         assert (p2_client_timeout
-    #                 <= receiving_time_ms
-    #                 < send_after + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("request_message, response_message", [
-    #     (UdsMessage(payload=[0x22, 0x10, 0x00],
-    #                 addressing_type=AddressingType.PHYSICAL),
-    #      UdsMessage(payload=[0x62, 0x10, 0x00] + [*range(255)] * 20,
-    #                 addressing_type=AddressingType.PHYSICAL)),
-    #     (UdsMessage(payload=[0x22, *range(255, -1, -1)],
-    #                 addressing_type=AddressingType.PHYSICAL),
-    #      UdsMessage(payload=[0x62] + [*range(255, -1, -1)] * 100,
-    #                 addressing_type=AddressingType.PHYSICAL)),
-    # ])
-    # @pytest.mark.parametrize("p2_client_timeout, p6_client_timeout, send_after", [
-    #     (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT - 30),
-    #     (50, 100, 10),
-    # ])
-    # def test_send_request_receive_responses__p6_timeout(self, request_message, response_message,
-    #                                                     p2_client_timeout, p6_client_timeout, send_after):
-    #     """
-    #     Check for a P2Client timeout.
-    #
-    #     Procedure:
-    #     1. Configure Client.
-    #     2. Schedule response message sending by the second Transport Interface just after P2Client timeout is reached.
-    #     3. Schedule request message reception by the second Transport Interface.
-    #     4. Send UDS request message and received UDS response by the Client.
-    #
-    #     :param request_message: Request message to send by Client.
-    #     :param response_message: Response message to receive by Client.
-    #     :param p2_client_timeout: P2Client timeout value to configure in Client.
-    #     :param send_after: Time after which response message would be sent.
-    #     """
-    #     self.configure_slow_message_reception()
-    #     client = Client(transport_interface=self.transport_interface_1,
-    #                     p2_client_timeout=p2_client_timeout,
-    #                     p6_client_timeout=p6_client_timeout)
-    #     self.send_message(transport_interface=self.transport_interface_2,
-    #                       message=response_message,
-    #                       delay=send_after)
-    #     self.receive_message(transport_interface=self.transport_interface_2,
-    #                          delay=0,
-    #                          start_timeout=100,
-    #                          end_timeout=None)
-    #     time_before = time()
-    #     with pytest.raises(TimeoutError):
-    #         client.send_request_receive_responses(request=request_message)
-    #     time_after = time()
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         receiving_time_ms = (time_after - time_before) * 1000.
-    #         assert (p6_client_timeout
-    #                 <= receiving_time_ms
-    #                 < p6_client_timeout + 2*self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("request_message, response_messages", [
-    #     (UdsMessage(payload=[0x22, 0x10, 0x00],
-    #                 addressing_type=AddressingType.PHYSICAL),
-    #      (UdsMessage(payload=[0x7F, 0x22, 0x78],
-    #                  addressing_type=AddressingType.PHYSICAL),
-    #       UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
-    #                  addressing_type=AddressingType.PHYSICAL))),
-    #     (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
-    #                 addressing_type=AddressingType.PHYSICAL),
-    #      (UdsMessage(payload=[0x7F, 0x2E, 0x78],
-    #                  addressing_type=AddressingType.PHYSICAL),
-    #       UdsMessage(payload=[0x7F, 0x2E, 0x78],
-    #                  addressing_type=AddressingType.PHYSICAL),
-    #       UdsMessage(payload=[0x7F, 0x2E, 0x78],
-    #                  addressing_type=AddressingType.PHYSICAL),
-    #       UdsMessage(payload=[0x6E, 0x23, 0x45],
-    #                  addressing_type=AddressingType.PHYSICAL))),
-    # ])
-    # @pytest.mark.parametrize("p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout, "
-    #                          "start_after, delay, send_after", [
-    #     (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_EXT_CLIENT_TIMEOUT, Client.DEFAULT_P6_EXT_CLIENT_TIMEOUT,
-    #      20, 1000, Client.DEFAULT_P2_EXT_CLIENT_TIMEOUT + 50),
-    #     (100, 1000, 5000,
-    #      50, 750, 1050),
-    # ])
-    # def test_send_request_receive_responses__p2_ext_timeout(self, request_message, response_messages,
-    #                                                         p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout,
-    #                                                         start_after, delay, send_after):
-    #     """
-    #     Check Client for sending UDS request and receiving delayed UDS response.
-    #
-    #     Procedure:
-    #     1. Configure Client.
-    #     2. Schedule response messages (Response Pending and Final Response) sending by the second Transport Interface.
-    #     3. Schedule request message reception by the second Transport Interface.
-    #     4. Send UDS request messages and received UDS response by the Client.
-    #     5. Validate attributes of request and response records.
-    #         Expected: Attributes values of returned records match values of request and response messages that
-    #             were scheduled for transmission.
-    #     6. Validate timing parameters.
-    #         Expected: Measured values of P2Client, P2*Client and P6*Client time parameters are updated and stored by
-    #             Client. Measured value of P6Client is equal to None (not measured).
-    #
-    #     :param request_message: Request message to send by Client.
-    #     :param response_messages: Response message to receive by Client.
-    #     :param p2_client_timeout: P2Client timeout value to configure in Client.
-    #     :param p2_ext_client_timeout: P2*Client timeout value to configure in Client.
-    #     :param p6_ext_client_timeout: P6*Client timeout value to configure in Client.
-    #     :param start_after: Time after which the first Response Pending message would be sent.
-    #     :param delay: Time after which following Response Pending messages are sent.
-    #     :param send_after: Time after which the final response message would be sent.
-    #     """
-    #     client = Client(transport_interface=self.transport_interface_1,
-    #                     p2_client_timeout=p2_client_timeout,
-    #                     p6_client_timeout=p2_client_timeout,
-    #                     p2_ext_client_timeout=p2_ext_client_timeout,
-    #                     p6_ext_client_timeout=p6_ext_client_timeout)
-    #     self.send_message(transport_interface=self.transport_interface_2,
-    #                       message=response_messages[0],
-    #                       delay=start_after)
-    #     for i, response_message in enumerate(response_messages[1:-1], start=1):
-    #         self.send_message(transport_interface=self.transport_interface_2,
-    #                           message=response_message,
-    #                           delay=start_after + delay * i)
-    #     self.send_message(transport_interface=self.transport_interface_2,
-    #                       message=response_messages[-1],
-    #                       delay=start_after + delay * len(response_messages[1:-1]) + send_after)
-    #     self.receive_message(transport_interface=self.transport_interface_2,
-    #                          delay=0,
-    #                          start_timeout=10000,
-    #                          end_timeout=None)
-    #     with pytest.raises(TimeoutError):
-    #         client.send_request_receive_responses(request=request_message)
+    @pytest.mark.parametrize("request_message, response_message", [
+        (UdsMessage(payload=[0x3E, 0x00],
+                    addressing_type=AddressingType.FUNCTIONAL),
+         UdsMessage(payload=[0x7E, 0x00],
+                    addressing_type=AddressingType.FUNCTIONAL)),
+        (UdsMessage(payload=[0x22, 0x10, 0x00],
+                    addressing_type=AddressingType.PHYSICAL),
+         UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
+                    addressing_type=AddressingType.PHYSICAL)),
+        (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
+                    addressing_type=AddressingType.PHYSICAL),
+         UdsMessage(payload=[0x7F, 0x2E, 0x7E],
+                    addressing_type=AddressingType.PHYSICAL)),
+    ])
+    @pytest.mark.parametrize("p2_client_timeout, p6_client_timeout, send_after", [
+        (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P6_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT - 30),
+        (100, 100, 50),
+    ])
+    def test_send_request_receive_responses__direct(self, request_message, response_message,
+                                                    p2_client_timeout, p6_client_timeout, send_after):
+        """
+        Check Client for sending UDS request and receiving direct UDS response.
+
+        Procedure:
+        1. Configure Client.
+        2. Schedule response message sending by the second Transport Interface.
+        3. Schedule request message reception by the second Transport Interface.
+        4. Send UDS request message and received UDS response by the Client.
+        5. Validate attributes of request and response records.
+            Expected: Attributes values of returned records match values of request and response messages that
+                were scheduled for transmission.
+        6. Validate timing parameters.
+            Expected: Measured values of P2Client and P6Client time parameters are updated and stored by Client.
+                Measured values of P2*Client and P6*Client time parameters are equal to None (not measured).
+
+        :param request_message: Request message to send by Client.
+        :param response_message: Response message to receive by Client.
+        :param p2_client_timeout: P2Client timeout value to configure in Client.
+        :param p6_client_timeout: P6Client timeout value to configure in Client.
+        :param send_after: Time after which response message would be sent.
+        """
+        client = Client(transport_interface=self.transport_interface_1,
+                        p2_client_timeout=p2_client_timeout,
+                        p6_client_timeout=p6_client_timeout)
+        self.send_message(transport_interface=self.transport_interface_2,
+                          message=response_message,
+                          delay=send_after)
+        self.receive_message(transport_interface=self.transport_interface_2,
+                             delay=0,
+                             start_timeout=1000,
+                             end_timeout=None)
+        time_before = time()
+        request_record, response_records = client.send_request_receive_responses(request=request_message)
+        time_after = time()
+        # check sent message
+        assert isinstance(request_record, UdsMessageRecord)
+        assert request_record.direction == TransmissionDirection.TRANSMITTED
+        assert request_record.payload == request_message.payload
+        assert request_record.addressing_type == request_message.addressing_type
+        # check received response
+        assert isinstance(response_records, tuple)
+        assert len(response_records) == 1
+        response_record = response_records[0]
+        assert response_record.direction == TransmissionDirection.RECEIVED
+        assert response_record.payload == response_message.payload
+        assert response_record.addressing_type == response_message.addressing_type
+        # measured time parameters
+        assert (client.p2_client_measured
+                == (response_record.transmission_start - request_record.transmission_end).total_seconds() * 1000.)
+        assert (client.p6_client_measured
+                == (response_record.transmission_end - request_record.transmission_end).total_seconds() * 1000.)
+        assert client.p2_ext_client_measured is None
+        assert client.p6_ext_client_measured is None
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= request_record.transmission_start
+                    <= request_record.transmission_end
+                    < response_record.transmission_start
+                    <= response_record.transmission_end
+                    <= datetime.fromtimestamp(time_after + self.TIMESTAMP_TOLERANCE / 1000.))
 
     @pytest.mark.parametrize("request_message, response_messages", [
-        # (UdsMessage(payload=[0x22, 0x10, 0x00],
-        #             addressing_type=AddressingType.PHYSICAL),
-        #  (UdsMessage(payload=[0x7F, 0x22, 0x78],
-        #              addressing_type=AddressingType.PHYSICAL),
-        #   UdsMessage(payload=[0x7F, 0x22, 0x78],
-        #              addressing_type=AddressingType.PHYSICAL),
-        #   UdsMessage(payload=[0x62, 0x10, 0x00] + [*range(255)] * 50,
-        #              addressing_type=AddressingType.PHYSICAL))),
+        (UdsMessage(payload=[0x22, 0x10, 0x00],
+                    addressing_type=AddressingType.PHYSICAL),
+         (UdsMessage(payload=[0x7F, 0x22, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
+                     addressing_type=AddressingType.PHYSICAL))),
         (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
                     addressing_type=AddressingType.PHYSICAL),
          (UdsMessage(payload=[0x7F, 0x2E, 0x78],
@@ -454,10 +152,321 @@ class AbstractClientTests(BaseSystemTests, ABC):
     ])
     @pytest.mark.parametrize("p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout, "
                              "start_after, delay, send_after", [
+        (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_EXT_CLIENT_TIMEOUT, Client.DEFAULT_P6_EXT_CLIENT_TIMEOUT,
+         20, 1000, 500),
+        (100, 1000, 5000,
+         50, 750, 80),
+    ])
+    def test_send_request_receive_responses__delayed(self, request_message, response_messages,
+                                                     p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout,
+                                                     start_after, delay, send_after):
+        """
+        Check Client for sending UDS request and receiving delayed UDS response.
+
+        Procedure:
+        1. Configure Client.
+        2. Schedule response messages (Response Pending and Final Response) sending by the second Transport Interface.
+        3. Schedule request message reception by the second Transport Interface.
+        4. Send UDS request messages and received UDS response by the Client.
+        5. Validate attributes of request and response records.
+            Expected: Attributes values of returned records match values of request and response messages that
+                were scheduled for transmission.
+        6. Validate timing parameters.
+            Expected: Measured values of P2Client, P2*Client and P6*Client time parameters are updated and stored by
+                Client. Measured value of P6Client is equal to None (not measured).
+
+        :param request_message: Request message to send by Client.
+        :param response_messages: Response message to receive by Client.
+        :param p2_client_timeout: P2Client timeout value to configure in Client.
+        :param p2_ext_client_timeout: P2*Client timeout value to configure in Client.
+        :param p6_ext_client_timeout: P6*Client timeout value to configure in Client.
+        :param start_after: Time after which the first Response Pending message would be sent.
+        :param delay: Time after which following Response Pending messages are sent.
+        :param send_after: Time after which the final response message would be sent.
+        """
+        client = Client(transport_interface=self.transport_interface_1,
+                        p2_client_timeout=p2_client_timeout,
+                        p6_client_timeout=p2_client_timeout,
+                        p2_ext_client_timeout=p2_ext_client_timeout,
+                        p6_ext_client_timeout=p6_ext_client_timeout)
+        self.send_message(transport_interface=self.transport_interface_2,
+                          message=response_messages[0],
+                          delay=start_after)
+        for i, response_message in enumerate(response_messages[1:-1], start=1):
+            self.send_message(transport_interface=self.transport_interface_2,
+                              message=response_message,
+                              delay=start_after + delay * i)
+        self.send_message(transport_interface=self.transport_interface_2,
+                          message=response_messages[-1],
+                          delay=start_after + delay * len(response_messages[1:-1]) + send_after)
+        self.receive_message(transport_interface=self.transport_interface_2,
+                             delay=0,
+                             start_timeout=10000,
+                             end_timeout=None)
+        time_before = time()
+        request_record, response_records = client.send_request_receive_responses(request=request_message)
+        time_after = time()
+        # check sent message
+        assert isinstance(request_record, UdsMessageRecord)
+        assert request_record.direction == TransmissionDirection.TRANSMITTED
+        assert request_record.payload == request_message.payload
+        assert request_record.addressing_type == request_message.addressing_type
+        # check received response
+        assert isinstance(response_records, tuple)
+        assert len(response_records) == len(response_messages)
+        for i, response_record in enumerate(response_records):
+            assert response_record.direction == TransmissionDirection.RECEIVED
+            assert response_record.payload == response_messages[i].payload
+            assert response_record.addressing_type == response_messages[i].addressing_type
+        # measured time parameters
+        assert (client.p2_client_measured
+                == (response_records[0].transmission_start - request_record.transmission_end).total_seconds() * 1000.)
+        assert isinstance(client.p2_ext_client_measured, tuple)
+        assert len(client.p2_ext_client_measured) == len(response_records) - 1
+        for i, response_record in enumerate(response_records[1:]):
+            assert (client.p2_ext_client_measured[i]
+                    == (response_record.transmission_end - response_records[
+                        i].transmission_end).total_seconds() * 1000.)
+        assert (client.p6_ext_client_measured
+                == (response_records[-1].transmission_end - request_record.transmission_end).total_seconds() * 1000.)
+        assert client.p6_client_measured is None
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= request_record.transmission_start
+                    <= request_record.transmission_end
+                    < response_records[0].transmission_start
+                    <= response_records[0].transmission_end
+                    < response_records[-1].transmission_start
+                    <= response_records[-1].transmission_end
+                    <= datetime.fromtimestamp(time_after + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("request_message, response_message", [
+        (UdsMessage(payload=[0x3E, 0x00],
+                    addressing_type=AddressingType.FUNCTIONAL),
+         UdsMessage(payload=[0x7E, 0x00],
+                    addressing_type=AddressingType.FUNCTIONAL)),
+        (UdsMessage(payload=[0x22, 0x10, 0x00],
+                    addressing_type=AddressingType.PHYSICAL),
+         UdsMessage(payload=[0x62, 0x10, 0x00, *range(10)],
+                    addressing_type=AddressingType.PHYSICAL)),
+        (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(50, 100)],
+                    addressing_type=AddressingType.PHYSICAL),
+         UdsMessage(payload=[0x7F, 0x2E, 0x7E],
+                    addressing_type=AddressingType.PHYSICAL)),
+    ])
+    @pytest.mark.parametrize("p2_client_timeout, send_after", [
+        (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT + 30),
+        (200, 230),
+    ])
+    def test_send_request_receive_responses__p2_timeout(self, request_message, response_message,
+                                                        p2_client_timeout, send_after):
+        """
+        Check for a P2Client timeout.
+
+        Procedure:
+        1. Configure Client.
+        2. Schedule response message sending by the second Transport Interface just after P2Client timeout is reached.
+        3. Schedule request message reception by the second Transport Interface.
+        4. Send UDS request message and received UDS response by the Client.
+
+        :param request_message: Request message to send by Client.
+        :param response_message: Response message to receive by Client.
+        :param p2_client_timeout: P2Client timeout value to configure in Client.
+        :param send_after: Time after which response message would be sent.
+        """
+        client = Client(transport_interface=self.transport_interface_1,
+                        p2_client_timeout=p2_client_timeout,
+                        p6_client_timeout=2*p2_client_timeout)
+        self.send_message(transport_interface=self.transport_interface_2,
+                          message=response_message,
+                          delay=send_after)
+        self.receive_message(transport_interface=self.transport_interface_2,
+                             delay=0,
+                             start_timeout=100,
+                             end_timeout=None)
+        time_before = perf_counter()
+        request_record, response_records = client.send_request_receive_responses(request=request_message)
+        time_after = perf_counter()
+        # check received response
+        assert isinstance(request_record, UdsMessageRecord)
+        assert request_record.payload == request_message.payload
+        assert request_record.addressing_type == request_message.addressing_type
+        assert isinstance(response_records, tuple) and len(response_records) == 0
+        # measured time parameters
+        assert client.p2_client_measured is None
+        assert client.p2_ext_client_measured is None
+        assert client.p6_client_measured is None
+        assert client.p6_ext_client_measured is None
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            receiving_time_ms = (time_after - time_before) * 1000.
+            assert (p2_client_timeout
+                    <= receiving_time_ms
+                    < p2_client_timeout + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("request_message, response_message", [
+        (UdsMessage(payload=[0x22, 0x10, 0x00],
+                    addressing_type=AddressingType.PHYSICAL),
+         UdsMessage(payload=[0x62, 0x10, 0x00] + [*range(255)] * 20,
+                    addressing_type=AddressingType.PHYSICAL)),
+        (UdsMessage(payload=[0x22, *range(255, 150, -1)],
+                    addressing_type=AddressingType.PHYSICAL),
+         UdsMessage(payload=[0x62] + [*range(255, -1, -1)] * 100,
+                    addressing_type=AddressingType.PHYSICAL)),
+    ])
+    @pytest.mark.parametrize("p2_client_timeout, p6_client_timeout, send_after", [
+        (Client.DEFAULT_P2_CLIENT_TIMEOUT, 2*Client.DEFAULT_P2_CLIENT_TIMEOUT, 20),
+        (250, 750, 50),
+    ])
+    def test_send_request_receive_responses__p6_timeout(self, request_message, response_message,
+                                                        p2_client_timeout, p6_client_timeout, send_after):
+        """
+        Check for a P2Client timeout.
+
+        Procedure:
+        1. Configure Client.
+        2. Schedule response message sending by the second Transport Interface just after P2Client timeout is reached.
+        3. Schedule request message reception by the second Transport Interface.
+        4. Send UDS request message and received UDS response by the Client.
+
+        :param request_message: Request message to send by Client.
+        :param response_message: Response message to receive by Client.
+        :param p2_client_timeout: P2Client timeout value to configure in Client.
+        :param send_after: Time after which response message would be sent.
+        """
+        self.configure_slow_message_reception()
+        client = Client(transport_interface=self.transport_interface_1,
+                        p2_client_timeout=p2_client_timeout,
+                        p6_client_timeout=p6_client_timeout)
+        self.send_message(transport_interface=self.transport_interface_2,
+                          message=response_message,
+                          delay=send_after)
+        self.receive_message(transport_interface=self.transport_interface_2,
+                             delay=0,
+                             start_timeout=100,
+                             end_timeout=None)
+        time_before = perf_counter()
+        with pytest.raises(TimeoutError):
+            client.send_request_receive_responses(request=request_message)
+        time_after = perf_counter()
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            receiving_time_ms = (time_after - time_before) * 1000.
+            assert (p6_client_timeout
+                    <= receiving_time_ms
+                    < p6_client_timeout + send_after + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("request_message, response_messages", [
+        (UdsMessage(payload=[0x22, 0x10, 0x00],
+                    addressing_type=AddressingType.PHYSICAL),
+         (UdsMessage(payload=[0x7F, 0x22, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
+                     addressing_type=AddressingType.PHYSICAL))),
+        (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
+                    addressing_type=AddressingType.PHYSICAL),
+         (UdsMessage(payload=[0x7F, 0x2E, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x7F, 0x2E, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x7F, 0x2E, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x6E, 0x23, 0x45],
+                     addressing_type=AddressingType.PHYSICAL))),
+    ])
+    @pytest.mark.parametrize("p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout, "
+                             "start_after, delay, send_after", [
+        (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_EXT_CLIENT_TIMEOUT, Client.DEFAULT_P6_EXT_CLIENT_TIMEOUT,
+         20, 1000, Client.DEFAULT_P2_EXT_CLIENT_TIMEOUT + 50),
+        (100, 1000, 5000,
+         50, 750, 1050),
+    ])
+    def test_send_request_receive_responses__p2_ext_timeout(self, request_message, response_messages,
+                                                            p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout,
+                                                            start_after, delay, send_after):
+        """
+        Check Client for sending UDS request and receiving delayed UDS response.
+
+        Procedure:
+        1. Configure Client.
+        2. Schedule response messages (Response Pending and Final Response) sending by the second Transport Interface.
+        3. Schedule request message reception by the second Transport Interface.
+        4. Send UDS request messages and received UDS response by the Client.
+        5. Validate attributes of request and response records.
+            Expected: Attributes values of returned records match values of request and response messages that
+                were scheduled for transmission.
+        6. Validate timing parameters.
+            Expected: Measured values of P2Client, P2*Client and P6*Client time parameters are updated and stored by
+                Client. Measured value of P6Client is equal to None (not measured).
+
+        :param request_message: Request message to send by Client.
+        :param response_messages: Response message to receive by Client.
+        :param p2_client_timeout: P2Client timeout value to configure in Client.
+        :param p2_ext_client_timeout: P2*Client timeout value to configure in Client.
+        :param p6_ext_client_timeout: P6*Client timeout value to configure in Client.
+        :param start_after: Time after which the first Response Pending message would be sent.
+        :param delay: Time after which following Response Pending messages are sent.
+        :param send_after: Time after which the final response message would be sent.
+        """
+        client = Client(transport_interface=self.transport_interface_1,
+                        p2_client_timeout=p2_client_timeout,
+                        p6_client_timeout=p2_client_timeout,
+                        p2_ext_client_timeout=p2_ext_client_timeout,
+                        p6_ext_client_timeout=p6_ext_client_timeout)
+        self.send_message(transport_interface=self.transport_interface_2,
+                          message=response_messages[0],
+                          delay=start_after)
+        for i, response_message in enumerate(response_messages[1:-1], start=1):
+            self.send_message(transport_interface=self.transport_interface_2,
+                              message=response_message,
+                              delay=start_after + delay * i)
+        self.send_message(transport_interface=self.transport_interface_2,
+                          message=response_messages[-1],
+                          delay=start_after + delay * len(response_messages[1:-1]) + send_after)
+        self.receive_message(transport_interface=self.transport_interface_2,
+                             delay=0,
+                             start_timeout=10000,
+                             end_timeout=None)
+        with pytest.raises(TimeoutError):
+            client.send_request_receive_responses(request=request_message)
+
+    @pytest.mark.parametrize("request_message, response_messages", [
+        (UdsMessage(payload=[0x22, 0x10, 0x00],
+                    addressing_type=AddressingType.PHYSICAL),
+         (UdsMessage(payload=[0x7F, 0x22, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x7F, 0x22, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x7F, 0x22, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x62, 0x10, 0x00] + [*range(255)] * 50,
+                     addressing_type=AddressingType.PHYSICAL))),
+        (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
+                    addressing_type=AddressingType.PHYSICAL),
+         (UdsMessage(payload=[0x7F, 0x2E, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x7F, 0x2E, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x7F, 0x2E, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x7F, 0x2E, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x7F, 0x2E, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x7F, 0x2E, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x7F, 0x2E, 0x78],
+                     addressing_type=AddressingType.PHYSICAL),
+          UdsMessage(payload=[0x6E, 0x23, 0x45],
+                     addressing_type=AddressingType.PHYSICAL))),
+    ])
+    @pytest.mark.parametrize("p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout, "
+                             "start_after, delay, send_after", [
                                  (50, 1000, 2250,
-                                  40, 900, 950),
-                                 # (100, 250, 400,
-                                 #  50, 200, 200),
+                                  20, 500, 750),
+                                 (100, 500, 750,
+                                  50, 250, 350),
                              ])
     def test_send_request_receive_responses__p6_ext_timeout(self, request_message, response_messages,
                                                             p2_client_timeout, p2_ext_client_timeout,
@@ -507,108 +516,108 @@ class AbstractClientTests(BaseSystemTests, ABC):
                              delay=0,
                              start_timeout=10000,
                              end_timeout=None)
-        time_before = time()
+        time_before = perf_counter()
         with pytest.raises(TimeoutError):
-            client.send_request_receive_responses(request=request_message)  # TODO: P6*Client is not handled properly
-        time_after = time()
+            client.send_request_receive_responses(request=request_message)
+        time_after = perf_counter()
         # performance checks
         if self.MAKE_TIMING_CHECKS:
             receiving_time_ms = (time_after - time_before) * 1000.
             assert (p6_ext_client_timeout
                     <= receiving_time_ms
-                    < p6_ext_client_timeout + start_after + 2*self.TASK_TIMING_TOLERANCE)
+                    <= p6_ext_client_timeout + send_after + self.TASK_TIMING_TOLERANCE)
 
     # Tester Present
 
-    # @pytest.mark.parametrize("addressing_type, sprmib, s3_client", [
-    #     (AddressingType.FUNCTIONAL, True, 1000),
-    #     (AddressingType.PHYSICAL, False, 500),
-    # ])
-    # def test_start_stop_tester_present(self, addressing_type, sprmib, s3_client):
-    #     """
-    #     Check for starting and stopping cyclical Tester Present sending.
-    #
-    #     Procedure:
-    #     1. Configure Client.
-    #     2. Start cyclical Tester Present transmission.
-    #     3. Receive 5 Tester Present messages.
-    #     4. Stop cyclical Tester Present transmission.
-    #     5. Check Tester Present message reception.
-    #         Expected: No message received.
-    #     6. Validate received Tester Present records.
-    #         Expected: Received Tester Present records period and attributes matches preconfigured values.
-    #
-    #     :param addressing_type: Addressing Type to use for Tester Present transmission.
-    #     :param sprmib: Whether Tester Present message have suppressPosRspMsgIndicationBit set.
-    #     :param s3_client: S3Client value to configure in Client.
-    #     """
-    #     client = Client(transport_interface=self.transport_interface_1,
-    #                     p6_client_timeout=s3_client,
-    #                     s3_client=s3_client)
-    #     tester_present_records: List[UdsMessageRecord] = []
-    #     client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
-    #     for i in range(5):
-    #         tester_present_records.append(self.transport_interface_2.receive_message(start_timeout=2 * s3_client))
-    #     client.stop_tester_present()
-    #     with pytest.raises(TimeoutError):
-    #         self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
-    #     # check sent messages
-    #     payload = b"\x3E\x80" if sprmib else b"\x3E\x00"
-    #     assert all([tp_record.payload == payload for tp_record in tester_present_records])
-    #     rx_physical_params = dict(self.transport_interface_2.addressing_information.rx_physical_params)
-    #     rx_functional_params = dict(self.transport_interface_2.addressing_information.rx_functional_params)
-    #     rx_physical_params.pop("addressing_type")
-    #     rx_functional_params.pop("addressing_type")
-    #     if rx_physical_params != rx_functional_params:  # make sure addressing parameters differ
-    #         assert all([tp_record.addressing_type == addressing_type for tp_record in tester_present_records])
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         for i, tp_record in enumerate(tester_present_records[1:]):
-    #             s3_client_measured = (tp_record.transmission_start.timestamp()
-    #                                   - tester_present_records[i].transmission_start.timestamp())
-    #             assert (s3_client - self.TASK_TIMING_TOLERANCE
-    #                     <=  s3_client_measured * 1000.
-    #                     <= s3_client + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("addressing_type, sprmib, s3_client", [
-    #     (AddressingType.FUNCTIONAL, True, 1000),
-    #     (AddressingType.PHYSICAL, False, 500),
-    # ])
-    # def test_restart_tester_present(self, addressing_type, sprmib, s3_client):
-    #     """
-    #     Check for restarting cyclical Tester Present sending.
-    #
-    #     Procedure:
-    #     1. Configure Client.
-    #     2. Start cyclical Tester Present transmission.
-    #     3. Receive 1 Tester Present message.
-    #     4. Stop cyclical Tester Present transmission.
-    #     5. Check Tester Present message reception.
-    #         Expected: No message received.
-    #     6. Restart cyclical Tester Present transmission.
-    #     7. Receive 1 Tester Present message.
-    #     8. Check Tester Present message reception.
-    #         Expected: No message received.
-    #     6. Validate received Tester Present records.
-    #         Expected: Received Tester Present records attributes matches preconfigured values.
-    #
-    #     :param addressing_type: Addressing Type to use for Tester Present transmission.
-    #     :param sprmib: Whether Tester Present message have suppressPosRspMsgIndicationBit set.
-    #     """
-    #     client = Client(transport_interface=self.transport_interface_1,
-    #                     p6_client_timeout=s3_client,
-    #                     s3_client=s3_client)
-    #     client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
-    #     tester_present_record_1 = self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
-    #     client.stop_tester_present()
-    #     with pytest.raises(TimeoutError):
-    #         self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
-    #     client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
-    #     tester_present_record_2 = self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
-    #     client.stop_tester_present()
-    #     with pytest.raises(TimeoutError):
-    #         self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
-    #     # check sent messages
-    #     payload = b"\x3E\x80" if sprmib else b"\x3E\x00"
-    #     assert tester_present_record_1.payload == tester_present_record_2.payload == payload
-    #     assert tester_present_record_1.addressing_type == tester_present_record_2.addressing_type  # do not compare with addressing_type in case the same rx and tx AI parameters
+    @pytest.mark.parametrize("addressing_type, sprmib, s3_client", [
+        (AddressingType.FUNCTIONAL, True, 1000),
+        (AddressingType.PHYSICAL, False, 500),
+    ])
+    def test_start_stop_tester_present(self, addressing_type, sprmib, s3_client):
+        """
+        Check for starting and stopping cyclical Tester Present sending.
+
+        Procedure:
+        1. Configure Client.
+        2. Start cyclical Tester Present transmission.
+        3. Receive 5 Tester Present messages.
+        4. Stop cyclical Tester Present transmission.
+        5. Check Tester Present message reception.
+            Expected: No message received.
+        6. Validate received Tester Present records.
+            Expected: Received Tester Present records period and attributes matches preconfigured values.
+
+        :param addressing_type: Addressing Type to use for Tester Present transmission.
+        :param sprmib: Whether Tester Present message have suppressPosRspMsgIndicationBit set.
+        :param s3_client: S3Client value to configure in Client.
+        """
+        client = Client(transport_interface=self.transport_interface_1,
+                        p6_client_timeout=s3_client,
+                        s3_client=s3_client)
+        tester_present_records: List[UdsMessageRecord] = []
+        client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
+        for i in range(5):
+            tester_present_records.append(self.transport_interface_2.receive_message(start_timeout=2 * s3_client))
+        client.stop_tester_present()
+        with pytest.raises(TimeoutError):
+            self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
+        # check sent messages
+        payload = b"\x3E\x80" if sprmib else b"\x3E\x00"
+        assert all([tp_record.payload == payload for tp_record in tester_present_records])
+        rx_physical_params = dict(self.transport_interface_2.addressing_information.rx_physical_params)
+        rx_functional_params = dict(self.transport_interface_2.addressing_information.rx_functional_params)
+        rx_physical_params.pop("addressing_type")
+        rx_functional_params.pop("addressing_type")
+        if rx_physical_params != rx_functional_params:  # make sure addressing parameters differ
+            assert all([tp_record.addressing_type == addressing_type for tp_record in tester_present_records])
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            for i, tp_record in enumerate(tester_present_records[1:]):
+                s3_client_measured = (tp_record.transmission_start.timestamp()
+                                      - tester_present_records[i].transmission_start.timestamp())
+                assert (s3_client - self.TASK_TIMING_TOLERANCE
+                        <=  s3_client_measured * 1000.
+                        <= s3_client + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("addressing_type, sprmib, s3_client", [
+        (AddressingType.FUNCTIONAL, True, 1000),
+        (AddressingType.PHYSICAL, False, 500),
+    ])
+    def test_restart_tester_present(self, addressing_type, sprmib, s3_client):
+        """
+        Check for restarting cyclical Tester Present sending.
+
+        Procedure:
+        1. Configure Client.
+        2. Start cyclical Tester Present transmission.
+        3. Receive 1 Tester Present message.
+        4. Stop cyclical Tester Present transmission.
+        5. Check Tester Present message reception.
+            Expected: No message received.
+        6. Restart cyclical Tester Present transmission.
+        7. Receive 1 Tester Present message.
+        8. Check Tester Present message reception.
+            Expected: No message received.
+        6. Validate received Tester Present records.
+            Expected: Received Tester Present records attributes matches preconfigured values.
+
+        :param addressing_type: Addressing Type to use for Tester Present transmission.
+        :param sprmib: Whether Tester Present message have suppressPosRspMsgIndicationBit set.
+        """
+        client = Client(transport_interface=self.transport_interface_1,
+                        p6_client_timeout=s3_client,
+                        s3_client=s3_client)
+        client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
+        tester_present_record_1 = self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
+        client.stop_tester_present()
+        with pytest.raises(TimeoutError):
+            self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
+        client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
+        tester_present_record_2 = self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
+        client.stop_tester_present()
+        with pytest.raises(TimeoutError):
+            self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
+        # check sent messages
+        payload = b"\x3E\x80" if sprmib else b"\x3E\x00"
+        assert tester_present_record_1.payload == tester_present_record_2.payload == payload
+        assert tester_present_record_1.addressing_type == tester_present_record_2.addressing_type  # do not compare with addressing_type in case the same rx and tx AI parameters

--- a/tests/system_tests/client/test_client.py
+++ b/tests/system_tests/client/test_client.py
@@ -269,10 +269,10 @@ class AbstractClientTests(BaseSystemTests, ABC):
         tester_present_records: List[UdsMessageRecord] = []
         client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
         for i in range(5):
-            tester_present_records.append(self.transport_interface_2.receive_message(timeout=2*s3_client))
+            tester_present_records.append(self.transport_interface_2.receive_message(start_timeout=2 * s3_client))
         client.stop_tester_present()
         with pytest.raises(TimeoutError):
-            self.transport_interface_2.receive_message(timeout=2 * s3_client)
+            self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
         # check sent messages
         payload = b"\x3E\x80" if sprmib else b"\x3E\x00"
         assert all([tp_record.payload == payload for tp_record in tester_present_records])
@@ -319,15 +319,15 @@ class AbstractClientTests(BaseSystemTests, ABC):
         client = Client(transport_interface=self.transport_interface_1,
                         s3_client=s3_client)
         client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
-        tester_present_record_1 = self.transport_interface_2.receive_message(timeout=2*s3_client)
+        tester_present_record_1 = self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
         client.stop_tester_present()
         with pytest.raises(TimeoutError):
-            self.transport_interface_2.receive_message(timeout=2 * s3_client)
+            self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
         client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
-        tester_present_record_2 = self.transport_interface_2.receive_message(timeout=2 * s3_client)
+        tester_present_record_2 = self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
         client.stop_tester_present()
         with pytest.raises(TimeoutError):
-            self.transport_interface_2.receive_message(timeout=2 * s3_client)
+            self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
         # check sent messages
         payload = b"\x3E\x80" if sprmib else b"\x3E\x00"
         assert tester_present_record_1.payload == tester_present_record_2.payload == payload

--- a/tests/system_tests/client/test_client.py
+++ b/tests/system_tests/client/test_client.py
@@ -10,6 +10,7 @@ from uds.addressing import AddressingType, TransmissionDirection
 from uds.client import Client
 from uds.message import UdsMessage, UdsMessageRecord
 from uds.transport_interface import AbstractTransportInterface
+from uds.utilities import MessageTransmissionNotStartedError
 
 
 class AbstractClientTests(BaseSystemTests, ABC):
@@ -25,6 +26,10 @@ class AbstractClientTests(BaseSystemTests, ABC):
         - transport_interface_1 - Client side Transport Interface
         - transport_interface_2 - Sever side Transport Interface
         """
+
+    @abstractmethod
+    def configure_slow_message_reception(self):
+        """Change configuration of Transport Interfaces to reach timeouts easily."""
 
     def setup_method(self):
         """
@@ -46,97 +51,396 @@ class AbstractClientTests(BaseSystemTests, ABC):
         del self.transport_interface_1
         del self.transport_interface_2
 
-    # simple: send - receive
-
-    @pytest.mark.parametrize("request_message, response_message", [
-        (UdsMessage(payload=[0x3E, 0x00],
-                    addressing_type=AddressingType.FUNCTIONAL),
-         UdsMessage(payload=[0x7E, 0x00],
-                    addressing_type=AddressingType.FUNCTIONAL)),
-        (UdsMessage(payload=[0x22, 0x10, 0x00],
-                    addressing_type=AddressingType.PHYSICAL),
-         UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
-                    addressing_type=AddressingType.PHYSICAL)),
-        (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
-                    addressing_type=AddressingType.PHYSICAL),
-         UdsMessage(payload=[0x7F, 0x2E, 0x7E],
-                    addressing_type=AddressingType.PHYSICAL)),
-    ])
-    @pytest.mark.parametrize("p2_client_timeout, p6_client_timeout, send_after", [
-        (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P6_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT - 30),
-        (100, 100, 50),
-    ])
-    def test_send_request_receive_responses__direct(self, request_message, response_message,
-                                                    p2_client_timeout, p6_client_timeout, send_after):
-        """
-        Check Client for sending UDS request and receiving direct UDS response.
-        
-        Procedure:
-        1. Configure Client.
-        2. Schedule response message sending by the second Transport Interface.
-        3. Schedule request message reception by the second Transport Interface.
-        4. Send UDS request message and received UDS response by the Client.
-        5. Validate attributes of request and response records.
-            Expected: Attributes values of returned records match values of request and response messages that
-                were scheduled for transmission.
-        6. Validate timing parameters.
-            Expected: Measured values of P2Client and P6Client time parameters are updated and stored by Client.
-                Measured values of P2*Client and P6*Client time parameters are equal to None (not measured). 
-        
-        :param request_message: Request message to send by Client.
-        :param response_message: Response message to receive by Client.
-        :param p2_client_timeout: P2Client timeout value to configure in Client.
-        :param p6_client_timeout: P6Client timeout value to configure in Client.
-        :param send_after: Time after which response message would be sent.
-        """
-        client = Client(transport_interface=self.transport_interface_1,
-                        p2_client_timeout=p2_client_timeout,
-                        p6_client_timeout=p6_client_timeout)
-        self.send_message(transport_interface=self.transport_interface_2,
-                          message=response_message,
-                          delay=send_after)
-        self.receive_message(transport_interface=self.transport_interface_2,
-                             delay=0,
-                             start_timeout=1000,
-                             end_timeout=None)
-        time_before = time()
-        request_record, response_records = client.send_request_receive_responses(request=request_message)
-        time_after = time()
-        # check sent message
-        assert isinstance(request_record, UdsMessageRecord)
-        assert request_record.direction == TransmissionDirection.TRANSMITTED
-        assert request_record.payload == request_message.payload
-        assert request_record.addressing_type == request_message.addressing_type
-        # check received response
-        assert isinstance(response_records, tuple)
-        assert len(response_records) == 1
-        response_record = response_records[0]
-        assert response_record.direction == TransmissionDirection.RECEIVED
-        assert response_record.payload == response_message.payload
-        assert response_record.addressing_type == response_message.addressing_type
-        # measured time parameters
-        assert (client.p2_client_measured
-                == (response_record.transmission_start - request_record.transmission_end).total_seconds() * 1000.)
-        assert (client.p6_client_measured
-                == (response_record.transmission_end - request_record.transmission_end).total_seconds() * 1000.)
-        assert client.p2_ext_client_measured is None
-        assert client.p6_ext_client_measured is None
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= request_record.transmission_start
-                    <= request_record.transmission_end
-                    < response_record.transmission_start
-                    <= response_record.transmission_end
-                    <= datetime.fromtimestamp(time_after + self.TIMESTAMP_TOLERANCE / 1000.))
+    # @pytest.mark.parametrize("request_message, response_message", [
+    #     (UdsMessage(payload=[0x3E, 0x00],
+    #                 addressing_type=AddressingType.FUNCTIONAL),
+    #      UdsMessage(payload=[0x7E, 0x00],
+    #                 addressing_type=AddressingType.FUNCTIONAL)),
+    #     (UdsMessage(payload=[0x22, 0x10, 0x00],
+    #                 addressing_type=AddressingType.PHYSICAL),
+    #      UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
+    #                 addressing_type=AddressingType.PHYSICAL)),
+    #     (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
+    #                 addressing_type=AddressingType.PHYSICAL),
+    #      UdsMessage(payload=[0x7F, 0x2E, 0x7E],
+    #                 addressing_type=AddressingType.PHYSICAL)),
+    # ])
+    # @pytest.mark.parametrize("p2_client_timeout, p6_client_timeout, send_after", [
+    #     (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P6_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT - 30),
+    #     (100, 100, 50),
+    # ])
+    # def test_send_request_receive_responses__direct(self, request_message, response_message,
+    #                                                 p2_client_timeout, p6_client_timeout, send_after):
+    #     """
+    #     Check Client for sending UDS request and receiving direct UDS response.
+    #
+    #     Procedure:
+    #     1. Configure Client.
+    #     2. Schedule response message sending by the second Transport Interface.
+    #     3. Schedule request message reception by the second Transport Interface.
+    #     4. Send UDS request message and received UDS response by the Client.
+    #     5. Validate attributes of request and response records.
+    #         Expected: Attributes values of returned records match values of request and response messages that
+    #             were scheduled for transmission.
+    #     6. Validate timing parameters.
+    #         Expected: Measured values of P2Client and P6Client time parameters are updated and stored by Client.
+    #             Measured values of P2*Client and P6*Client time parameters are equal to None (not measured).
+    #
+    #     :param request_message: Request message to send by Client.
+    #     :param response_message: Response message to receive by Client.
+    #     :param p2_client_timeout: P2Client timeout value to configure in Client.
+    #     :param p6_client_timeout: P6Client timeout value to configure in Client.
+    #     :param send_after: Time after which response message would be sent.
+    #     """
+    #     client = Client(transport_interface=self.transport_interface_1,
+    #                     p2_client_timeout=p2_client_timeout,
+    #                     p6_client_timeout=p6_client_timeout)
+    #     self.send_message(transport_interface=self.transport_interface_2,
+    #                       message=response_message,
+    #                       delay=send_after)
+    #     self.receive_message(transport_interface=self.transport_interface_2,
+    #                          delay=0,
+    #                          start_timeout=1000,
+    #                          end_timeout=None)
+    #     time_before = time()
+    #     request_record, response_records = client.send_request_receive_responses(request=request_message)
+    #     time_after = time()
+    #     # check sent message
+    #     assert isinstance(request_record, UdsMessageRecord)
+    #     assert request_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert request_record.payload == request_message.payload
+    #     assert request_record.addressing_type == request_message.addressing_type
+    #     # check received response
+    #     assert isinstance(response_records, tuple)
+    #     assert len(response_records) == 1
+    #     response_record = response_records[0]
+    #     assert response_record.direction == TransmissionDirection.RECEIVED
+    #     assert response_record.payload == response_message.payload
+    #     assert response_record.addressing_type == response_message.addressing_type
+    #     # measured time parameters
+    #     assert (client.p2_client_measured
+    #             == (response_record.transmission_start - request_record.transmission_end).total_seconds() * 1000.)
+    #     assert (client.p6_client_measured
+    #             == (response_record.transmission_end - request_record.transmission_end).total_seconds() * 1000.)
+    #     assert client.p2_ext_client_measured is None
+    #     assert client.p6_ext_client_measured is None
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= request_record.transmission_start
+    #                 <= request_record.transmission_end
+    #                 < response_record.transmission_start
+    #                 <= response_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("request_message, response_messages", [
+    #     (UdsMessage(payload=[0x22, 0x10, 0x00],
+    #                 addressing_type=AddressingType.PHYSICAL),
+    #      (UdsMessage(payload=[0x7F, 0x22, 0x78],
+    #                  addressing_type=AddressingType.PHYSICAL),
+    #       UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
+    #                  addressing_type=AddressingType.PHYSICAL))),
+    #     (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
+    #                 addressing_type=AddressingType.PHYSICAL),
+    #      (UdsMessage(payload=[0x7F, 0x2E, 0x78],
+    #                  addressing_type=AddressingType.PHYSICAL),
+    #       UdsMessage(payload=[0x7F, 0x2E, 0x78],
+    #                  addressing_type=AddressingType.PHYSICAL),
+    #       UdsMessage(payload=[0x7F, 0x2E, 0x78],
+    #                  addressing_type=AddressingType.PHYSICAL),
+    #       UdsMessage(payload=[0x6E, 0x23, 0x45],
+    #                  addressing_type=AddressingType.PHYSICAL))),
+    # ])
+    # @pytest.mark.parametrize("p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout, "
+    #                          "start_after, delay, send_after", [
+    #     (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_EXT_CLIENT_TIMEOUT, Client.DEFAULT_P6_EXT_CLIENT_TIMEOUT,
+    #      20, 1000, 500),
+    #     (100, 1000, 5000,
+    #      50, 750, 80),
+    # ])
+    # def test_send_request_receive_responses__delayed(self, request_message, response_messages,
+    #                                                  p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout,
+    #                                                  start_after, delay, send_after):
+    #     """
+    #     Check Client for sending UDS request and receiving delayed UDS response.
+    #
+    #     Procedure:
+    #     1. Configure Client.
+    #     2. Schedule response messages (Response Pending and Final Response) sending by the second Transport Interface.
+    #     3. Schedule request message reception by the second Transport Interface.
+    #     4. Send UDS request messages and received UDS response by the Client.
+    #     5. Validate attributes of request and response records.
+    #         Expected: Attributes values of returned records match values of request and response messages that
+    #             were scheduled for transmission.
+    #     6. Validate timing parameters.
+    #         Expected: Measured values of P2Client, P2*Client and P6*Client time parameters are updated and stored by
+    #             Client. Measured value of P6Client is equal to None (not measured).
+    #
+    #     :param request_message: Request message to send by Client.
+    #     :param response_messages: Response message to receive by Client.
+    #     :param p2_client_timeout: P2Client timeout value to configure in Client.
+    #     :param p2_ext_client_timeout: P2*Client timeout value to configure in Client.
+    #     :param p6_ext_client_timeout: P6*Client timeout value to configure in Client.
+    #     :param start_after: Time after which the first Response Pending message would be sent.
+    #     :param delay: Time after which following Response Pending messages are sent.
+    #     :param send_after: Time after which the final response message would be sent.
+    #     """
+    #     client = Client(transport_interface=self.transport_interface_1,
+    #                     p2_client_timeout=p2_client_timeout,
+    #                     p6_client_timeout=p2_client_timeout,
+    #                     p2_ext_client_timeout=p2_ext_client_timeout,
+    #                     p6_ext_client_timeout=p6_ext_client_timeout)
+    #     self.send_message(transport_interface=self.transport_interface_2,
+    #                       message=response_messages[0],
+    #                       delay=start_after)
+    #     for i, response_message in enumerate(response_messages[1:-1], start=1):
+    #         self.send_message(transport_interface=self.transport_interface_2,
+    #                           message=response_message,
+    #                           delay=start_after + delay * i)
+    #     self.send_message(transport_interface=self.transport_interface_2,
+    #                       message=response_messages[-1],
+    #                       delay=start_after + delay * len(response_messages[1:-1]) + send_after)
+    #     self.receive_message(transport_interface=self.transport_interface_2,
+    #                          delay=0,
+    #                          start_timeout=10000,
+    #                          end_timeout=None)
+    #     time_before = time()
+    #     request_record, response_records = client.send_request_receive_responses(request=request_message)
+    #     time_after = time()
+    #     # check sent message
+    #     assert isinstance(request_record, UdsMessageRecord)
+    #     assert request_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert request_record.payload == request_message.payload
+    #     assert request_record.addressing_type == request_message.addressing_type
+    #     # check received response
+    #     assert isinstance(response_records, tuple)
+    #     assert len(response_records) == len(response_messages)
+    #     for i, response_record in enumerate(response_records):
+    #         assert response_record.direction == TransmissionDirection.RECEIVED
+    #         assert response_record.payload == response_messages[i].payload
+    #         assert response_record.addressing_type == response_messages[i].addressing_type
+    #     # measured time parameters
+    #     assert (client.p2_client_measured
+    #             == (response_records[0].transmission_start - request_record.transmission_end).total_seconds() * 1000.)
+    #     assert isinstance(client.p2_ext_client_measured, tuple)
+    #     assert len(client.p2_ext_client_measured) == len(response_records) - 1
+    #     for i, response_record in enumerate(response_records[1:]):
+    #         assert (client.p2_ext_client_measured[i]
+    #                 == (response_record.transmission_end - response_records[
+    #                     i].transmission_end).total_seconds() * 1000.)
+    #     assert (client.p6_ext_client_measured
+    #             == (response_records[-1].transmission_end - request_record.transmission_end).total_seconds() * 1000.)
+    #     assert client.p6_client_measured is None
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= request_record.transmission_start
+    #                 <= request_record.transmission_end
+    #                 < response_records[0].transmission_start
+    #                 <= response_records[0].transmission_end
+    #                 < response_records[-1].transmission_start
+    #                 <= response_records[-1].transmission_end
+    #                 <= datetime.fromtimestamp(time_after + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("request_message, response_message", [
+    #     (UdsMessage(payload=[0x3E, 0x00],
+    #                 addressing_type=AddressingType.FUNCTIONAL),
+    #      UdsMessage(payload=[0x7E, 0x00],
+    #                 addressing_type=AddressingType.FUNCTIONAL)),
+    #     (UdsMessage(payload=[0x22, 0x10, 0x00],
+    #                 addressing_type=AddressingType.PHYSICAL),
+    #      UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
+    #                 addressing_type=AddressingType.PHYSICAL)),
+    #     (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
+    #                 addressing_type=AddressingType.PHYSICAL),
+    #      UdsMessage(payload=[0x7F, 0x2E, 0x7E],
+    #                 addressing_type=AddressingType.PHYSICAL)),
+    # ])
+    # @pytest.mark.parametrize("p2_client_timeout, send_after", [
+    #     (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT + 30),
+    #     (200, 230),
+    # ])
+    # def test_send_request_receive_responses__p2_timeout(self, request_message, response_message,
+    #                                                     p2_client_timeout, send_after):
+    #     """
+    #     Check for a P2Client timeout.
+    #
+    #     Procedure:
+    #     1. Configure Client.
+    #     2. Schedule response message sending by the second Transport Interface just after P2Client timeout is reached.
+    #     3. Schedule request message reception by the second Transport Interface.
+    #     4. Send UDS request message and received UDS response by the Client.
+    #
+    #     :param request_message: Request message to send by Client.
+    #     :param response_message: Response message to receive by Client.
+    #     :param p2_client_timeout: P2Client timeout value to configure in Client.
+    #     :param send_after: Time after which response message would be sent.
+    #     """
+    #     client = Client(transport_interface=self.transport_interface_1,
+    #                     p2_client_timeout=p2_client_timeout,
+    #                     p6_client_timeout=2*p2_client_timeout)
+    #     self.send_message(transport_interface=self.transport_interface_2,
+    #                       message=response_message,
+    #                       delay=send_after)
+    #     self.receive_message(transport_interface=self.transport_interface_2,
+    #                          delay=0,
+    #                          start_timeout=100,
+    #                          end_timeout=None)
+    #     time_before = time()
+    #     request_record, response_records = client.send_request_receive_responses(request=request_message)
+    #     time_after = time()
+    #     # check received response
+    #     assert isinstance(request_record, UdsMessageRecord)
+    #     assert request_record.payload == request_message.payload
+    #     assert request_record.addressing_type == request_message.addressing_type
+    #     assert isinstance(response_records, tuple) and len(response_records) == 0
+    #     # measured time parameters
+    #     assert client.p2_client_measured is None
+    #     assert client.p2_ext_client_measured is None
+    #     assert client.p6_client_measured is None
+    #     assert client.p6_ext_client_measured is None
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         receiving_time_ms = (time_after - time_before) * 1000.
+    #         assert (p2_client_timeout
+    #                 <= receiving_time_ms
+    #                 < send_after + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("request_message, response_message", [
+    #     (UdsMessage(payload=[0x22, 0x10, 0x00],
+    #                 addressing_type=AddressingType.PHYSICAL),
+    #      UdsMessage(payload=[0x62, 0x10, 0x00] + [*range(255)] * 20,
+    #                 addressing_type=AddressingType.PHYSICAL)),
+    #     (UdsMessage(payload=[0x22, *range(255, -1, -1)],
+    #                 addressing_type=AddressingType.PHYSICAL),
+    #      UdsMessage(payload=[0x62] + [*range(255, -1, -1)] * 100,
+    #                 addressing_type=AddressingType.PHYSICAL)),
+    # ])
+    # @pytest.mark.parametrize("p2_client_timeout, p6_client_timeout, send_after", [
+    #     (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT - 30),
+    #     (50, 100, 10),
+    # ])
+    # def test_send_request_receive_responses__p6_timeout(self, request_message, response_message,
+    #                                                     p2_client_timeout, p6_client_timeout, send_after):
+    #     """
+    #     Check for a P2Client timeout.
+    #
+    #     Procedure:
+    #     1. Configure Client.
+    #     2. Schedule response message sending by the second Transport Interface just after P2Client timeout is reached.
+    #     3. Schedule request message reception by the second Transport Interface.
+    #     4. Send UDS request message and received UDS response by the Client.
+    #
+    #     :param request_message: Request message to send by Client.
+    #     :param response_message: Response message to receive by Client.
+    #     :param p2_client_timeout: P2Client timeout value to configure in Client.
+    #     :param send_after: Time after which response message would be sent.
+    #     """
+    #     self.configure_slow_message_reception()
+    #     client = Client(transport_interface=self.transport_interface_1,
+    #                     p2_client_timeout=p2_client_timeout,
+    #                     p6_client_timeout=p6_client_timeout)
+    #     self.send_message(transport_interface=self.transport_interface_2,
+    #                       message=response_message,
+    #                       delay=send_after)
+    #     self.receive_message(transport_interface=self.transport_interface_2,
+    #                          delay=0,
+    #                          start_timeout=100,
+    #                          end_timeout=None)
+    #     time_before = time()
+    #     with pytest.raises(TimeoutError):
+    #         client.send_request_receive_responses(request=request_message)
+    #     time_after = time()
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         receiving_time_ms = (time_after - time_before) * 1000.
+    #         assert (p6_client_timeout
+    #                 <= receiving_time_ms
+    #                 < p6_client_timeout + 2*self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("request_message, response_messages", [
+    #     (UdsMessage(payload=[0x22, 0x10, 0x00],
+    #                 addressing_type=AddressingType.PHYSICAL),
+    #      (UdsMessage(payload=[0x7F, 0x22, 0x78],
+    #                  addressing_type=AddressingType.PHYSICAL),
+    #       UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
+    #                  addressing_type=AddressingType.PHYSICAL))),
+    #     (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
+    #                 addressing_type=AddressingType.PHYSICAL),
+    #      (UdsMessage(payload=[0x7F, 0x2E, 0x78],
+    #                  addressing_type=AddressingType.PHYSICAL),
+    #       UdsMessage(payload=[0x7F, 0x2E, 0x78],
+    #                  addressing_type=AddressingType.PHYSICAL),
+    #       UdsMessage(payload=[0x7F, 0x2E, 0x78],
+    #                  addressing_type=AddressingType.PHYSICAL),
+    #       UdsMessage(payload=[0x6E, 0x23, 0x45],
+    #                  addressing_type=AddressingType.PHYSICAL))),
+    # ])
+    # @pytest.mark.parametrize("p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout, "
+    #                          "start_after, delay, send_after", [
+    #     (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_EXT_CLIENT_TIMEOUT, Client.DEFAULT_P6_EXT_CLIENT_TIMEOUT,
+    #      20, 1000, Client.DEFAULT_P2_EXT_CLIENT_TIMEOUT + 50),
+    #     (100, 1000, 5000,
+    #      50, 750, 1050),
+    # ])
+    # def test_send_request_receive_responses__p2_ext_timeout(self, request_message, response_messages,
+    #                                                         p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout,
+    #                                                         start_after, delay, send_after):
+    #     """
+    #     Check Client for sending UDS request and receiving delayed UDS response.
+    #
+    #     Procedure:
+    #     1. Configure Client.
+    #     2. Schedule response messages (Response Pending and Final Response) sending by the second Transport Interface.
+    #     3. Schedule request message reception by the second Transport Interface.
+    #     4. Send UDS request messages and received UDS response by the Client.
+    #     5. Validate attributes of request and response records.
+    #         Expected: Attributes values of returned records match values of request and response messages that
+    #             were scheduled for transmission.
+    #     6. Validate timing parameters.
+    #         Expected: Measured values of P2Client, P2*Client and P6*Client time parameters are updated and stored by
+    #             Client. Measured value of P6Client is equal to None (not measured).
+    #
+    #     :param request_message: Request message to send by Client.
+    #     :param response_messages: Response message to receive by Client.
+    #     :param p2_client_timeout: P2Client timeout value to configure in Client.
+    #     :param p2_ext_client_timeout: P2*Client timeout value to configure in Client.
+    #     :param p6_ext_client_timeout: P6*Client timeout value to configure in Client.
+    #     :param start_after: Time after which the first Response Pending message would be sent.
+    #     :param delay: Time after which following Response Pending messages are sent.
+    #     :param send_after: Time after which the final response message would be sent.
+    #     """
+    #     client = Client(transport_interface=self.transport_interface_1,
+    #                     p2_client_timeout=p2_client_timeout,
+    #                     p6_client_timeout=p2_client_timeout,
+    #                     p2_ext_client_timeout=p2_ext_client_timeout,
+    #                     p6_ext_client_timeout=p6_ext_client_timeout)
+    #     self.send_message(transport_interface=self.transport_interface_2,
+    #                       message=response_messages[0],
+    #                       delay=start_after)
+    #     for i, response_message in enumerate(response_messages[1:-1], start=1):
+    #         self.send_message(transport_interface=self.transport_interface_2,
+    #                           message=response_message,
+    #                           delay=start_after + delay * i)
+    #     self.send_message(transport_interface=self.transport_interface_2,
+    #                       message=response_messages[-1],
+    #                       delay=start_after + delay * len(response_messages[1:-1]) + send_after)
+    #     self.receive_message(transport_interface=self.transport_interface_2,
+    #                          delay=0,
+    #                          start_timeout=10000,
+    #                          end_timeout=None)
+    #     with pytest.raises(TimeoutError):
+    #         client.send_request_receive_responses(request=request_message)
 
     @pytest.mark.parametrize("request_message, response_messages", [
-        (UdsMessage(payload=[0x22, 0x10, 0x00],
-                    addressing_type=AddressingType.PHYSICAL),
-         (UdsMessage(payload=[0x7F, 0x22, 0x78],
-                     addressing_type=AddressingType.PHYSICAL),
-          UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
-                     addressing_type=AddressingType.PHYSICAL))),
+        # (UdsMessage(payload=[0x22, 0x10, 0x00],
+        #             addressing_type=AddressingType.PHYSICAL),
+        #  (UdsMessage(payload=[0x7F, 0x22, 0x78],
+        #              addressing_type=AddressingType.PHYSICAL),
+        #   UdsMessage(payload=[0x7F, 0x22, 0x78],
+        #              addressing_type=AddressingType.PHYSICAL),
+        #   UdsMessage(payload=[0x62, 0x10, 0x00] + [*range(255)] * 50,
+        #              addressing_type=AddressingType.PHYSICAL))),
         (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
                     addressing_type=AddressingType.PHYSICAL),
          (UdsMessage(payload=[0x7F, 0x2E, 0x78],
@@ -150,14 +454,15 @@ class AbstractClientTests(BaseSystemTests, ABC):
     ])
     @pytest.mark.parametrize("p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout, "
                              "start_after, delay, send_after", [
-        (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_EXT_CLIENT_TIMEOUT, Client.DEFAULT_P6_EXT_CLIENT_TIMEOUT,
-         20, 1000, 500),
-        (100, 1000, 5000,
-         50, 750, 80),
-    ])
-    def test_send_request_receive_responses__delayed(self, request_message, response_messages,
-                                                     p2_client_timeout, p2_ext_client_timeout, p6_ext_client_timeout,
-                                                     start_after, delay, send_after):
+                                 (50, 1000, 2250,
+                                  40, 900, 950),
+                                 # (100, 250, 400,
+                                 #  50, 200, 200),
+                             ])
+    def test_send_request_receive_responses__p6_ext_timeout(self, request_message, response_messages,
+                                                            p2_client_timeout, p2_ext_client_timeout,
+                                                            p6_ext_client_timeout,
+                                                            start_after, delay, send_after):
         """
         Check Client for sending UDS request and receiving delayed UDS response.
 
@@ -182,6 +487,7 @@ class AbstractClientTests(BaseSystemTests, ABC):
         :param delay: Time after which following Response Pending messages are sent.
         :param send_after: Time after which the final response message would be sent.
         """
+        self.configure_slow_message_reception()
         client = Client(transport_interface=self.transport_interface_1,
                         p2_client_timeout=p2_client_timeout,
                         p6_client_timeout=p2_client_timeout,
@@ -202,189 +508,107 @@ class AbstractClientTests(BaseSystemTests, ABC):
                              start_timeout=10000,
                              end_timeout=None)
         time_before = time()
-        request_record, response_records = client.send_request_receive_responses(request=request_message)
-        time_after = time()
-        # check sent message
-        assert isinstance(request_record, UdsMessageRecord)
-        assert request_record.direction == TransmissionDirection.TRANSMITTED
-        assert request_record.payload == request_message.payload
-        assert request_record.addressing_type == request_message.addressing_type
-        # check received response
-        assert isinstance(response_records, tuple)
-        assert len(response_records) == len(response_messages)
-        for i, response_record in enumerate(response_records):
-            assert response_record.direction == TransmissionDirection.RECEIVED
-            assert response_record.payload == response_messages[i].payload
-            assert response_record.addressing_type == response_messages[i].addressing_type
-        # measured time parameters
-        assert (client.p2_client_measured
-                == (response_records[0].transmission_start - request_record.transmission_end).total_seconds() * 1000.)
-        assert isinstance(client.p2_ext_client_measured, tuple)
-        assert len(client.p2_ext_client_measured) == len(response_records) - 1
-        for i, response_record in enumerate(response_records[1:]):
-            assert (client.p2_ext_client_measured[i]
-                    == (response_record.transmission_end - response_records[
-                        i].transmission_end).total_seconds() * 1000.)
-        assert (client.p6_ext_client_measured
-                == (response_records[-1].transmission_end - request_record.transmission_end).total_seconds() * 1000.)
-        assert client.p6_client_measured is None
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= request_record.transmission_start
-                    <= request_record.transmission_end
-                    < response_records[0].transmission_start
-                    <= response_records[0].transmission_end
-                    < response_records[-1].transmission_start
-                    <= response_records[-1].transmission_end
-                    <= datetime.fromtimestamp(time_after + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("request_message, response_message", [
-        (UdsMessage(payload=[0x3E, 0x00],
-                    addressing_type=AddressingType.FUNCTIONAL),
-         UdsMessage(payload=[0x7E, 0x00],
-                    addressing_type=AddressingType.FUNCTIONAL)),
-        (UdsMessage(payload=[0x22, 0x10, 0x00],
-                    addressing_type=AddressingType.PHYSICAL),
-         UdsMessage(payload=[0x62, 0x10, 0x00, *range(255)],
-                    addressing_type=AddressingType.PHYSICAL)),
-        (UdsMessage(payload=[0x2E, 0x23, 0x45, *range(0, 255, 2), *(1, 255, 2)],
-                    addressing_type=AddressingType.PHYSICAL),
-         UdsMessage(payload=[0x7F, 0x2E, 0x7E],
-                    addressing_type=AddressingType.PHYSICAL)),
-    ])
-    @pytest.mark.parametrize("p2_client_timeout, send_after", [
-        (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT + 30),
-        (200, 230),
-    ])
-    def test_send_request_receive_responses__p2_timeout(self, request_message, response_message,
-                                                        p2_client_timeout, send_after):
-        """
-        Check for a P2Client timeout.
-
-        Procedure:
-        1. Configure Client.
-        2. Schedule response message sending by the second Transport Interface just after P2Client timeout is reached.
-        3. Schedule request message reception by the second Transport Interface.
-        4. Send UDS request message and received UDS response by the Client.
-
-        :param request_message: Request message to send by Client.
-        :param response_message: Response message to receive by Client.
-        :param p2_client_timeout: P2Client timeout value to configure in Client.
-        :param send_after: Time after which response message would be sent.
-        """
-        client = Client(transport_interface=self.transport_interface_1,
-                        p2_client_timeout=p2_client_timeout,
-                        p6_client_timeout=2*p2_client_timeout)
-        self.send_message(transport_interface=self.transport_interface_2,
-                          message=response_message,
-                          delay=send_after)
-        self.receive_message(transport_interface=self.transport_interface_2,
-                             delay=0,
-                             start_timeout=100,
-                             end_timeout=None)
-        time_before = time()
         with pytest.raises(TimeoutError):
-            client.send_request_receive_responses(request=request_message)
+            client.send_request_receive_responses(request=request_message)  # TODO: P6*Client is not handled properly
         time_after = time()
         # performance checks
         if self.MAKE_TIMING_CHECKS:
             receiving_time_ms = (time_after - time_before) * 1000.
-            assert p2_client_timeout <= receiving_time_ms < send_after + self.TASK_TIMING_TOLERANCE
-
-    # TODO: P6Client timeout
-    # TODO: P2*Client timeout
-    # TODO: P6*Client timeout
+            assert (p6_ext_client_timeout
+                    <= receiving_time_ms
+                    < p6_ext_client_timeout + start_after + 2*self.TASK_TIMING_TOLERANCE)
 
     # Tester Present
 
-    @pytest.mark.parametrize("addressing_type, sprmib, s3_client", [
-        (AddressingType.FUNCTIONAL, True, 1000),
-        (AddressingType.PHYSICAL, False, 500),
-    ])
-    def test_start_stop_tester_present(self, addressing_type, sprmib, s3_client):
-        """
-        Check for starting and stopping cyclical Tester Present sending.
-
-        Procedure:
-        1. Configure Client.
-        2. Start cyclical Tester Present transmission.
-        3. Receive 5 Tester Present messages.
-        4. Stop cyclical Tester Present transmission.
-        5. Check Tester Present message reception.
-            Expected: No message received.
-        6. Validate received Tester Present records.
-            Expected: Received Tester Present records period and attributes matches preconfigured values.
-
-        :param addressing_type: Addressing Type to use for Tester Present transmission.
-        :param sprmib: Whether Tester Present message have suppressPosRspMsgIndicationBit set.
-        :param s3_client: S3Client value to configure in Client.
-        """
-        client = Client(transport_interface=self.transport_interface_1,
-                        s3_client=s3_client)
-        tester_present_records: List[UdsMessageRecord] = []
-        client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
-        for i in range(5):
-            tester_present_records.append(self.transport_interface_2.receive_message(start_timeout=2 * s3_client))
-        client.stop_tester_present()
-        with pytest.raises(TimeoutError):
-            self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
-        # check sent messages
-        payload = b"\x3E\x80" if sprmib else b"\x3E\x00"
-        assert all([tp_record.payload == payload for tp_record in tester_present_records])
-        rx_physical_params = dict(self.transport_interface_2.addressing_information.rx_physical_params)
-        rx_functional_params = dict(self.transport_interface_2.addressing_information.rx_functional_params)
-        rx_physical_params.pop("addressing_type")
-        rx_functional_params.pop("addressing_type")
-        if rx_physical_params != rx_functional_params:  # make sure addressing parameters differ
-            assert all([tp_record.addressing_type == addressing_type for tp_record in tester_present_records])
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            for i, tp_record in enumerate(tester_present_records[1:]):
-                s3_client_measured = (tp_record.transmission_start.timestamp()
-                                      - tester_present_records[i].transmission_start.timestamp())
-                assert (s3_client - self.TASK_TIMING_TOLERANCE
-                        <=  s3_client_measured * 1000.
-                        <= s3_client + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("addressing_type, sprmib, s3_client", [
-        (AddressingType.FUNCTIONAL, True, 1000),
-        (AddressingType.PHYSICAL, False, 500),
-    ])
-    def test_restart_tester_present(self, addressing_type, sprmib, s3_client):
-        """
-        Check for restarting cyclical Tester Present sending.
-
-        Procedure:
-        1. Configure Client.
-        2. Start cyclical Tester Present transmission.
-        3. Receive 1 Tester Present message.
-        4. Stop cyclical Tester Present transmission.
-        5. Check Tester Present message reception.
-            Expected: No message received.
-        6. Restart cyclical Tester Present transmission.
-        7. Receive 1 Tester Present message.
-        8. Check Tester Present message reception.
-            Expected: No message received.
-        6. Validate received Tester Present records.
-            Expected: Received Tester Present records attributes matches preconfigured values.
-
-        :param addressing_type: Addressing Type to use for Tester Present transmission.
-        :param sprmib: Whether Tester Present message have suppressPosRspMsgIndicationBit set.
-        """
-        client = Client(transport_interface=self.transport_interface_1,
-                        s3_client=s3_client)
-        client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
-        tester_present_record_1 = self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
-        client.stop_tester_present()
-        with pytest.raises(TimeoutError):
-            self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
-        client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
-        tester_present_record_2 = self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
-        client.stop_tester_present()
-        with pytest.raises(TimeoutError):
-            self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
-        # check sent messages
-        payload = b"\x3E\x80" if sprmib else b"\x3E\x00"
-        assert tester_present_record_1.payload == tester_present_record_2.payload == payload
-        assert tester_present_record_1.addressing_type == tester_present_record_2.addressing_type  # do not compare with addressing_type in case the same rx and tx AI parameters
+    # @pytest.mark.parametrize("addressing_type, sprmib, s3_client", [
+    #     (AddressingType.FUNCTIONAL, True, 1000),
+    #     (AddressingType.PHYSICAL, False, 500),
+    # ])
+    # def test_start_stop_tester_present(self, addressing_type, sprmib, s3_client):
+    #     """
+    #     Check for starting and stopping cyclical Tester Present sending.
+    #
+    #     Procedure:
+    #     1. Configure Client.
+    #     2. Start cyclical Tester Present transmission.
+    #     3. Receive 5 Tester Present messages.
+    #     4. Stop cyclical Tester Present transmission.
+    #     5. Check Tester Present message reception.
+    #         Expected: No message received.
+    #     6. Validate received Tester Present records.
+    #         Expected: Received Tester Present records period and attributes matches preconfigured values.
+    #
+    #     :param addressing_type: Addressing Type to use for Tester Present transmission.
+    #     :param sprmib: Whether Tester Present message have suppressPosRspMsgIndicationBit set.
+    #     :param s3_client: S3Client value to configure in Client.
+    #     """
+    #     client = Client(transport_interface=self.transport_interface_1,
+    #                     p6_client_timeout=s3_client,
+    #                     s3_client=s3_client)
+    #     tester_present_records: List[UdsMessageRecord] = []
+    #     client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
+    #     for i in range(5):
+    #         tester_present_records.append(self.transport_interface_2.receive_message(start_timeout=2 * s3_client))
+    #     client.stop_tester_present()
+    #     with pytest.raises(TimeoutError):
+    #         self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
+    #     # check sent messages
+    #     payload = b"\x3E\x80" if sprmib else b"\x3E\x00"
+    #     assert all([tp_record.payload == payload for tp_record in tester_present_records])
+    #     rx_physical_params = dict(self.transport_interface_2.addressing_information.rx_physical_params)
+    #     rx_functional_params = dict(self.transport_interface_2.addressing_information.rx_functional_params)
+    #     rx_physical_params.pop("addressing_type")
+    #     rx_functional_params.pop("addressing_type")
+    #     if rx_physical_params != rx_functional_params:  # make sure addressing parameters differ
+    #         assert all([tp_record.addressing_type == addressing_type for tp_record in tester_present_records])
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         for i, tp_record in enumerate(tester_present_records[1:]):
+    #             s3_client_measured = (tp_record.transmission_start.timestamp()
+    #                                   - tester_present_records[i].transmission_start.timestamp())
+    #             assert (s3_client - self.TASK_TIMING_TOLERANCE
+    #                     <=  s3_client_measured * 1000.
+    #                     <= s3_client + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("addressing_type, sprmib, s3_client", [
+    #     (AddressingType.FUNCTIONAL, True, 1000),
+    #     (AddressingType.PHYSICAL, False, 500),
+    # ])
+    # def test_restart_tester_present(self, addressing_type, sprmib, s3_client):
+    #     """
+    #     Check for restarting cyclical Tester Present sending.
+    #
+    #     Procedure:
+    #     1. Configure Client.
+    #     2. Start cyclical Tester Present transmission.
+    #     3. Receive 1 Tester Present message.
+    #     4. Stop cyclical Tester Present transmission.
+    #     5. Check Tester Present message reception.
+    #         Expected: No message received.
+    #     6. Restart cyclical Tester Present transmission.
+    #     7. Receive 1 Tester Present message.
+    #     8. Check Tester Present message reception.
+    #         Expected: No message received.
+    #     6. Validate received Tester Present records.
+    #         Expected: Received Tester Present records attributes matches preconfigured values.
+    #
+    #     :param addressing_type: Addressing Type to use for Tester Present transmission.
+    #     :param sprmib: Whether Tester Present message have suppressPosRspMsgIndicationBit set.
+    #     """
+    #     client = Client(transport_interface=self.transport_interface_1,
+    #                     p6_client_timeout=s3_client,
+    #                     s3_client=s3_client)
+    #     client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
+    #     tester_present_record_1 = self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
+    #     client.stop_tester_present()
+    #     with pytest.raises(TimeoutError):
+    #         self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
+    #     client.start_tester_present(addressing_type=addressing_type, sprmib=sprmib)
+    #     tester_present_record_2 = self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
+    #     client.stop_tester_present()
+    #     with pytest.raises(TimeoutError):
+    #         self.transport_interface_2.receive_message(start_timeout=2 * s3_client)
+    #     # check sent messages
+    #     payload = b"\x3E\x80" if sprmib else b"\x3E\x00"
+    #     assert tester_present_record_1.payload == tester_present_record_2.payload == payload
+    #     assert tester_present_record_1.addressing_type == tester_present_record_2.addressing_type  # do not compare with addressing_type in case the same rx and tx AI parameters

--- a/tests/system_tests/client/test_client.py
+++ b/tests/system_tests/client/test_client.py
@@ -66,7 +66,7 @@ class AbstractClientTests(BaseSystemTests, ABC):
     ])
     @pytest.mark.parametrize("p2_client_timeout, p6_client_timeout, send_after", [
         (Client.DEFAULT_P2_CLIENT_TIMEOUT, Client.DEFAULT_P6_CLIENT_TIMEOUT, Client.DEFAULT_P2_CLIENT_TIMEOUT - 30),
-        (100, 100, 50),
+        (250, 250, 150),
     ])
     def test_send_request_receive_responses__direct(self, request_message, response_message,
                                                     p2_client_timeout, p6_client_timeout, send_after):

--- a/uds/can/packet/flow_control.py
+++ b/uds/can/packet/flow_control.py
@@ -126,7 +126,7 @@ class CanSTminTranslator:
 
         :param time_value: STmin time in milliseconds.
 
-        :raise TypeError: Provided value is not int or flow type.
+        :raise TypeError: Provided value is not int or float type.
         :raise ValueError: Value out of supported range.
 
         :return: Raw value of STmin.

--- a/uds/can/transport_interface/python_can.py
+++ b/uds/can/transport_interface/python_can.py
@@ -35,7 +35,7 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
     .. note:: Documentation for python-can package: https://python-can.readthedocs.io/
     """
 
-    _MAX_LISTENER_TIMEOUT: float = 4280000.  # ms
+    _MAX_LISTENER_TIMEOUT: float = 4280.  # s
     """Maximal timeout value accepted by python-can listeners."""
     _MIN_NOTIFIER_TIMEOUT: float = 0.001  # s
     """Minimal timeout for notifiers that does not cause malfunctioning of listeners."""
@@ -358,7 +358,7 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
             # handle following Consecutive Frame
             if (received_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
                     and received_packet.sequence_number == sequence_number):
-                timestamp_start = time()
+                timestamp_start = perf_counter()
                 received_cf.append(received_packet)
                 received_payload_size += len(received_packet.payload)  # type: ignore
                 sequence_number = (received_packet.sequence_number + 1) & 0xF
@@ -416,7 +416,7 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
             # handle following Consecutive Frame
             if (received_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
                     and received_packet.sequence_number == sequence_number):
-                timestamp_start = time()
+                timestamp_start = perf_counter()
                 received_cf.append(received_packet)
                 received_payload_size += len(received_packet.payload)  # type: ignore
                 sequence_number = (received_packet.sequence_number + 1) & 0xF

--- a/uds/can/transport_interface/python_can.py
+++ b/uds/can/transport_interface/python_can.py
@@ -440,12 +440,11 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         sequence_number: int = 1
         flow_control_iterator = iter(self.flow_control_parameters_generator)
         while True:
-            time_now = time()
             if timestamp_end is not None:
-                remaining_end_timeout_ms = (timestamp_end - time()) * 1000.
+                remaining_end_timeout_ms = (timestamp_end - perf_counter()) * 1000.
                 if remaining_end_timeout_ms < 0:
                     raise TimeoutError("Total message reception timeout was reached.")
-            time_elapsed_ms = (time_now - packets_records[-1].transmission_time.timestamp()) * 1000.
+            time_elapsed_ms = (time() - packets_records[-1].transmission_time.timestamp()) * 1000.
             remaining_n_br_timeout_ms = self.n_br - time_elapsed_ms
             if remaining_n_br_timeout_ms > 0:
                 try:
@@ -505,12 +504,11 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         sequence_number: int = 1
         flow_control_iterator = iter(self.flow_control_parameters_generator)
         while True:
-            time_now = time()
             if timestamp_end is not None:
-                remaining_end_timeout_ms = (timestamp_end - time()) * 1000.
+                remaining_end_timeout_ms = (timestamp_end - perf_counter()) * 1000.
                 if remaining_end_timeout_ms < 0:
                     raise TimeoutError("Total message reception timeout was reached.")
-            time_elapsed_ms = (time_now - packets_records[-1].transmission_time.timestamp()) * 1000.
+            time_elapsed_ms = (time() - packets_records[-1].transmission_time.timestamp()) * 1000.
             remaining_n_br_timeout_ms = self.n_br - time_elapsed_ms
             if remaining_n_br_timeout_ms > 0:
                 try:
@@ -818,8 +816,6 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         """
         Receive UDS message over CAN.
 
-        .. warning:: Value of end_timeout must not be less than the value of start_timeout.
-
         :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
             Leave None to wait forever.
         :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
@@ -849,6 +845,8 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
             timestamp_end_timeout = timestamp_now + end_timeout / 1000.
         else:
             timestamp_end_timeout = None
+        if start_timeout is not None and end_timeout is not None and end_timeout < start_timeout:
+            timestamp_start_timeout = timestamp_end_timeout
         self.__setup_notifier()
         while True:
             # calculate remaining timeout
@@ -876,8 +874,6 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
                                     loop: Optional[AbstractEventLoop] = None) -> UdsMessageRecord:
         """
         Receive asynchronously UDS message over CAN.
-
-        .. warning:: Value of end_timeout must not be less than the value of start_timeout.
 
         :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
             Leave None to wait forever.
@@ -909,6 +905,8 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
             timestamp_end_timeout = timestamp_now + end_timeout / 1000.
         else:
             timestamp_end_timeout = None
+        if start_timeout is not None and end_timeout is not None and end_timeout < start_timeout:
+            timestamp_start_timeout = timestamp_end_timeout
         loop = get_running_loop() if loop is None else loop
         self.__setup_async_notifier(loop=loop)
         while True:

--- a/uds/client.py
+++ b/uds/client.py
@@ -357,13 +357,13 @@ class Client:
         """
         timestamp_start = perf_counter()
         remaining_start_timeout_ms = start_timeout  # either P2Client or P2*Client
-        remaining_end_timeout__ms = end_timeout  # either P6Client or P6*Client
-        while remaining_start_timeout_ms > 0 and remaining_end_timeout__ms > 0:
+        remaining_end_timeout_ms = end_timeout  # either P6Client or P6*Client
+        while remaining_start_timeout_ms > 0 and remaining_end_timeout_ms > 0:
             # try to receive a message
             try:
                 response_record = self.transport_interface.receive_message(
-                    start_timeout=min(remaining_start_timeout_ms, remaining_end_timeout__ms),
-                    end_timeout=remaining_end_timeout__ms)
+                    start_timeout=min(remaining_start_timeout_ms, remaining_end_timeout_ms),
+                    end_timeout=remaining_end_timeout_ms)
             except MessageTransmissionNotStartedError:
                 return None
             # positive response message received
@@ -377,7 +377,7 @@ class Client:
             # update time parameters
             time_elapsed_ms = (perf_counter() - timestamp_start) * 1000.
             remaining_start_timeout_ms = start_timeout - time_elapsed_ms
-            remaining_end_timeout__ms = end_timeout - time_elapsed_ms
+            remaining_end_timeout_ms = end_timeout - time_elapsed_ms
         return None
 
     def _send_tester_present(self, tester_present_message: UdsMessage) -> None:

--- a/uds/client.py
+++ b/uds/client.py
@@ -347,7 +347,7 @@ class Client:
         time_remaining_ms = timeout
         while time_remaining_ms > 0:
             try:
-                response_record = self.transport_interface.receive_message(timeout=time_remaining_ms)
+                response_record = self.transport_interface.receive_message(start_timeout=time_remaining_ms)
             except TimeoutError:
                 return None
             # positive response message received

--- a/uds/client.py
+++ b/uds/client.py
@@ -362,7 +362,6 @@ class Client:
             try:
                 response_record = self.transport_interface.receive_message(start_timeout=start_timeout_remaining_ms,
                                                                            end_timeout=end_timeout_remaining_ms)
-                print(f"timestamp (_receive_response) = {time()}")
             except MessageTransmissionNotStartedError:
                 return None
             # positive response message received
@@ -520,7 +519,6 @@ class Client:
             return request_record, tuple()
         response_records.append(response_record)
         timestamp_end_timeout = time_request_sent + self.p6_ext_client_timeout / 1000.
-        print(f"timestamp_end_timeout = {timestamp_end_timeout}")
         while self.is_response_pending_message(message=response_records[-1], request_sid=sid):
             timestamp_start_timeout = (response_records[-1].transmission_end.timestamp()
                                        + self.p2_ext_client_timeout / 1000.)
@@ -528,7 +526,6 @@ class Client:
                 response_record = self._receive_response(sid=sid,
                                                          start_timeout=(timestamp_start_timeout - time()) * 1000.,
                                                          end_timeout=(timestamp_end_timeout - time()) * 1000.)
-                print(f"timestamp (send_request_receive_responses) = {time()}")
             except TimeoutError as exception:
                 raise TimeoutError("P6*Client timeout reached.") from exception
             if response_record is None:  # timeout achieved - no following response

--- a/uds/client.py
+++ b/uds/client.py
@@ -3,7 +3,7 @@
 __all__ = ["Client"]
 
 from threading import Event, Thread
-from time import monotonic, time
+from time import perf_counter, time
 from typing import List, Optional, Sequence, Tuple, Union
 from warnings import warn
 
@@ -13,8 +13,8 @@ from uds.translator import TESTER_PRESENT
 from uds.transport_interface import AbstractTransportInterface
 from uds.utilities import (
     InconsistencyError,
+    MessageTransmissionNotStartedError,
     ReassignmentError,
-MessageTransmissionNotStartedError,
     TimeMillisecondsAlias,
     ValueWarning,
     bytes_to_hex,
@@ -355,13 +355,15 @@ class Client:
         :return: Record with response message received to the last UDS request message sent.
             None if a timeout was reached.
         """
-        timestamp_start = time()
-        start_timeout_remaining_ms = start_timeout
-        end_timeout_remaining_ms = end_timeout
-        while start_timeout_remaining_ms > 0 and end_timeout_remaining_ms > 0:
+        timestamp_start = perf_counter()
+        remaining_start_timeout_ms = start_timeout  # either P2Client or P2*Client
+        remaining_end_timeout__ms = end_timeout  # either P6Client or P6*Client
+        while remaining_start_timeout_ms > 0 and remaining_end_timeout__ms > 0:
+            # try to receive a message
             try:
-                response_record = self.transport_interface.receive_message(start_timeout=start_timeout_remaining_ms,
-                                                                           end_timeout=end_timeout_remaining_ms)
+                response_record = self.transport_interface.receive_message(
+                    start_timeout=min(remaining_start_timeout_ms, remaining_end_timeout__ms),
+                    end_timeout=remaining_end_timeout__ms)
             except MessageTransmissionNotStartedError:
                 return None
             # positive response message received
@@ -372,9 +374,10 @@ class Client:
                 return response_record
             # other response message received
             # TODO: add it to response queue when created - https://github.com/mdabrowski1990/uds/issues/63
-            time_elapsed_ms = (time() - timestamp_start) * 1000.
-            start_timeout_remaining_ms = start_timeout - time_elapsed_ms
-            end_timeout_remaining_ms = end_timeout - time_elapsed_ms
+            # update time parameters
+            time_elapsed_ms = (perf_counter() - timestamp_start) * 1000.
+            remaining_start_timeout_ms = start_timeout - time_elapsed_ms
+            remaining_end_timeout__ms = end_timeout - time_elapsed_ms
         return None
 
     def _send_tester_present(self, tester_present_message: UdsMessage) -> None:
@@ -384,11 +387,11 @@ class Client:
         :param tester_present_message: Tester Present message to send.
         """
         period = self.s3_client / 1000.0
-        next_call = monotonic()
+        next_call = perf_counter()
         while not self.__tester_present_stop_event.is_set():
             self.transport_interface.send_message(tester_present_message)
             next_call += period
-            remaining_wait = next_call - monotonic()
+            remaining_wait = next_call - perf_counter()
             if self.__tester_present_stop_event.wait(remaining_wait):
                 break
 
@@ -508,34 +511,34 @@ class Client:
         time_request_sent = request_record.transmission_end.timestamp()
         sid = RequestSID(request_record.payload[0])
         response_records: List[UdsMessageRecord] = []
+        time_elapsed_ms = (time() - time_request_sent) * 1000.
         # get the first response (either final response or negative response with response pending nrc)
         try:
             response_record = self._receive_response(sid=sid,
-                                                     start_timeout=self.p2_client_timeout,
-                                                     end_timeout=self.p6_client_timeout)
+                                                     start_timeout=self.p2_client_timeout - time_elapsed_ms,
+                                                     end_timeout=self.p6_client_timeout - time_elapsed_ms)
         except TimeoutError as exception:
             raise TimeoutError("P6Client timeout reached.") from exception
         if response_record is None:  # timeout achieved - no response
             return request_record, tuple()
         response_records.append(response_record)
-        timestamp_end_timeout = time_request_sent + self.p6_ext_client_timeout / 1000.
+        timestamp_p6_ext_timeout = time_request_sent + self.p6_ext_client_timeout / 1000.
         while self.is_response_pending_message(message=response_records[-1], request_sid=sid):
-            timestamp_start_timeout = (response_records[-1].transmission_end.timestamp()
-                                       + self.p2_ext_client_timeout / 1000.)
+            timestamp_now = time()
+            timestamp_p2_ext_timeout = (response_records[-1].transmission_end.timestamp()
+                                        + self.p2_ext_client_timeout / 1000.)
+            remaining_p2_ext_timeout = (timestamp_p2_ext_timeout - timestamp_now) * 1000.
+            remaining_p6_ext_timeout = (timestamp_p6_ext_timeout - timestamp_now) * 1000.
             try:
                 response_record = self._receive_response(sid=sid,
-                                                         start_timeout=(timestamp_start_timeout - time()) * 1000.,
-                                                         end_timeout=(timestamp_end_timeout - time()) * 1000.)
+                                                         start_timeout=remaining_p2_ext_timeout,
+                                                         end_timeout=remaining_p6_ext_timeout)
             except TimeoutError as exception:
                 raise TimeoutError("P6*Client timeout reached.") from exception
             if response_record is None:  # timeout achieved - no following response
                 raise TimeoutError(f"P2*Client timeout ({self.p2_ext_client_timeout} ms) reached after receiving "
                                    f"{len(response_records)} response pending messages "
                                    f"({bytes_to_hex(response_records[-1].payload)}).")
-            if (self.is_response_pending_message(message=response_record, request_sid=sid)
-                    or response_record.payload[0] == sid + RESPONSE_REQUEST_SID_DIFF):
-                response_records.append(response_record)
-            else:
-                pass  # TODO: add it to response queue when created - https://github.com/mdabrowski1990/uds/issues/63
+            response_records.append(response_record)
         self._update_measured_client_values(request_record=request_record, response_records=response_records)
         return request_record, tuple(response_records)

--- a/uds/transport_interface/abstract_transport_interface.py
+++ b/uds/transport_interface/abstract_transport_interface.py
@@ -172,6 +172,8 @@ class AbstractTransportInterface(ABC):
         """
         Receive UDS message.
 
+        .. warning:: Value of end_timeout must not be less than the value of start_timeout.
+
         :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
             Leave None to wait forever.
         :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
@@ -189,6 +191,8 @@ class AbstractTransportInterface(ABC):
                                     loop: Optional[AbstractEventLoop] = None) -> UdsMessageRecord:
         """
         Receive asynchronously UDS message.
+
+        .. warning:: Value of end_timeout must not be less than the value of start_timeout.
 
         :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
             Leave None to wait forever.

--- a/uds/transport_interface/abstract_transport_interface.py
+++ b/uds/transport_interface/abstract_transport_interface.py
@@ -166,11 +166,15 @@ class AbstractTransportInterface(ABC):
         """
 
     @abstractmethod
-    def receive_message(self, timeout: Optional[TimeMillisecondsAlias] = None) -> UdsMessageRecord:
+    def receive_message(self,
+                        start_timeout: Optional[TimeMillisecondsAlias] = None,
+                        end_timeout: Optional[TimeMillisecondsAlias] = None) -> UdsMessageRecord:
         """
         Receive UDS message.
 
-        :param timeout: Maximal time (in milliseconds) to wait.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+            Leave None to wait forever.
+        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
             Leave None to wait forever.
 
         :raise TimeoutError: Timeout was reached.
@@ -180,12 +184,15 @@ class AbstractTransportInterface(ABC):
 
     @abstractmethod
     async def async_receive_message(self,
-                                    timeout: Optional[TimeMillisecondsAlias] = None,
+                                    start_timeout: Optional[TimeMillisecondsAlias] = None,
+                                    end_timeout: Optional[TimeMillisecondsAlias] = None,
                                     loop: Optional[AbstractEventLoop] = None) -> UdsMessageRecord:
         """
         Receive asynchronously UDS message.
 
-        :param timeout: Maximal time (in milliseconds) to wait.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+            Leave None to wait forever.
+        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
             Leave None to wait forever.
         :param loop: An asyncio event loop to use for scheduling this task.
 

--- a/uds/utilities/__init__.py
+++ b/uds/utilities/__init__.py
@@ -5,7 +5,7 @@ from .common_types import (
     RawBytesListAlias,
     RawBytesSetAlias,
     RawBytesTupleAlias,
-    TimeMillisecondsAlias,
+    TimeMillisecondsAlias, TimestampSecondsAlias,
     validate_nibble,
     validate_raw_byte,
     validate_raw_bytes,

--- a/uds/utilities/__init__.py
+++ b/uds/utilities/__init__.py
@@ -5,13 +5,20 @@ from .common_types import (
     RawBytesListAlias,
     RawBytesSetAlias,
     RawBytesTupleAlias,
-    TimeMillisecondsAlias, TimestampSecondsAlias,
+    TimeMillisecondsAlias,
+    TimestampSecondsAlias,
     validate_nibble,
     validate_raw_byte,
     validate_raw_bytes,
 )
 from .conversions import bytes_to_hex, bytes_to_int, int_to_bytes
-from .custom_exceptions import AmbiguityError, InconsistencyError, ReassignmentError, UnusedArgumentError
+from .custom_exceptions import (
+    AmbiguityError,
+    InconsistencyError,
+    MessageTransmissionNotStartedError,
+    ReassignmentError,
+    UnusedArgumentError,
+)
 from .custom_warnings import (
     NewMessageReceptionWarning,
     UnexpectedPacketReceptionWarning,

--- a/uds/utilities/__init__.py
+++ b/uds/utilities/__init__.py
@@ -6,7 +6,7 @@ from .common_types import (
     RawBytesSetAlias,
     RawBytesTupleAlias,
     TimeMillisecondsAlias,
-    TimestampSecondsAlias,
+    TimestampAlias,
     validate_nibble,
     validate_raw_byte,
     validate_raw_bytes,

--- a/uds/utilities/common_types.py
+++ b/uds/utilities/common_types.py
@@ -1,6 +1,6 @@
 """Module with all common types (and its aliases) used in the package and helper functions for these types."""
 
-__all__ = ["TimeMillisecondsAlias",
+__all__ = ["TimeMillisecondsAlias", "TimestampSecondsAlias",
            "RawBytesAlias", "RawBytesTupleAlias", "RawBytesListAlias", "RawBytesSetAlias",
            "validate_nibble", "validate_raw_byte", "validate_raw_bytes"]
 
@@ -8,6 +8,8 @@ from typing import List, Set, Tuple, Union
 
 TimeMillisecondsAlias = Union[int, float]
 """Alias of a time value in milliseconds."""
+TimestampSecondsAlias = float
+"""Alias of a timestamp value in seconds."""
 RawBytesTupleAlias = Tuple[int, ...]
 """Alias of a tuple filled with byte values."""
 RawBytesSetAlias = Set[int]

--- a/uds/utilities/common_types.py
+++ b/uds/utilities/common_types.py
@@ -1,6 +1,6 @@
 """Module with all common types (and its aliases) used in the package and helper functions for these types."""
 
-__all__ = ["TimeMillisecondsAlias", "TimestampSecondsAlias",
+__all__ = ["TimeMillisecondsAlias", "TimestampAlias",
            "RawBytesAlias", "RawBytesTupleAlias", "RawBytesListAlias", "RawBytesSetAlias",
            "validate_nibble", "validate_raw_byte", "validate_raw_bytes"]
 
@@ -8,8 +8,8 @@ from typing import List, Set, Tuple, Union
 
 TimeMillisecondsAlias = Union[int, float]
 """Alias of a time value in milliseconds."""
-TimestampSecondsAlias = float
-"""Alias of a timestamp value in seconds."""
+TimestampAlias = float
+"""Alias of a timestamp value in seconds (used by :func:`~time.perf_counter`)."""
 RawBytesTupleAlias = Tuple[int, ...]
 """Alias of a tuple filled with byte values."""
 RawBytesSetAlias = Set[int]

--- a/uds/utilities/custom_exceptions.py
+++ b/uds/utilities/custom_exceptions.py
@@ -43,3 +43,13 @@ class UnusedArgumentError(ValueError):
 
 class AmbiguityError(ValueError):
     """Operation cannot be executed because it is ambiguous."""
+
+
+class MessageTransmissionNotStartedError(TimeoutError):
+    """
+    Timeout Error where a timeout was reached before message transmission has been started.
+
+    Example:
+        Timeout defined by `start_timeout` argument was reached by
+        :meth:`~uds.transport_interface.abstract_transport_interface.AbstractTransportInterface.receive_message`
+    """


### PR DESCRIPTION
# Description
<!--- Describe your changes -->
- Update Transport Interface methods for receiving messages - start and end timeout.
- Update Client to use P6Client and P6*Client timeouts


# How Has This Been Tested?
<!--- Please shortly describe how you tested your code. -->
- system tests


# Process
<!--- If you are familiar with the process, leave the line below. If not, please describe what you did, so we could help you deliver your changed according to our quality policies -->
I know the [process](https://github.com/mdabrowski1990/uds/wiki/Software-Development-Life-Cycle) and did my best to follow it
