### PR TITLE
Fix for client raising an exception if response to underfine service received

### DIFF
--- a/tests/software_tests/client/test_client.py
+++ b/tests/software_tests/client/test_client.py
@@ -1568,6 +1568,7 @@ class TestClient:
         assert Client.is_response_to_request(self.mock_client,
                                              response_message=response_message,
                                              request_message=request_message) is False
+        self.mock_warn.assert_not_called()
 
     @pytest.mark.parametrize("response_message, request_message", [
         (Mock(spec=UdsMessage,
@@ -1585,10 +1586,10 @@ class TestClient:
               payload=[0x22, 0x10, 0x13],
               addressing_type=AddressingType.FUNCTIONAL),),
     ])
-    @patch(f"{SCRIPT_LOCATION}.ResponseSID")
-    def test_is_response_to_request__false__undefined_response(self, mock_response_sid,
+    @patch(f"{SCRIPT_LOCATION}.ResponseSID.is_member")
+    def test_is_response_to_request__false__undefined_response(self, mock_is_rsid_member,
                                                                response_message, request_message):
-        mock_response_sid.side_effect = ValueError
+        mock_is_rsid_member.return_value = False
         self.mock_validate_request_sid.side_effect = RequestSID
         self.mock_client.transport_interface.addressing_information.rx_physical_params = {
             "addressing_type": AddressingType.PHYSICAL,
@@ -1601,6 +1602,8 @@ class TestClient:
         assert Client.is_response_to_request(self.mock_client,
                                              response_message=response_message,
                                              request_message=request_message) is False
+        mock_is_rsid_member.assert_called_once_with(response_message.payload[0])
+        self.mock_warn.assert_called_once()
 
     @pytest.mark.parametrize("response_message, request_message", [
         (Mock(spec=UdsMessage,
@@ -1639,6 +1642,7 @@ class TestClient:
         assert Client.is_response_to_request(self.mock_client,
                                              response_message=response_message,
                                              request_message=request_message) is True
+        self.mock_warn.assert_not_called()
 
     @pytest.mark.parametrize("response_message, request_message", [
         (Mock(spec=UdsMessage,
@@ -1677,6 +1681,7 @@ class TestClient:
         assert Client.is_response_to_request(self.mock_client,
                                              response_message=response_message,
                                              request_message=request_message) is False
+        self.mock_warn.assert_not_called()
 
     # wait_till_ready_for_physical_transmission
 

--- a/tests/software_tests/client/test_client.py
+++ b/tests/software_tests/client/test_client.py
@@ -1584,6 +1584,39 @@ class TestClient:
               transmission_end_timestamp=1.234,
               payload=[0x22, 0x10, 0x13],
               addressing_type=AddressingType.FUNCTIONAL),),
+    ])
+    @patch(f"{SCRIPT_LOCATION}.ResponseSID")
+    def test_is_response_to_request__false__undefined_response(self, mock_response_sid,
+                                                               response_message, request_message):
+        mock_response_sid.side_effect = ValueError
+        self.mock_validate_request_sid.side_effect = RequestSID
+        self.mock_client.transport_interface.addressing_information.rx_physical_params = {
+            "addressing_type": AddressingType.PHYSICAL,
+            "some_attr": "some value",
+        }
+        self.mock_client.transport_interface.addressing_information.rx_functional_params = {
+            "addressing_type": AddressingType.FUNCTIONAL,
+            "some_attr": "some other value",
+        }
+        assert Client.is_response_to_request(self.mock_client,
+                                             response_message=response_message,
+                                             request_message=request_message) is False
+
+    @pytest.mark.parametrize("response_message, request_message", [
+        (Mock(spec=UdsMessage,
+              payload=[0x7E, 0x00],
+              addressing_type=AddressingType.PHYSICAL),
+         Mock(spec=UdsMessage,
+              payload=[0x3E, 0x00],
+              addressing_type=AddressingType.PHYSICAL),),
+        (Mock(spec=UdsMessageRecord,
+              transmission_start_timestamp=1.234,
+              payload=[0x62, 0x10, 0x13, 0xB4],
+              addressing_type=AddressingType.FUNCTIONAL),
+         Mock(spec=UdsMessageRecord,
+              transmission_end_timestamp=1.234,
+              payload=[0x22, 0x10, 0x13],
+              addressing_type=AddressingType.FUNCTIONAL),),
         (Mock(spec=UdsMessageRecord,
               payload=[0x7F, 0x10, 0x78],
               addressing_type=AddressingType.PHYSICAL,

--- a/uds/client.py
+++ b/uds/client.py
@@ -803,9 +803,14 @@ class Client:
             if rx_physical_params != rx_functional_params:
                 return False
         request_sid = RequestSID.validate_member(request_message.payload[0])
-        response_sid = ResponseSID(response_message.payload[0])
-        if request_sid.name == response_sid.name:
-            return True  # Positive Response
+        try:
+            response_sid = ResponseSID(response_message.payload[0])
+        except ValueError:
+            warn(message=f"Response with undefined SID (0x{response_message.payload[0]:02X}) was provided.",
+                 category=RuntimeWarning)
+            return False
+        if request_sid.name == response_sid.name:  # Positive Response
+            return True
         return (len(response_message.payload) == 3
                 and response_sid == ResponseSID.NegativeResponse
                 and response_message.payload[1] == request_sid)  # True if Negative Response, False otherwise

--- a/uds/client.py
+++ b/uds/client.py
@@ -803,10 +803,10 @@ class Client:
             if rx_physical_params != rx_functional_params:
                 return False
         request_sid = RequestSID.validate_member(request_message.payload[0])
-        try:
+        if ResponseSID.is_member(response_message.payload[0]):
             response_sid = ResponseSID(response_message.payload[0])
-        except ValueError:
-            warn(message=f"Response with undefined SID (0x{response_message.payload[0]:02X}) was provided.",
+        else:
+            warn(message=f"Response with undefined RSID value (0x{response_message.payload[0]:02X}) was provided.",
                  category=RuntimeWarning)
             return False
         if request_sid.name == response_sid.name:  # Positive Response


### PR DESCRIPTION
# Description
<!--- Describe your changes -->
Make client handle responses for undefined services.


# How Has This Been Tested?
<!--- Please shortly describe how you tested your code. -->
- add regression tests (unit level)


# Process
<!--- If you are familiar with the process, leave the line below. If not, please describe what you did, so we could help you deliver your changed according to our quality policies -->
I know the [process](https://github.com/mdabrowski1990/uds/wiki/Software-Development-Life-Cycle) and did my best to follow it
