### PR TITLE
Allow external notifiers in PyCanTransportInterface

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -205,6 +205,8 @@ jobs:
 
       - name: Install project dependencies
         run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
           pip install -r requirements.txt
 
       - name: Install external packages used for documentation checking

--- a/docs/source/pages/user_guide/can.rst
+++ b/docs/source/pages/user_guide/can.rst
@@ -882,8 +882,14 @@ Following functionalities are provided by :class:`~uds.can.transport_interface.p
 - Configuration of the transport interface:
 
   The configuration takes place during :meth:`uds.can.transport_interface.python_can.PyCanTransportInterface.__init__`
-  call. From the user perspective it does not provide any additional features to common implementation defined by
+  call.
+
+  User can provide `notifier` and `async_notifier` objects on top of implementation defined in
   :meth:`uds.can.transport_interface.common.AbstractCanTransportInterface.__init__`.
+
+  .. warning:: There shall be exactly one notifier active at any time.
+    Either for synchronous (with `BufferedReader` listeners)
+    or asynchronous (with `AsyncBufferedReader` listeners and `loop` attribute set).
 
   **Example code:**
 

--- a/docs/source/pages/user_guide/can.rst
+++ b/docs/source/pages/user_guide/can.rst
@@ -884,7 +884,7 @@ Following functionalities are provided by :class:`~uds.can.transport_interface.p
   The configuration takes place during :meth:`uds.can.transport_interface.python_can.PyCanTransportInterface.__init__`
   call.
 
