### PR TITLE
Fix `_receive_initial_response` in Client.

### DIFF
--- a/tests/software_tests/client/test_client.py
+++ b/tests/software_tests/client/test_client.py
@@ -1394,6 +1394,7 @@ class TestClient:
                 == self.mock_client._receive_response.return_value)
         assert self.mock_client._receive_response.call_count == 2
         assert self.mock_client.is_response_to_request.call_count == 2
+        assert self.mock_perf_counter.call_count == 2
         self.mock_warn.assert_not_called()
         self.mock_client._Client__response_queue.put_nowait.assert_called_once_with(
             self.mock_client._receive_response.return_value)

--- a/uds/client.py
+++ b/uds/client.py
@@ -712,6 +712,7 @@ class Client:
                              "It was put into response_queue.",
                      category=RuntimeWarning)
             self.__response_queue.put_nowait(response_record)
+            timestamp_now = perf_counter()
         raise TimeoutError("P2Client timeout exceeded.")
 
     def _receive_following_response(self,


### PR DESCRIPTION
# Description
Fix Client being stack in infinite loop in case of ECU sending responses to other requests.


# How Has This Been Tested?
<!--- Please shortly describe how you tested your code. -->
- Against ECU kept sending SID 0x01 responses but times out often.


# Process
<!--- If you are familiar with the process, leave the line below. If not, please describe what you did, so we could help you deliver your changed according to our quality policies -->
I know the [process](https://github.com/mdabrowski1990/uds/wiki/Software-Development-Life-Cycle) and did my best to follow it