-  User can provide `notifier` and `async_notifier` objects on top of implementation defined in
+  User can provide `notifier` and `async_notifier` objects on top of other arguments defined in
   :meth:`uds.can.transport_interface.common.AbstractCanTransportInterface.__init__`.
 
   .. warning:: There shall be exactly one notifier active at any time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ maintainers = [
 ]
 dependencies = [
     "aenum >= 3.0.0",
-    "python-can >= 4.6.1"
+    "python-can >= 4.6.0"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ maintainers = [
 ]
 dependencies = [
     "aenum >= 3.0.0",
-    "python-can == 4.*"
+    "python-can >= 4.6.1"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ docs = [
     "tomli",
 ]
 docs-checks = [
-    "doc8 == 2.0.0",
+    "doc8 == 1.1.1",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ docs = [
     "tomli",
 ]
 docs-checks = [
-    "doc8 == 1.1.1",
+    "doc8 == 2.0.0",
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aenum==3.1.16
-python-can==4.5.0
+python-can==4.6.1

--- a/tests/prospector_profile.yaml
+++ b/tests/prospector_profile.yaml
@@ -15,6 +15,7 @@ pep8:
 
 pylint:
   options:
+    max-module-lines: 2000
     max-line-length: 120
     max-args: 12
     max-positional-arguments: 12

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -608,8 +608,8 @@ class AbstractCanPacketTests(AbstractPythonCanTests, ABC):
                     < timeout + self.TASK_TIMING_TOLERANCE)
 
 
-class AbstractMessageTests(AbstractPythonCanTests, ABC):
-    """Common implementation of system tests related to sending and receiving UDS (DoCAN) messages."""
+class AbstractUnsegmentedMessageTests(AbstractPythonCanTests, ABC):
+    """Common implementation of system tests related to sending and receiving unsegmented UDS (DoCAN) messages."""
 
     @pytest.mark.parametrize("message", [
         UdsMessage(payload=[0x22, 0x12, 0x34, 0x56, 0x78], addressing_type=AddressingType.PHYSICAL),
@@ -911,6 +911,10 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
             assert (start_timeout
                     <= receiving_time_ms
                     < send_after + self.TASK_TIMING_TOLERANCE)
+
+
+class AbstractSegmentedMessageTests(AbstractPythonCanTests, ABC):
+    """Common implementation of system tests related to sending and receiving segmented UDS (DoCAN) messages."""
 
     @pytest.mark.parametrize("message", [
         UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
@@ -1474,6 +1478,10 @@ class AbstractMessageTests(AbstractPythonCanTests, ABC):
             assert (end_timeout
                     < receiving_time_ms
                     < end_timeout + self.TASK_TIMING_TOLERANCE)
+
+
+class AbstractFullDuplexTests(AbstractPythonCanTests, ABC):
+    """Common implementation of system tests related to DoCAN Full-Duplex transmission."""
 
     @pytest.mark.parametrize("tx_message, rx_message, tx_block_size, tx_st_min, rx_block_size, rx_st_min", [
         (

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -916,507 +916,507 @@ class AbstractUnsegmentedMessageTests(AbstractPythonCanTests, ABC):
 class AbstractSegmentedMessageTests(AbstractPythonCanTests, ABC):
     """Common implementation of system tests related to sending and receiving segmented UDS (DoCAN) messages."""
 
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("n_bs_timeout, send_after", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950),  # ms
-        (50, 20),
-    ])
-    def test_send_message__multi_packets(self, example_can_addressing_information,
-                                         message, n_bs_timeout, send_after):
-        """
-        Check for a synchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-        2. Send a UDS message using Transport Interface (via CAN Interface).
-            Expected: UDS message record returned.
-        3. Validate transmitted UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=n_bs_timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                         packet=flow_control_packet,
-                         delay=send_after)
-        time_before_send = time()
-        message_record = can_transport_interface.send_message(message)
-        time_after_send = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.TRANSMITTED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        assert len(message_record.packets_records) > 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-                   and following_packet.direction == TransmissionDirection.TRANSMITTED
-                   for following_packet in message_record.packets_records[2:])
-        # timing parameters
-        assert isinstance(can_transport_interface.n_bs_measured, tuple)
-        assert len(can_transport_interface.n_bs_measured) == 1
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-            assert (send_after - self.TASK_TIMING_TOLERANCE
-                    <= can_transport_interface.n_bs_measured[0]
-                    <= send_after + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("n_bs_timeout, send_after", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 950),  # ms
-        (50, 20),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_send_message__multi_packets(self, example_can_addressing_information,
-                                                     message, n_bs_timeout, send_after):
-        """
-        Check for an asynchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-            Expected: UDS message record returned.
-        3. Validate transmitted UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=n_bs_timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        send_packet_task = asyncio.create_task(self.async_send_packet(
-            transport_interface=can_transport_interface_2nd_node,
-            packet=flow_control_packet,
-            delay=send_after))
-        time_before_send = time()
-        message_record = await can_transport_interface.async_send_message(message)
-        time_after_send = time()
-        await send_packet_task
-        assert isinstance(message_record, UdsMessageRecord)
-        assert message_record.direction == TransmissionDirection.TRANSMITTED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        assert len(message_record.packets_records) > 1
-        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-                   and following_packet.direction == TransmissionDirection.TRANSMITTED
-                   for following_packet in message_record.packets_records[2:])
-        # timing parameters
-        assert isinstance(can_transport_interface.n_bs_measured, tuple)
-        assert len(can_transport_interface.n_bs_measured) == 1
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-            assert (send_after - self.TASK_TIMING_TOLERANCE
-                    <= can_transport_interface.n_bs_measured[0]
-                    <= send_after + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("n_bs_timeout, send_after", [
-        (1000, 1010),  # ms
-        (50, 60),
-    ])
-    def test_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
-                                                       message, n_bs_timeout, send_after):
-        """
-        Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-        2. Send a UDS message using Transport Interface (via CAN Interface).
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=n_bs_timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                         packet=flow_control_packet,
-                         delay=send_after)
-        time_before_receive = perf_counter()
-        with pytest.raises(TimeoutError):
-            can_transport_interface.send_message(message)
-        time_after_receive = perf_counter()
-        # timing parameters
-        if self.MAKE_TIMING_CHECKS:
-            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-            assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-                    < receiving_time_ms
-                    < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("n_bs_timeout, send_after", [
-        (1000, 1010),  # ms
-        (50, 60),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
-                                                                   message, n_bs_timeout, send_after):
-        """
-        Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
-
-        Procedure:
-        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-        :param message: UDS message to send.
-        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-        :param send_after: Delay to use for sending CAN flow control.
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_bs_timeout=n_bs_timeout)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-            flow_status=CanFlowStatus.ContinueToSend,
-            block_size=0,
-            st_min=0)
-        send_packet_task = asyncio.create_task(self.async_send_packet(
-            transport_interface=can_transport_interface_2nd_node,
-            packet=flow_control_packet,
-            delay=send_after))
-        time_before_receive = perf_counter()
-        with pytest.raises(TimeoutError):
-            await can_transport_interface.async_send_message(message)
-        time_after_receive = perf_counter()
-        await send_packet_task
-        # timing parameters
-        if self.MAKE_TIMING_CHECKS:
-            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-            assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-                    < receiving_time_ms
-                    < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 2000, 950, 20),  # ms
-        (50, 1500, 20, 50),
-    ])
-    def test_receive_message__multi_packets(self, example_can_addressing_information,
-                                            message, start_timeout, end_timeout, send_after, delay):
-        """
-        Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-            UDS message (First Frame and then Consecutive Frames).
-        2. Call method to receive message via Transport Interface.
-            Expected: UDS message is received.
-        3. Validate received UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the received UDS message.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_br=0)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-        for i, packet in enumerate(packets):
-            self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                             packet=packet,
-                             delay=send_after + i * delay)
-        time_before_receive = time()
-        message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
-                                                                 end_timeout=end_timeout)
-        time_after_receive = time()
-        assert isinstance(message_record, UdsMessageRecord)
-        assert len(message_record.packets_records) == len(packets) + 1, \
-            "All packets (including Flow Control) are stored"
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
-        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-        (1000, 2000, 950, 20),  # ms
-        (50, 2000, 20, 50),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
-                                                        message, start_timeout, end_timeout, send_after, delay):
-        """
-        Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-            UDS message (First Frame and then Consecutive Frames).
-        2. Call async method to receive message via Transport Interface.
-            Expected: UDS message is received.
-        3. Validate received UDS message record attributes.
-            Expected: Attributes of UDS message record are in line with the received UDS message.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-
-        async def _send_message():
-            for packet in packets:
-                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
-                                             packet=packet,
-                                             delay=send_after if packet == packets[0] else delay)
-
-        send_message_task = asyncio.create_task(_send_message())
-        time_before_receive = time()
-        message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
-                                                                             end_timeout=end_timeout)
-        time_after_receive = time()
-        await send_message_task
-        assert isinstance(message_record, UdsMessageRecord)
-        assert len(message_record.packets_records) == len(packets) + 1, \
-            "All packets (including Flow Control) are stored"
-        assert message_record.direction == TransmissionDirection.RECEIVED
-        assert message_record.payload == message.payload
-        assert message_record.addressing_type == message.addressing_type
-        assert message_record.transmission_start < message_record.transmission_end
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-                    <= message_record.transmission_start)
-            assert (message_record.transmission_end
-                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("start_timeout, send_after, delay", [
-        (1000, 50, 20),  # ms
-        (50, 0, 50),
-    ])
-    def test_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
-                                                          message, start_timeout, send_after, delay):
-        """
-        Check for a timeout during receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carries part of received
-            UDS message (First Frame and then Consecutive Frames with one Consecutive Frame missing).
-        2. Call method to receive message via Transport Interface.
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_br=0)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-        self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                         packet=packets[0],
-                         delay=send_after)
-        for i, cf_packet in enumerate(packets[1:-1], start=1):
-            self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                             packet=cf_packet,
-                             delay=send_after + i * delay)
-        with pytest.raises(TimeoutError):
-            can_transport_interface.receive_message(start_timeout=start_timeout)
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("start_timeout, send_after, delay", [
-        (1000, 50, 20),  # ms
-        (50, 0, 50),
-    ])
-    @pytest.mark.asyncio
-    async def test_async_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
-                                                                      message, start_timeout, send_after, delay):
-        """
-        Check for a timeout during asynchronous receiving of a UDS message (carried by First Frame and
-        Consecutive Frame packets).
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-            UDS message (First Frame and then Consecutive Frames).
-        2. Call async method to receive message via Transport Interface.
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-            :param message: UDS message to transmit.
-        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-
-        async def _send_message():
-            for packet in packets[:-1]:
-                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
-                                             packet=packet,
-                                             delay=send_after if packet == packets[0] else delay)
-
-        send_message_task = asyncio.create_task(_send_message())
-        with pytest.raises(TimeoutError):
-            await can_transport_interface.async_receive_message(start_timeout=start_timeout)
-        await send_message_task
-
-    @pytest.mark.parametrize("message", [
-        UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
-        UdsMessage(payload=[0x62, 0x12, 0x34] + [*range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
-    ])
-    @pytest.mark.parametrize("end_timeout, send_after, delay", [
-        (100, 50, 20),  # ms
-        (1500, 10, 50),
-    ])
-    def test_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
-                                                         message, end_timeout, send_after, delay):
-        """
-        Check for an end message timeout during synchronous multi packet (FF + CF) UDS message reception.
-
-        Procedure:
-        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-            UDS message (First Frame and then Consecutive Frames).
-        2. Call method to receive message via Transport Interface with timeout set before the entire segmented
-            UDS message is transmitted.
-            Expected: Timeout exception is raised.
-
-        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-        :param message: UDS message to transmit.
-        :param end_timeout: Maximal time (in milliseconds) to wait for the end of a message transmission.
-        :param send_after: Time when to send First Frame after call of receive method [ms].
-        :param delay: Time distance to use for sending Consecutive Frames [ms].
-        """
-        can_transport_interface = PyCanTransportInterface(
-            network_manager=self.can_interface_1,
-            addressing_information=example_can_addressing_information,
-            n_br=0)
-        can_transport_interface_2nd_node = PyCanTransportInterface(
-            network_manager=self.can_interface_2,
-            addressing_information=example_can_addressing_information.get_other_end())
-        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-        for i, packet in enumerate(packets):
-            self.send_packet(transport_interface=can_transport_interface_2nd_node,
-                             packet=packet,
-                             delay=send_after + i * delay)
-        time_before_receive = perf_counter()
-        with pytest.raises(TimeoutError):
-            can_transport_interface.receive_message(start_timeout=2 * send_after + 50,
-                                                    end_timeout=end_timeout)
-        time_after_receive = perf_counter()
-        # performance checks
-        if self.MAKE_TIMING_CHECKS:
-            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-            assert (end_timeout
-                    < receiving_time_ms
-                    < end_timeout + self.TASK_TIMING_TOLERANCE)
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 950),  # ms
+    #     (50, 20),
+    # ])
+    # def test_send_message__multi_packets(self, example_can_addressing_information,
+    #                                      message, n_bs_timeout, send_after):
+    #     """
+    #     Check for a synchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+    #     2. Send a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: UDS message record returned.
+    #     3. Validate transmitted UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=n_bs_timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                      packet=flow_control_packet,
+    #                      delay=send_after)
+    #     time_before_send = time()
+    #     message_record = can_transport_interface.send_message(message)
+    #     time_after_send = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     assert len(message_record.packets_records) > 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
+    #                for following_packet in message_record.packets_records[2:])
+    #     # timing parameters
+    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
+    #     assert len(can_transport_interface.n_bs_measured) == 1
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+    #         assert (send_after - self.TASK_TIMING_TOLERANCE
+    #                 <= can_transport_interface.n_bs_measured[0]
+    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 950),  # ms
+    #     (50, 20),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_send_message__multi_packets(self, example_can_addressing_information,
+    #                                                  message, n_bs_timeout, send_after):
+    #     """
+    #     Check for an asynchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: UDS message record returned.
+    #     3. Validate transmitted UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=n_bs_timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     send_packet_task = asyncio.create_task(self.async_send_packet(
+    #         transport_interface=can_transport_interface_2nd_node,
+    #         packet=flow_control_packet,
+    #         delay=send_after))
+    #     time_before_send = time()
+    #     message_record = await can_transport_interface.async_send_message(message)
+    #     time_after_send = time()
+    #     await send_packet_task
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     assert len(message_record.packets_records) > 1
+    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
+    #                for following_packet in message_record.packets_records[2:])
+    #     # timing parameters
+    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
+    #     assert len(can_transport_interface.n_bs_measured) == 1
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+    #         assert (send_after - self.TASK_TIMING_TOLERANCE
+    #                 <= can_transport_interface.n_bs_measured[0]
+    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
+    #     (1000, 1010),  # ms
+    #     (50, 60),
+    # ])
+    # def test_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
+    #                                                    message, n_bs_timeout, send_after):
+    #     """
+    #     Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+    #     2. Send a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=n_bs_timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                      packet=flow_control_packet,
+    #                      delay=send_after)
+    #     time_before_receive = perf_counter()
+    #     with pytest.raises(TimeoutError):
+    #         can_transport_interface.send_message(message)
+    #     time_after_receive = perf_counter()
+    #     # timing parameters
+    #     if self.MAKE_TIMING_CHECKS:
+    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #         assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+    #                 < receiving_time_ms
+    #                 < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
+    #     (1000, 1010),  # ms
+    #     (50, 60),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
+    #                                                                message, n_bs_timeout, send_after):
+    #     """
+    #     Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
+    #
+    #     Procedure:
+    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+    #     :param message: UDS message to send.
+    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+    #     :param send_after: Delay to use for sending CAN flow control.
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_bs_timeout=n_bs_timeout)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+    #         flow_status=CanFlowStatus.ContinueToSend,
+    #         block_size=0,
+    #         st_min=0)
+    #     send_packet_task = asyncio.create_task(self.async_send_packet(
+    #         transport_interface=can_transport_interface_2nd_node,
+    #         packet=flow_control_packet,
+    #         delay=send_after))
+    #     time_before_receive = perf_counter()
+    #     with pytest.raises(TimeoutError):
+    #         await can_transport_interface.async_send_message(message)
+    #     time_after_receive = perf_counter()
+    #     await send_packet_task
+    #     # timing parameters
+    #     if self.MAKE_TIMING_CHECKS:
+    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #         assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+    #                 < receiving_time_ms
+    #                 < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 2000, 950, 20),  # ms
+    #     (50, 1500, 20, 50),
+    # ])
+    # def test_receive_message__multi_packets(self, example_can_addressing_information,
+    #                                         message, start_timeout, end_timeout, send_after, delay):
+    #     """
+    #     Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+    #         UDS message (First Frame and then Consecutive Frames).
+    #     2. Call method to receive message via Transport Interface.
+    #         Expected: UDS message is received.
+    #     3. Validate received UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the received UDS message.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_br=0)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #     for i, packet in enumerate(packets):
+    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                          packet=packet,
+    #                          delay=send_after + i * delay)
+    #     time_before_receive = time()
+    #     message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
+    #                                                              end_timeout=end_timeout)
+    #     time_after_receive = time()
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert len(message_record.packets_records) == len(packets) + 1, \
+    #         "All packets (including Flow Control) are stored"
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+    #     (1000, 2000, 950, 20),  # ms
+    #     (50, 2000, 20, 50),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
+    #                                                     message, start_timeout, end_timeout, send_after, delay):
+    #     """
+    #     Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+    #         UDS message (First Frame and then Consecutive Frames).
+    #     2. Call async method to receive message via Transport Interface.
+    #         Expected: UDS message is received.
+    #     3. Validate received UDS message record attributes.
+    #         Expected: Attributes of UDS message record are in line with the received UDS message.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #
+    #     async def _send_message():
+    #         for packet in packets:
+    #             await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                                          packet=packet,
+    #                                          delay=send_after if packet == packets[0] else delay)
+    #
+    #     send_message_task = asyncio.create_task(_send_message())
+    #     time_before_receive = time()
+    #     message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
+    #                                                                          end_timeout=end_timeout)
+    #     time_after_receive = time()
+    #     await send_message_task
+    #     assert isinstance(message_record, UdsMessageRecord)
+    #     assert len(message_record.packets_records) == len(packets) + 1, \
+    #         "All packets (including Flow Control) are stored"
+    #     assert message_record.direction == TransmissionDirection.RECEIVED
+    #     assert message_record.payload == message.payload
+    #     assert message_record.addressing_type == message.addressing_type
+    #     assert message_record.transmission_start < message_record.transmission_end
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+    #                 <= message_record.transmission_start)
+    #         assert (message_record.transmission_end
+    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, send_after, delay", [
+    #     (1000, 50, 20),  # ms
+    #     (50, 0, 50),
+    # ])
+    # def test_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
+    #                                                       message, start_timeout, send_after, delay):
+    #     """
+    #     Check for a timeout during receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carries part of received
+    #         UDS message (First Frame and then Consecutive Frames with one Consecutive Frame missing).
+    #     2. Call method to receive message via Transport Interface.
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_br=0)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                      packet=packets[0],
+    #                      delay=send_after)
+    #     for i, cf_packet in enumerate(packets[1:-1], start=1):
+    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                          packet=cf_packet,
+    #                          delay=send_after + i * delay)
+    #     with pytest.raises(TimeoutError):
+    #         can_transport_interface.receive_message(start_timeout=start_timeout)
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("start_timeout, send_after, delay", [
+    #     (1000, 50, 20),  # ms
+    #     (50, 0, 50),
+    # ])
+    # @pytest.mark.asyncio
+    # async def test_async_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
+    #                                                                   message, start_timeout, send_after, delay):
+    #     """
+    #     Check for a timeout during asynchronous receiving of a UDS message (carried by First Frame and
+    #     Consecutive Frame packets).
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+    #         UDS message (First Frame and then Consecutive Frames).
+    #     2. Call async method to receive message via Transport Interface.
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #         :param message: UDS message to transmit.
+    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #
+    #     async def _send_message():
+    #         for packet in packets[:-1]:
+    #             await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                                          packet=packet,
+    #                                          delay=send_after if packet == packets[0] else delay)
+    #
+    #     send_message_task = asyncio.create_task(_send_message())
+    #     with pytest.raises(TimeoutError):
+    #         await can_transport_interface.async_receive_message(start_timeout=start_timeout)
+    #     await send_message_task
+    #
+    # @pytest.mark.parametrize("message", [
+    #     UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
+    #     UdsMessage(payload=[0x62, 0x12, 0x34] + [*range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
+    # ])
+    # @pytest.mark.parametrize("end_timeout, send_after, delay", [
+    #     (100, 50, 20),  # ms
+    #     (1500, 10, 50),
+    # ])
+    # def test_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
+    #                                                      message, end_timeout, send_after, delay):
+    #     """
+    #     Check for an end message timeout during synchronous multi packet (FF + CF) UDS message reception.
+    #
+    #     Procedure:
+    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+    #         UDS message (First Frame and then Consecutive Frames).
+    #     2. Call method to receive message via Transport Interface with timeout set before the entire segmented
+    #         UDS message is transmitted.
+    #         Expected: Timeout exception is raised.
+    #
+    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+    #     :param message: UDS message to transmit.
+    #     :param end_timeout: Maximal time (in milliseconds) to wait for the end of a message transmission.
+    #     :param send_after: Time when to send First Frame after call of receive method [ms].
+    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
+    #     """
+    #     can_transport_interface = PyCanTransportInterface(
+    #         network_manager=self.can_interface_1,
+    #         addressing_information=example_can_addressing_information,
+    #         n_br=0)
+    #     can_transport_interface_2nd_node = PyCanTransportInterface(
+    #         network_manager=self.can_interface_2,
+    #         addressing_information=example_can_addressing_information.get_other_end())
+    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+    #     for i, packet in enumerate(packets):
+    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
+    #                          packet=packet,
+    #                          delay=send_after + i * delay)
+    #     time_before_receive = perf_counter()
+    #     with pytest.raises(TimeoutError):
+    #         can_transport_interface.receive_message(start_timeout=2 * send_after + 50,
+    #                                                 end_timeout=end_timeout)
+    #     time_after_receive = perf_counter()
+    #     # performance checks
+    #     if self.MAKE_TIMING_CHECKS:
+    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+    #         assert (end_timeout
+    #                 < receiving_time_ms
+    #                 < end_timeout + self.TASK_TIMING_TOLERANCE)
 
     @pytest.mark.parametrize("message", [
         UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),

--- a/tests/system_tests/can/python_can/python_can.py
+++ b/tests/system_tests/can/python_can/python_can.py
@@ -916,507 +916,507 @@ class AbstractUnsegmentedMessageTests(AbstractPythonCanTests, ABC):
 class AbstractSegmentedMessageTests(AbstractPythonCanTests, ABC):
     """Common implementation of system tests related to sending and receiving segmented UDS (DoCAN) messages."""
 
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 950),  # ms
-    #     (50, 20),
-    # ])
-    # def test_send_message__multi_packets(self, example_can_addressing_information,
-    #                                      message, n_bs_timeout, send_after):
-    #     """
-    #     Check for a synchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-    #     2. Send a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: UDS message record returned.
-    #     3. Validate transmitted UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=n_bs_timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                      packet=flow_control_packet,
-    #                      delay=send_after)
-    #     time_before_send = time()
-    #     message_record = can_transport_interface.send_message(message)
-    #     time_after_send = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     assert len(message_record.packets_records) > 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
-    #                for following_packet in message_record.packets_records[2:])
-    #     # timing parameters
-    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
-    #     assert len(can_transport_interface.n_bs_measured) == 1
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-    #         assert (send_after - self.TASK_TIMING_TOLERANCE
-    #                 <= can_transport_interface.n_bs_measured[0]
-    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 950),  # ms
-    #     (50, 20),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_send_message__multi_packets(self, example_can_addressing_information,
-    #                                                  message, n_bs_timeout, send_after):
-    #     """
-    #     Check for an asynchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
-    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: UDS message record returned.
-    #     3. Validate transmitted UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the transmitted UDS message.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=n_bs_timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     send_packet_task = asyncio.create_task(self.async_send_packet(
-    #         transport_interface=can_transport_interface_2nd_node,
-    #         packet=flow_control_packet,
-    #         delay=send_after))
-    #     time_before_send = time()
-    #     message_record = await can_transport_interface.async_send_message(message)
-    #     time_after_send = time()
-    #     await send_packet_task
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert message_record.direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     assert len(message_record.packets_records) > 1
-    #     assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
-    #     assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
-    #     assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
-    #     assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
-    #     assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-    #                and following_packet.direction == TransmissionDirection.TRANSMITTED
-    #                for following_packet in message_record.packets_records[2:])
-    #     # timing parameters
-    #     assert isinstance(can_transport_interface.n_bs_measured, tuple)
-    #     assert len(can_transport_interface.n_bs_measured) == 1
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
-    #         assert (send_after - self.TASK_TIMING_TOLERANCE
-    #                 <= can_transport_interface.n_bs_measured[0]
-    #                 <= send_after + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
-    #     (1000, 1010),  # ms
-    #     (50, 60),
-    # ])
-    # def test_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
-    #                                                    message, n_bs_timeout, send_after):
-    #     """
-    #     Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-    #     2. Send a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=n_bs_timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                      packet=flow_control_packet,
-    #                      delay=send_after)
-    #     time_before_receive = perf_counter()
-    #     with pytest.raises(TimeoutError):
-    #         can_transport_interface.send_message(message)
-    #     time_after_receive = perf_counter()
-    #     # timing parameters
-    #     if self.MAKE_TIMING_CHECKS:
-    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #         assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-    #                 < receiving_time_ms
-    #                 < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("n_bs_timeout, send_after", [
-    #     (1000, 1010),  # ms
-    #     (50, 60),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
-    #                                                                message, n_bs_timeout, send_after):
-    #     """
-    #     Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
-    #
-    #     Procedure:
-    #     1. Schedule Flow Control CAN Packet just after N_Bs timeout.
-    #     2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Example Addressing Information of a CAN Node.
-    #     :param message: UDS message to send.
-    #     :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
-    #     :param send_after: Delay to use for sending CAN flow control.
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_bs_timeout=n_bs_timeout)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
-    #         flow_status=CanFlowStatus.ContinueToSend,
-    #         block_size=0,
-    #         st_min=0)
-    #     send_packet_task = asyncio.create_task(self.async_send_packet(
-    #         transport_interface=can_transport_interface_2nd_node,
-    #         packet=flow_control_packet,
-    #         delay=send_after))
-    #     time_before_receive = perf_counter()
-    #     with pytest.raises(TimeoutError):
-    #         await can_transport_interface.async_send_message(message)
-    #     time_after_receive = perf_counter()
-    #     await send_packet_task
-    #     # timing parameters
-    #     if self.MAKE_TIMING_CHECKS:
-    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #         assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
-    #                 < receiving_time_ms
-    #                 < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 2000, 950, 20),  # ms
-    #     (50, 1500, 20, 50),
-    # ])
-    # def test_receive_message__multi_packets(self, example_can_addressing_information,
-    #                                         message, start_timeout, end_timeout, send_after, delay):
-    #     """
-    #     Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-    #         UDS message (First Frame and then Consecutive Frames).
-    #     2. Call method to receive message via Transport Interface.
-    #         Expected: UDS message is received.
-    #     3. Validate received UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the received UDS message.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_br=0)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #     for i, packet in enumerate(packets):
-    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                          packet=packet,
-    #                          delay=send_after + i * delay)
-    #     time_before_receive = time()
-    #     message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
-    #                                                              end_timeout=end_timeout)
-    #     time_after_receive = time()
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert len(message_record.packets_records) == len(packets) + 1, \
-    #         "All packets (including Flow Control) are stored"
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
-    #     # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
-    #     (1000, 2000, 950, 20),  # ms
-    #     (50, 2000, 20, 50),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
-    #                                                     message, start_timeout, end_timeout, send_after, delay):
-    #     """
-    #     Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-    #         UDS message (First Frame and then Consecutive Frames).
-    #     2. Call async method to receive message via Transport Interface.
-    #         Expected: UDS message is received.
-    #     3. Validate received UDS message record attributes.
-    #         Expected: Attributes of UDS message record are in line with the received UDS message.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #
-    #     async def _send_message():
-    #         for packet in packets:
-    #             await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                                          packet=packet,
-    #                                          delay=send_after if packet == packets[0] else delay)
-    #
-    #     send_message_task = asyncio.create_task(_send_message())
-    #     time_before_receive = time()
-    #     message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
-    #                                                                          end_timeout=end_timeout)
-    #     time_after_receive = time()
-    #     await send_message_task
-    #     assert isinstance(message_record, UdsMessageRecord)
-    #     assert len(message_record.packets_records) == len(packets) + 1, \
-    #         "All packets (including Flow Control) are stored"
-    #     assert message_record.direction == TransmissionDirection.RECEIVED
-    #     assert message_record.payload == message.payload
-    #     assert message_record.addressing_type == message.addressing_type
-    #     assert message_record.transmission_start < message_record.transmission_end
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
-    #                 <= message_record.transmission_start)
-    #         assert (message_record.transmission_end
-    #                 <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, send_after, delay", [
-    #     (1000, 50, 20),  # ms
-    #     (50, 0, 50),
-    # ])
-    # def test_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
-    #                                                       message, start_timeout, send_after, delay):
-    #     """
-    #     Check for a timeout during receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carries part of received
-    #         UDS message (First Frame and then Consecutive Frames with one Consecutive Frame missing).
-    #     2. Call method to receive message via Transport Interface.
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_br=0)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #     self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                      packet=packets[0],
-    #                      delay=send_after)
-    #     for i, cf_packet in enumerate(packets[1:-1], start=1):
-    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                          packet=cf_packet,
-    #                          delay=send_after + i * delay)
-    #     with pytest.raises(TimeoutError):
-    #         can_transport_interface.receive_message(start_timeout=start_timeout)
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("start_timeout, send_after, delay", [
-    #     (1000, 50, 20),  # ms
-    #     (50, 0, 50),
-    # ])
-    # @pytest.mark.asyncio
-    # async def test_async_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
-    #                                                                   message, start_timeout, send_after, delay):
-    #     """
-    #     Check for a timeout during asynchronous receiving of a UDS message (carried by First Frame and
-    #     Consecutive Frame packets).
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-    #         UDS message (First Frame and then Consecutive Frames).
-    #     2. Call async method to receive message via Transport Interface.
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #         :param message: UDS message to transmit.
-    #     :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #
-    #     async def _send_message():
-    #         for packet in packets[:-1]:
-    #             await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                                          packet=packet,
-    #                                          delay=send_after if packet == packets[0] else delay)
-    #
-    #     send_message_task = asyncio.create_task(_send_message())
-    #     with pytest.raises(TimeoutError):
-    #         await can_transport_interface.async_receive_message(start_timeout=start_timeout)
-    #     await send_message_task
-    #
-    # @pytest.mark.parametrize("message", [
-    #     UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
-    #     UdsMessage(payload=[0x62, 0x12, 0x34] + [*range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
-    # ])
-    # @pytest.mark.parametrize("end_timeout, send_after, delay", [
-    #     (100, 50, 20),  # ms
-    #     (1500, 10, 50),
-    # ])
-    # def test_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
-    #                                                      message, end_timeout, send_after, delay):
-    #     """
-    #     Check for an end message timeout during synchronous multi packet (FF + CF) UDS message reception.
-    #
-    #     Procedure:
-    #     1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
-    #         UDS message (First Frame and then Consecutive Frames).
-    #     2. Call method to receive message via Transport Interface with timeout set before the entire segmented
-    #         UDS message is transmitted.
-    #         Expected: Timeout exception is raised.
-    #
-    #     :param example_can_addressing_information: Addressing Information of receiving CAN Node.
-    #     :param message: UDS message to transmit.
-    #     :param end_timeout: Maximal time (in milliseconds) to wait for the end of a message transmission.
-    #     :param send_after: Time when to send First Frame after call of receive method [ms].
-    #     :param delay: Time distance to use for sending Consecutive Frames [ms].
-    #     """
-    #     can_transport_interface = PyCanTransportInterface(
-    #         network_manager=self.can_interface_1,
-    #         addressing_information=example_can_addressing_information,
-    #         n_br=0)
-    #     can_transport_interface_2nd_node = PyCanTransportInterface(
-    #         network_manager=self.can_interface_2,
-    #         addressing_information=example_can_addressing_information.get_other_end())
-    #     packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
-    #     for i, packet in enumerate(packets):
-    #         self.send_packet(transport_interface=can_transport_interface_2nd_node,
-    #                          packet=packet,
-    #                          delay=send_after + i * delay)
-    #     time_before_receive = perf_counter()
-    #     with pytest.raises(TimeoutError):
-    #         can_transport_interface.receive_message(start_timeout=2 * send_after + 50,
-    #                                                 end_timeout=end_timeout)
-    #     time_after_receive = perf_counter()
-    #     # performance checks
-    #     if self.MAKE_TIMING_CHECKS:
-    #         receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
-    #         assert (end_timeout
-    #                 < receiving_time_ms
-    #                 < end_timeout + self.TASK_TIMING_TOLERANCE)
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 950),  # ms
+        (50, 20),
+    ])
+    def test_send_message__multi_packets(self, example_can_addressing_information,
+                                         message, n_bs_timeout, send_after):
+        """
+        Check for a synchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+        2. Send a UDS message using Transport Interface (via CAN Interface).
+            Expected: UDS message record returned.
+        3. Validate transmitted UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                         packet=flow_control_packet,
+                         delay=send_after)
+        time_before_send = time()
+        message_record = can_transport_interface.send_message(message)
+        time_after_send = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.TRANSMITTED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        assert len(message_record.packets_records) > 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+                   and following_packet.direction == TransmissionDirection.TRANSMITTED
+                   for following_packet in message_record.packets_records[2:])
+        # timing parameters
+        assert isinstance(can_transport_interface.n_bs_measured, tuple)
+        assert len(can_transport_interface.n_bs_measured) == 1
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+            assert (send_after - self.TASK_TIMING_TOLERANCE
+                    <= can_transport_interface.n_bs_measured[0]
+                    <= send_after + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 950),  # ms
+        (50, 20),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_send_message__multi_packets(self, example_can_addressing_information,
+                                                     message, n_bs_timeout, send_after):
+        """
+        Check for an asynchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet with information to continue sending all consecutive frame packets at once.
+        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+            Expected: UDS message record returned.
+        3. Validate transmitted UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the transmitted UDS message.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        send_packet_task = asyncio.create_task(self.async_send_packet(
+            transport_interface=can_transport_interface_2nd_node,
+            packet=flow_control_packet,
+            delay=send_after))
+        time_before_send = time()
+        message_record = await can_transport_interface.async_send_message(message)
+        time_after_send = time()
+        await send_packet_task
+        assert isinstance(message_record, UdsMessageRecord)
+        assert message_record.direction == TransmissionDirection.TRANSMITTED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        assert len(message_record.packets_records) > 1
+        assert message_record.packets_records[0].packet_type == CanPacketType.FIRST_FRAME
+        assert message_record.packets_records[0].direction == TransmissionDirection.TRANSMITTED
+        assert message_record.packets_records[1].packet_type == CanPacketType.FLOW_CONTROL
+        assert message_record.packets_records[1].direction == TransmissionDirection.RECEIVED
+        assert all(following_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
+                   and following_packet.direction == TransmissionDirection.TRANSMITTED
+                   for following_packet in message_record.packets_records[2:])
+        # timing parameters
+        assert isinstance(can_transport_interface.n_bs_measured, tuple)
+        assert len(can_transport_interface.n_bs_measured) == 1
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_send - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_send + self.TIMESTAMP_TOLERANCE / 1000.))
+            assert (send_after - self.TASK_TIMING_TOLERANCE
+                    <= can_transport_interface.n_bs_measured[0]
+                    <= send_after + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        (1000, 1010),  # ms
+        (50, 60),
+    ])
+    def test_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
+                                                       message, n_bs_timeout, send_after):
+        """
+        Check for a timeout (N_Bs timeout exceeded) during synchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+        2. Send a UDS message using Transport Interface (via CAN Interface).
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                         packet=flow_control_packet,
+                         delay=send_after)
+        time_before_receive = perf_counter()
+        with pytest.raises(TimeoutError):
+            can_transport_interface.send_message(message)
+        time_after_receive = perf_counter()
+        # timing parameters
+        if self.MAKE_TIMING_CHECKS:
+            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+            assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+                    < receiving_time_ms
+                    < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("n_bs_timeout, send_after", [
+        (1000, 1010),  # ms
+        (50, 60),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_send_message__multi_packets__n_bs_timeout(self, example_can_addressing_information,
+                                                                   message, n_bs_timeout, send_after):
+        """
+        Check for a timeout (N_Bs timeout exceeded) during asynchronous multi packet (FF + CF) UDS message sending.
+
+        Procedure:
+        1. Schedule Flow Control CAN Packet just after N_Bs timeout.
+        2. Send (using async method) a UDS message using Transport Interface (via CAN Interface).
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Example Addressing Information of a CAN Node.
+        :param message: UDS message to send.
+        :param n_bs_timeout: Value of N_Bs timeout [ms] to use.
+        :param send_after: Delay to use for sending CAN flow control.
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_bs_timeout=n_bs_timeout)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        flow_control_packet = can_transport_interface_2nd_node.segmenter.get_flow_control_packet(
+            flow_status=CanFlowStatus.ContinueToSend,
+            block_size=0,
+            st_min=0)
+        send_packet_task = asyncio.create_task(self.async_send_packet(
+            transport_interface=can_transport_interface_2nd_node,
+            packet=flow_control_packet,
+            delay=send_after))
+        time_before_receive = perf_counter()
+        with pytest.raises(TimeoutError):
+            await can_transport_interface.async_send_message(message)
+        time_after_receive = perf_counter()
+        await send_packet_task
+        # timing parameters
+        if self.MAKE_TIMING_CHECKS:
+            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+            assert (can_transport_interface.n_bs_timeout - self.TIMESTAMP_TOLERANCE
+                    < receiving_time_ms
+                    < can_transport_interface.n_bs_timeout + self.TASK_TIMING_TOLERANCE)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 2000, 950, 20),  # ms
+        (50, 1500, 20, 50),
+    ])
+    def test_receive_message__multi_packets(self, example_can_addressing_information,
+                                            message, start_timeout, end_timeout, send_after, delay):
+        """
+        Check for receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call method to receive message via Transport Interface.
+            Expected: UDS message is received.
+        3. Validate received UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the received UDS message.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+        for i, packet in enumerate(packets):
+            self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                             packet=packet,
+                             delay=send_after + i * delay)
+        time_before_receive = time()
+        message_record = can_transport_interface.receive_message(start_timeout=start_timeout,
+                                                                 end_timeout=end_timeout)
+        time_after_receive = time()
+        assert isinstance(message_record, UdsMessageRecord)
+        assert len(message_record.packets_records) == len(packets) + 1, \
+            "All packets (including Flow Control) are stored"
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, end_timeout, send_after, delay", [
+        # TODO: adjust values to be closer to boundary when https://github.com/mdabrowski1990/uds/issues/228 resolved
+        (1000, 2000, 950, 20),  # ms
+        (50, 2000, 20, 50),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_receive_message__multi_packets(self, example_can_addressing_information,
+                                                        message, start_timeout, end_timeout, send_after, delay):
+        """
+        Check for asynchronous receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call async method to receive message via Transport Interface.
+            Expected: UDS message is received.
+        3. Validate received UDS message record attributes.
+            Expected: Attributes of UDS message record are in line with the received UDS message.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param end_timeout: Maximal time (in milliseconds) to wait for a message transmission to finish.
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+
+        async def _send_message():
+            for packet in packets:
+                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+                                             packet=packet,
+                                             delay=send_after if packet == packets[0] else delay)
+
+        send_message_task = asyncio.create_task(_send_message())
+        time_before_receive = time()
+        message_record = await can_transport_interface.async_receive_message(start_timeout=start_timeout,
+                                                                             end_timeout=end_timeout)
+        time_after_receive = time()
+        await send_message_task
+        assert isinstance(message_record, UdsMessageRecord)
+        assert len(message_record.packets_records) == len(packets) + 1, \
+            "All packets (including Flow Control) are stored"
+        assert message_record.direction == TransmissionDirection.RECEIVED
+        assert message_record.payload == message.payload
+        assert message_record.addressing_type == message.addressing_type
+        assert message_record.transmission_start < message_record.transmission_end
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            assert (datetime.fromtimestamp(time_before_receive - self.TIMESTAMP_TOLERANCE / 1000.)
+                    <= message_record.transmission_start)
+            assert (message_record.transmission_end
+                    <= datetime.fromtimestamp(time_after_receive + self.TIMESTAMP_TOLERANCE / 1000.))
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, send_after, delay", [
+        (1000, 50, 20),  # ms
+        (50, 0, 50),
+    ])
+    def test_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
+                                                          message, start_timeout, send_after, delay):
+        """
+        Check for a timeout during receiving of a UDS message (carried by First Frame and Consecutive Frame packets).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carries part of received
+            UDS message (First Frame and then Consecutive Frames with one Consecutive Frame missing).
+        2. Call method to receive message via Transport Interface.
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+        self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                         packet=packets[0],
+                         delay=send_after)
+        for i, cf_packet in enumerate(packets[1:-1], start=1):
+            self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                             packet=cf_packet,
+                             delay=send_after + i * delay)
+        with pytest.raises(TimeoutError):
+            can_transport_interface.receive_message(start_timeout=start_timeout)
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22, *range(62)], addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34, *range(100, 250)], addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("start_timeout, send_after, delay", [
+        (1000, 50, 20),  # ms
+        (50, 0, 50),
+    ])
+    @pytest.mark.asyncio
+    async def test_async_receive_message__multi_packets__n_cr_timeout(self, example_can_addressing_information,
+                                                                      message, start_timeout, send_after, delay):
+        """
+        Check for a timeout during asynchronous receiving of a UDS message (carried by First Frame and
+        Consecutive Frame packets).
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call async method to receive message via Transport Interface.
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+            :param message: UDS message to transmit.
+        :param start_timeout: Maximal time (in milliseconds) to wait for the start of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+
+        async def _send_message():
+            for packet in packets[:-1]:
+                await self.async_send_packet(transport_interface=can_transport_interface_2nd_node,
+                                             packet=packet,
+                                             delay=send_after if packet == packets[0] else delay)
+
+        send_message_task = asyncio.create_task(_send_message())
+        with pytest.raises(TimeoutError):
+            await can_transport_interface.async_receive_message(start_timeout=start_timeout)
+        await send_message_task
+
+    @pytest.mark.parametrize("message", [
+        UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),
+        UdsMessage(payload=[0x62, 0x12, 0x34] + [*range(100, 164)] * 65, addressing_type=AddressingType.PHYSICAL),
+    ])
+    @pytest.mark.parametrize("end_timeout, send_after, delay", [
+        (100, 50, 20),  # ms
+        (1500, 10, 50),
+    ])
+    def test_receive_message__multi_packets__end_timeout(self, example_can_addressing_information,
+                                                         message, end_timeout, send_after, delay):
+        """
+        Check for an end message timeout during synchronous multi packet (FF + CF) UDS message reception.
+
+        Procedure:
+        1. Schedule transmission (using second CAN interface) of a CAN frames that carry received
+            UDS message (First Frame and then Consecutive Frames).
+        2. Call method to receive message via Transport Interface with timeout set before the entire segmented
+            UDS message is transmitted.
+            Expected: Timeout exception is raised.
+
+        :param example_can_addressing_information: Addressing Information of receiving CAN Node.
+        :param message: UDS message to transmit.
+        :param end_timeout: Maximal time (in milliseconds) to wait for the end of a message transmission.
+        :param send_after: Time when to send First Frame after call of receive method [ms].
+        :param delay: Time distance to use for sending Consecutive Frames [ms].
+        """
+        can_transport_interface = PyCanTransportInterface(
+            network_manager=self.can_interface_1,
+            addressing_information=example_can_addressing_information,
+            n_br=0)
+        can_transport_interface_2nd_node = PyCanTransportInterface(
+            network_manager=self.can_interface_2,
+            addressing_information=example_can_addressing_information.get_other_end())
+        packets = can_transport_interface_2nd_node.segmenter.segmentation(message)
+        for i, packet in enumerate(packets):
+            self.send_packet(transport_interface=can_transport_interface_2nd_node,
+                             packet=packet,
+                             delay=send_after + i * delay)
+        time_before_receive = perf_counter()
+        with pytest.raises(TimeoutError):
+            can_transport_interface.receive_message(start_timeout=2 * send_after + 50,
+                                                    end_timeout=end_timeout)
+        time_after_receive = perf_counter()
+        # performance checks
+        if self.MAKE_TIMING_CHECKS:
+            receiving_time_ms = (time_after_receive - time_before_receive) * 1000.
+            assert (end_timeout
+                    < receiving_time_ms
+                    < end_timeout + self.TASK_TIMING_TOLERANCE)
 
     @pytest.mark.parametrize("message", [
         UdsMessage(payload=[0x22] +  [*range(255), *range(255)] * 15, addressing_type=AddressingType.PHYSICAL),

--- a/tests/system_tests/can/python_can/test_python_can_kvaser.py
+++ b/tests/system_tests/can/python_can/test_python_can_kvaser.py
@@ -3,15 +3,18 @@ from can import Bus
 from .python_can import (
     AbstractCanPacketTests,
     AbstractErrorGuessingTests,
-    AbstractMessageTests,
+    AbstractUnsegmentedMessageTests,
+    AbstractSegmentedMessageTests,
+    AbstractFullDuplexTests,
     AbstractPythonCanTests,
     AbstractUseCaseTests,
 )
 
-# Configs
+
+# Config
 
 class KvaserConfig(AbstractPythonCanTests):
-    """Configuration for Python CAN Transport Interface tests with Kvaser CAN interfaces."""
+    """Configuration for python-can Transport Interface tests with Kvaser CAN interfaces."""
 
     def _define_interfaces(self):
         """Configure CAN bus objects that manage CAN interfaces."""
@@ -22,22 +25,36 @@ class KvaserConfig(AbstractPythonCanTests):
                                    channel=1,
                                    fd=True)
 
+
 # Can Packets Transmission and Reception
 
 class TestKvaserCanPacket(AbstractCanPacketTests, KvaserConfig):
-    """CAN packets related system tests for Python CAN Transport Interface."""
+    """CAN packets related system tests for python-can Transport Interface."""
+
 
 # Messages Transmission and Reception
 
-class TestKvaserMessage(AbstractMessageTests, KvaserConfig):
-    """UDS message related system tests for Python CAN Transport Interface."""
+class TestKvaserUnsegmentedMessage(AbstractUnsegmentedMessageTests, KvaserConfig):
+    """Unsegmented UDS message related system tests for python-can Transport Interface."""
+
+
+class TestKvaserSegmentedMessage(AbstractSegmentedMessageTests, KvaserConfig):  # TODO: test_async_receive_message__multi_packets__end_timeout failing
+    """Segmented UDS message related system tests for python-can Transport Interface."""
+
+
+# Full Duplex
+
+class TestKvaserFullDuplex(AbstractFullDuplexTests, KvaserConfig):
+    """Full-Duplex related system tests for python-can Transport Interface."""
+
 
 # Use-Cases
 
 class TestKvaserUseCase(AbstractUseCaseTests, KvaserConfig):
-    """Use case based system tests for Python CAN Transport Interface."""
+    """Use case based system tests for python-can Transport Interface."""
+
 
 # Error Guessing
 
 class TestKvaserErrorGuessing(AbstractErrorGuessingTests, KvaserConfig):
-    """Error guessing system tests for Python CAN Transport Interface."""
+    """Error guessing system tests for python-can Transport Interface."""

--- a/tests/system_tests/can/python_can/test_python_can_kvaser.py
+++ b/tests/system_tests/can/python_can/test_python_can_kvaser.py
@@ -3,13 +3,12 @@ from can import Bus
 from .python_can import (
     AbstractCanPacketTests,
     AbstractErrorGuessingTests,
-    AbstractUnsegmentedMessageTests,
-    AbstractSegmentedMessageTests,
     AbstractFullDuplexTests,
     AbstractPythonCanTests,
+    AbstractSegmentedMessageTests,
+    AbstractUnsegmentedMessageTests,
     AbstractUseCaseTests,
 )
-
 
 # Config
 
@@ -38,8 +37,10 @@ class TestKvaserUnsegmentedMessage(AbstractUnsegmentedMessageTests, KvaserConfig
     """Unsegmented UDS message related system tests for python-can Transport Interface."""
 
 
-class TestKvaserSegmentedMessage(AbstractSegmentedMessageTests, KvaserConfig):  # TODO: test_async_receive_message__multi_packets__end_timeout failing
+class TestKvaserSegmentedMessage(AbstractSegmentedMessageTests, KvaserConfig):
     """Segmented UDS message related system tests for python-can Transport Interface."""
+    # TODO: test_async_receive_message__multi_packets__end_timeout failing due to
+    #  https://github.com/mdabrowski1990/uds/issues/228
 
 
 # Full Duplex

--- a/uds/can/transport_interface/python_can.py
+++ b/uds/can/transport_interface/python_can.py
@@ -12,7 +12,7 @@ from typing import Any, List, Optional, Tuple, Union
 from warnings import warn
 
 from can import AsyncBufferedReader, BufferedReader, BusABC
-from can import Message as PythonCanMessage
+from can import Message as PythonCanFrame
 from can import Notifier
 from uds.addressing import AddressingType, TransmissionDirection
 from uds.message import UdsMessage, UdsMessageRecord
@@ -46,6 +46,8 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
     def __init__(self,
                  network_manager: BusABC,
                  addressing_information: AbstractCanAddressingInformation,
+                 notifier: Optional[Notifier] = None,
+                 async_notifier: Optional[Notifier] = None,
                  **configuration_params: Any) -> None:
         """
         Create Transport Interface that uses python-can package to control CAN bus.
@@ -53,6 +55,16 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         :param network_manager: Python-can bus object for handling CAN network.
         :param addressing_information: Addressing Information configuration of a simulated node that is taking part in
             DoCAN communication.
+        :param notifier: Python-can notifier object for reporting received and sent CAN Frames to listeners.
+            Leave None to create new notifier when needed.
+
+            .. warning:: Only one notifier object shall be active at any time.
+
+        :param async_notifier: Python-can notifier object for reporting received and sent CAN Frames to async listeners.
+            Leave None to create new notifier when needed.
+
+            .. warning:: Only one notifier object shall be active at any time.
+
         :param configuration_params: Additional configuration parameters.
 
             - :parameter n_as_timeout: Timeout value for :ref:`N_As <knowledge-base-can-n-as>` time parameter.
@@ -73,78 +85,146 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         super().__init__(network_manager=network_manager,
                          addressing_information=addressing_information,
                          **configuration_params)
-        self.__notifier: Optional[Notifier] = None
-        self.__async_notifier: Optional[Notifier] = None
-        # listeners for receiving packets
+        self.notifier = notifier
+        self.async_notifier = async_notifier
         self.__rx_frames_buffer = BufferedReader()
         self.__async_rx_frames_buffer = AsyncBufferedReader()
-        # listeners for receiving FC packets when sending messages
         self.__tx_frames_buffer = BufferedReader()
         self.__async_tx_frames_buffer = AsyncBufferedReader()
 
     def __del__(self) -> None:
         """Safely close all threads opened by this object."""
-        self.__teardown_notifier(suppress_warning=True)
-        self.__teardown_async_notifier(suppress_warning=True)
+        self.__teardown_sync_listening(suppress_warning=True)
+        self.__teardown_async_listening(suppress_warning=True)
         self.__rx_frames_buffer.stop()
         self.__async_rx_frames_buffer.stop()
         self.__tx_frames_buffer.stop()
         self.__async_tx_frames_buffer.stop()
 
-    def __teardown_notifier(self, suppress_warning: bool = False) -> None:
-        """
-        Stop and remove CAN frame notifier for synchronous communication.
+    @property
+    def notifier(self) -> Optional[Notifier]:
+        """Notifier used by python-can for reporting received and sent CAN Frames to listeners."""
+        return self.__notifier
 
-        :param suppress_warning: Do not warn about mixing Synchronous and Asynchronous implementation.
+    @notifier.setter
+    def notifier(self, value: Optional[Notifier]) -> None:
         """
-        if self.__notifier is not None:
-            self.__notifier.stop(self._MIN_NOTIFIER_TIMEOUT)
+        Set notifier for reporting received and sent CAN Frames to listeners.
+
+        :param value: Value of notifier to set.
+
+        :raise TypeError: Value is not None neither Notifier type.
+        """
+        if value is None:
             self.__notifier = None
-            if not suppress_warning:
-                warn(message="Asynchronous (`PyCanTransportInterface.async_send_packet`, "
-                             "`PyCanTransportInterface.async_receive_packet methods`) "
-                             "and synchronous (`PyCanTransportInterface.send_packet`, "
-                             "`PyCanTransportInterface.receive_packet methods`) shall not be used together.",
+        elif isinstance(value, Notifier):
+            self.__notifier = value
+            if self.__notifier.timeout > self._MIN_NOTIFIER_TIMEOUT:
+                self.__notifier.timeout = self._MIN_NOTIFIER_TIMEOUT
+                warn(message=f"Notifier's timeout value was changed to {self._MIN_NOTIFIER_TIMEOUT}[s] "
+                             f"due to performance reasons.",
                      category=UserWarning)
+        else:
+            raise TypeError(f"Provided value is not None neither Notifier type. Actual type: {type(value)}.")
 
-    def __teardown_async_notifier(self, suppress_warning: bool = False) -> None:
-        """
-        Stop and remove CAN frame notifier for asynchronous communication.
+    @property
+    def async_notifier(self) -> Optional[Notifier]:
+        """Notifier used by python-can for reporting received and sent CAN Frames to async listeners."""
+        return self.__async_notifier
 
-        :param suppress_warning: Do not warn about mixing Synchronous and Asynchronous implementation.
+    @async_notifier.setter
+    def async_notifier(self, value: Optional[Notifier]) -> None:
         """
-        if self.__async_notifier is not None:
-            self.__async_notifier.stop(self._MIN_NOTIFIER_TIMEOUT)
+        Set notifier for reporting received and sent CAN Frames to async listeners.
+
+        :param value: Value of notifier to set.
+
+        :raise TypeError: Value is not None neither Notifier type.
+        """
+        if value is None:
             self.__async_notifier = None
-            if not suppress_warning:
-                warn(message="Asynchronous (`PyCanTransportInterface.async_send_packet`, "
-                             "`PyCanTransportInterface.async_receive_packet methods`) "
-                             "and synchronous (`PyCanTransportInterface.send_packet`, "
-                             "`PyCanTransportInterface.receive_packet methods`) shall not be used together.",
+        elif isinstance(value, Notifier):
+            self.__async_notifier = value
+            if self.__async_notifier.timeout > self._MIN_NOTIFIER_TIMEOUT:
+                self.__async_notifier.timeout = self._MIN_NOTIFIER_TIMEOUT
+                warn(message=f"Asynchronous Notifier's timeout value was changed to {self._MIN_NOTIFIER_TIMEOUT}[s] "
+                             f"due to performance reasons.",
                      category=UserWarning)
+        else:
+            raise TypeError(f"Provided value is not None neither Notifier type. Actual type: {type(value)}.")
 
-    def __setup_notifier(self) -> None:
+    def __setup_sync_listening(self) -> None:
         """Configure CAN frame notifier for synchronous communication."""
-        self.__teardown_async_notifier()
-        if self.__notifier is None:
-            self.__notifier = Notifier(bus=self.network_manager,
-                                       listeners=[self.__rx_frames_buffer,
-                                                  self.__tx_frames_buffer],
-                                       timeout=self._MIN_NOTIFIER_TIMEOUT)
+        self.__teardown_async_listening()
+        self.__rx_frames_buffer.is_stopped = False  # noqa: vulture
+        self.__tx_frames_buffer.is_stopped = False  # noqa: vulture
+        if self.notifier is None or self.notifier.stopped:
+            self.notifier = Notifier(bus=self.network_manager,
+                                     listeners=[self.__async_rx_frames_buffer,
+                                                self.__async_tx_frames_buffer],
+                                     timeout=self._MIN_NOTIFIER_TIMEOUT)
+        if self.network_manager not in self.notifier._bus_list:  # pylint: disable=protected-access
+            self.notifier.add_bus(self.network_manager)
+        if self.__rx_frames_buffer not in self.notifier.listeners:
+            self.notifier.add_listener(self.__rx_frames_buffer)
+        if self.__tx_frames_buffer not in self.notifier.listeners:
+            self.notifier.add_listener(self.__tx_frames_buffer)
 
-    def __setup_async_notifier(self, loop: AbstractEventLoop) -> None:
+    def __setup_async_listening(self, loop: AbstractEventLoop) -> None:
         """
         Configure CAN frame notifier for asynchronous communication.
 
         :param loop: An :mod:`asyncio` event loop to use.
         """
-        self.__teardown_notifier()
-        if self.__async_notifier is None:
-            self.__async_notifier = Notifier(bus=self.network_manager,
-                                             listeners=[self.__async_rx_frames_buffer,
-                                                        self.__async_tx_frames_buffer],
-                                             timeout=self._MIN_NOTIFIER_TIMEOUT,
-                                             loop=loop)
+        self.__teardown_async_listening()
+        self.__async_rx_frames_buffer.is_stopped = False  # noqa: vulture
+        self.__async_tx_frames_buffer.is_stopped = False  # noqa: vulture
+        if self.async_notifier is None or self.async_notifier.stopped:
+            self.async_notifier = Notifier(bus=self.network_manager,
+                                           listeners=[self.__async_rx_frames_buffer,
+                                                      self.__async_tx_frames_buffer],
+                                           timeout=self._MIN_NOTIFIER_TIMEOUT,
+                                           loop=loop)
+        if self.network_manager not in self.async_notifier._bus_list:  # pylint: disable=protected-access
+            self.async_notifier.add_bus(self.network_manager)
+        if self.__async_rx_frames_buffer not in self.async_notifier.listeners:
+            self.async_notifier.add_listener(self.__async_rx_frames_buffer)
+        if self.__async_tx_frames_buffer not in self.async_notifier.listeners:
+            self.async_notifier.add_listener(self.__async_tx_frames_buffer)
+
+    def __teardown_sync_listening(self, suppress_warning: bool = False) -> None:
+        """
+        Stop and remove CAN frame notifier for synchronous communication.
+
+        :param suppress_warning: Do not warn about mixing Synchronous and Asynchronous implementation.
+        """
+        if self.notifier is not None:
+            self.notifier.stop(self._MIN_NOTIFIER_TIMEOUT)
+            self.notifier = None
+            if not suppress_warning:
+                warn(message="Notifier (python-can) was stopped. "
+                             "Asynchronous (`PyCanTransportInterface.async_send_packet`, "
+                             "`PyCanTransportInterface.async_receive_packet methods`) "
+                             "and synchronous (`PyCanTransportInterface.send_packet`, "
+                             "`PyCanTransportInterface.receive_packet methods`) calls shall not be used together.",
+                     category=UserWarning)
+
+    def __teardown_async_listening(self, suppress_warning: bool = False) -> None:
+        """
+        Stop and remove CAN frame notifier for asynchronous communication.
+
+        :param suppress_warning: Do not warn about mixing Synchronous and Asynchronous implementation.
+        """
+        if self.async_notifier is not None:
+            self.async_notifier.stop(self._MIN_NOTIFIER_TIMEOUT)
+            self.async_notifier = None
+            if not suppress_warning:
+                warn(message="Async notifier (python-can) was stopped. "
+                             "Asynchronous (`PyCanTransportInterface.async_send_packet`, "
+                             "`PyCanTransportInterface.async_receive_packet methods`) "
+                             "and synchronous (`PyCanTransportInterface.send_packet`, "
+                             "`PyCanTransportInterface.receive_packet methods`) calls shall not be used together.",
+                     category=UserWarning)
 
     @staticmethod
     def __validate_timeout(value: Optional[TimeMillisecondsAlias]) -> None:
@@ -654,24 +734,24 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         is_flow_control_packet = packet.packet_type == CanPacketType.FLOW_CONTROL
         timeout_ms = self.n_ar_timeout if is_flow_control_packet else self.n_as_timeout
         fd = self.can_version == CanVersion.CAN_FD or CanDlcHandler.is_can_fd_specific_dlc(packet.dlc)
-        can_frame = PythonCanMessage(arbitration_id=packet.can_id,
-                                     is_extended_id=CanIdHandler.is_extended_can_id(packet.can_id),
-                                     data=packet.raw_frame_data,
-                                     is_fd=fd,
-                                     is_rx=False,
-                                     is_error_frame=False,
-                                     is_remote_frame=False)
+        can_frame = PythonCanFrame(arbitration_id=packet.can_id,
+                                   is_extended_id=CanIdHandler.is_extended_can_id(packet.can_id),
+                                   data=packet.raw_frame_data,
+                                   is_fd=fd,
+                                   is_rx=False,
+                                   is_error_frame=False,
+                                   is_remote_frame=False)
         timestamp_start = time()
         self.network_manager.send(msg=can_frame, timeout=timeout_ms / 1000.)
         timestamp_sent = time()
-        sent_frame = PythonCanMessage(arbitration_id=can_frame.arbitration_id,
-                                      is_extended_id=can_frame.is_extended_id,
-                                      data=can_frame.data,
-                                      is_fd=can_frame.is_fd,
-                                      is_rx=False,
-                                      is_error_frame=False,
-                                      is_remote_frame=False,
-                                      timestamp=timestamp_sent)
+        sent_frame = PythonCanFrame(arbitration_id=can_frame.arbitration_id,
+                                    is_extended_id=can_frame.is_extended_id,
+                                    data=can_frame.data,
+                                    is_fd=can_frame.is_fd,
+                                    is_rx=False,
+                                    is_error_frame=False,
+                                    is_remote_frame=False,
+                                    timestamp=timestamp_sent)
         transmission_time = datetime.fromtimestamp(sent_frame.timestamp)
         if is_flow_control_packet:
             self._update_n_ar_measured((timestamp_sent - timestamp_start) * 1000.)
@@ -708,7 +788,7 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         :return: Record with historic information about received CAN packet.
         """
         self.__validate_timeout(timeout)
-        self.__setup_notifier()
+        self.__setup_sync_listening()
         return self._wait_for_packet(buffer=self.__rx_frames_buffer, timeout=timeout)
 
     async def async_receive_packet(self,
@@ -725,7 +805,7 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         """
         self.__validate_timeout(timeout)
         loop = loop if isinstance(loop, AbstractEventLoop) else get_running_loop()
-        self.__setup_async_notifier(loop=loop)
+        self.__setup_async_listening(loop=loop)
         return await self._async_wait_for_packet(buffer=self.__async_rx_frames_buffer, timeout=timeout)
 
     def send_message(self, message: UdsMessage) -> UdsMessageRecord:
@@ -742,7 +822,7 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
 
         :return: Record with historic information about transmitted UDS message.
         """
-        self.__setup_notifier()
+        self.__setup_sync_listening()
         self.clear_tx_frames_buffers()
         packets_to_send = list(self.segmenter.segmentation(message))
         packet_records = [self.send_packet(packets_to_send.pop(0))]
@@ -787,7 +867,7 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         :return: Record with historic information about transmitted UDS message.
         """
         loop = loop if isinstance(loop, AbstractEventLoop) else get_running_loop()
-        self.__setup_async_notifier(loop)
+        self.__setup_async_listening(loop)
         self.clear_tx_frames_buffers()
         packets_to_send = list(self.segmenter.segmentation(message))
         packet_records = [await self.async_send_packet(packets_to_send.pop(0), loop=loop)]
@@ -846,7 +926,7 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
             timestamp_end_timeout = timestamp_now + end_timeout / 1000.
         else:
             timestamp_end_timeout = None
-        self.__setup_notifier()
+        self.__setup_sync_listening()
         while True:
             # calculate remaining timeout
             if start_timeout is not None:
@@ -900,7 +980,7 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         else:
             timestamp_end_timeout = None
         loop = get_running_loop() if loop is None else loop
-        self.__setup_async_notifier(loop=loop)
+        self.__setup_async_listening(loop=loop)
         while True:
             # calculate remaining timeout
             if start_timeout is not None:

--- a/uds/can/transport_interface/python_can.py
+++ b/uds/can/transport_interface/python_can.py
@@ -156,8 +156,8 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
     def __setup_sync_listening(self) -> None:
         """Configure CAN frame notifier for synchronous communication."""
         self.__teardown_async_listening()
-        self.__rx_frames_buffer.is_stopped = False
-        self.__tx_frames_buffer.is_stopped = False
+        self.__rx_frames_buffer.is_stopped = False  # noqa: vulture
+        self.__tx_frames_buffer.is_stopped = False  # noqa: vulture
         if self.notifier is None or self.notifier.stopped:
             self.notifier = Notifier(bus=self.network_manager,
                                      listeners=[self.__rx_frames_buffer,
@@ -177,8 +177,8 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
         :param loop: An :mod:`asyncio` event loop to use.
         """
         self.__teardown_sync_listening()
-        self.__async_rx_frames_buffer.is_stopped = False
-        self.__async_tx_frames_buffer.is_stopped = False
+        self.__async_rx_frames_buffer.is_stopped = False  # noqa: vulture
+        self.__async_tx_frames_buffer.is_stopped = False  # noqa: vulture
         if self.async_notifier is None or self.async_notifier.stopped:
             self.async_notifier = Notifier(bus=self.network_manager,
                                            listeners=[self.__async_rx_frames_buffer,
@@ -355,11 +355,11 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
                 packet_addressing_type = self.addressing_information.is_input_packet(
                     can_id=received_frame.arbitration_id,
                     raw_frame_data=received_frame.data)
-        return CanPacketRecord(frame=received_frame,
+        return CanPacketRecord(frame=received_frame,  # type: ignore
                                direction=TransmissionDirection.RECEIVED,
                                addressing_type=packet_addressing_type,
                                addressing_format=self.segmenter.addressing_format,
-                               transmission_time=datetime.fromtimestamp(received_frame.timestamp))
+                               transmission_time=datetime.fromtimestamp(received_frame.timestamp))  # type: ignore
 
     async def _async_wait_for_packet(self,
                                      buffer: AsyncBufferedReader,
@@ -389,11 +389,11 @@ class PyCanTransportInterface(AbstractCanTransportInterface):
                 packet_addressing_type = self.addressing_information.is_input_packet(
                     can_id=received_frame.arbitration_id,
                     raw_frame_data=received_frame.data)
-        return CanPacketRecord(frame=received_frame,
+        return CanPacketRecord(frame=received_frame,  # type: ignore
                                direction=TransmissionDirection.RECEIVED,
                                addressing_type=packet_addressing_type,
                                addressing_format=self.segmenter.addressing_format,
-                               transmission_time=datetime.fromtimestamp(received_frame.timestamp))
+                               transmission_time=datetime.fromtimestamp(received_frame.timestamp))  # type: ignore
 
     def _receive_cf_packets_block(self,
                                   sequence_number: int,

--- a/uds/translator/data_record_definitions/conditional.py
+++ b/uds/translator/data_record_definitions/conditional.py
@@ -1,4 +1,4 @@
-"""Definitions for Conditional Data Records."""  # pylint: disable=too-many-lines
+"""Definitions for Conditional Data Records."""
 
 __all__ = [
     # Shared

--- a/uds/translator/data_record_definitions/formula.py
+++ b/uds/translator/data_record_definitions/formula.py
@@ -1,4 +1,4 @@
-"""Formulas used by Conditional Data Records."""  # pylint: disable=too-many-lines
+"""Formulas used by Conditional Data Records."""
 
 __all__ = [
     # Shared


### PR DESCRIPTION
# Description
<!--- Describe your changes -->
- add an option for user to pass a notifier to `PyCanTransportInterface`
- expose `notifier` and `sync_notifier` attributes in `PyCanTransportInterface` class


# How Has This Been Tested?
<!--- Please shortly describe how you tested your code. -->
- system tests


# Process
<!--- If you are familiar with the process, leave the line below. If not, please describe what you did, so we could help you deliver your changed according to our quality policies -->
I know the [process](https://github.com/mdabrowski1990/uds/wiki/Software-Development-Life-Cycle) and did my best to follow it
