### PR TITLE
Fix handling CAN Consecutive Frames with incorrect Sequence Number

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13"]  # TODO: add "3.14" once https://github.com/prospector-dev/prospector/issues/825 fixed
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]  # TODO: add "3.14" once https://github.com/prospector-dev/prospector/issues/825 fixed
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v7

--- a/tests/software_tests/can/test_segmenter.py
+++ b/tests/software_tests/can/test_segmenter.py
@@ -13,8 +13,8 @@ from uds.can.segmenter import (
     CanPacket,
     CanPacketRecord,
     CanPacketType,
+    CanSegmentationError,
     CanSegmenter,
-    SegmentationError,
     UdsMessage,
 )
 
@@ -224,7 +224,7 @@ class TestCanSegmenter:
     def test_physical_segmentation__too_long(self, mock_len, message_payload_size):
         mock_len.return_value = message_payload_size
         mock_message = Mock(spec=UdsMessage, addressing_type=AddressingType.PHYSICAL)
-        with pytest.raises(SegmentationError):
+        with pytest.raises(CanSegmentationError):
             CanSegmenter._CanSegmenter__physical_segmentation(self=self.mock_can_segmenter, message=mock_message)
         mock_len.assert_called_once_with(mock_message.payload)
 
@@ -401,7 +401,7 @@ class TestCanSegmenter:
         mock_is_too_long = Mock(return_value=True)
         self.mock_get_single_frame_min_dlc.return_value = MagicMock(__gt__=mock_is_too_long)
         mock_message = Mock(spec=UdsMessage, addressing_type=AddressingType.FUNCTIONAL)
-        with pytest.raises(SegmentationError):
+        with pytest.raises(CanSegmentationError):
             CanSegmenter._CanSegmenter__functional_segmentation(self=self.mock_can_segmenter, message=mock_message)
         mock_len.assert_called_once_with(mock_message.payload)
         self.mock_get_single_frame_min_dlc.assert_called_once_with(
@@ -419,7 +419,7 @@ class TestCanSegmenter:
         self.mock_get_single_frame_min_dlc.side_effect = ValueError()
         self.mock_can_segmenter.dlc = dlc
         mock_message = Mock(spec=UdsMessage, addressing_type=AddressingType.FUNCTIONAL)
-        with pytest.raises(SegmentationError):
+        with pytest.raises(CanSegmentationError):
             CanSegmenter._CanSegmenter__functional_segmentation(self=self.mock_can_segmenter, message=mock_message)
         mock_len.assert_called_once_with(mock_message.payload)
         self.mock_get_single_frame_min_dlc.assert_called_once_with(
@@ -658,7 +658,7 @@ class TestCanSegmenter:
     ])
     def test_desegmentation__segmentation_error(self, packets):
         self.mock_can_segmenter.is_desegmented_message.return_value = False
-        with pytest.raises(SegmentationError):
+        with pytest.raises(CanSegmentationError):
             CanSegmenter.desegmentation(self=self.mock_can_segmenter, packets=packets)
         self.mock_can_segmenter.is_desegmented_message.assert_called_once_with(packets)
 
@@ -734,7 +734,7 @@ class TestCanSegmenter:
         self.mock_can_segmenter.is_desegmented_message.return_value = True
         mock_isinstance.side_effect = lambda value, type_: (type_ == self.mock_can_packet
                                                             and isinstance(value, CanPacket))
-        with pytest.raises(SegmentationError):
+        with pytest.raises(CanSegmentationError):
             CanSegmenter.desegmentation(self=self.mock_can_segmenter, packets=packets)
         self.mock_can_segmenter.is_desegmented_message.assert_called_once_with(packets)
 

--- a/tests/software_tests/can/transport_interface/test_common.py
+++ b/tests/software_tests/can/transport_interface/test_common.py
@@ -11,8 +11,10 @@ from uds.can.transport_interface.common import (
     AbstractEventLoop,
     AbstractFlowControlParametersGenerator,
     CanFlowStatus,
+    CanOverflowFlowStatus,
     CanPacket,
     CanPacketType,
+    CanUnexpectedSequenceNumber,
     CanVersion,
     MessageTransmissionNotStartedError,
     TransmissionDirection,
@@ -782,7 +784,7 @@ class TestAbstractCanTransportInterface:
         self.mock_sleep.assert_not_called()
         self.mock_async_sleep.assert_called()
 
-# _receive_cf_packets_block
+    # _receive_cf_packets_block
 
     @pytest.mark.parametrize("sequence_number, block_size, remaining_data_length, timestamp_end", [
         (Mock(), Mock(), 1, MagicMock(__sub__=lambda this, other: this,
@@ -866,6 +868,35 @@ class TestAbstractCanTransportInterface:
             initial_packet=self.mock_can_transport_interface.receive_packet.return_value,
             timestamp_end=timestamp_end)
         self.mock_warn.assert_called_once()
+
+    @pytest.mark.parametrize("sequence_number, packet_sequence_numbers, block_size, remaining_data_length, timestamp_end", [
+        (1, [0], 1, 1, MagicMock(__sub__=lambda this, other: this,
+                            __mul__=lambda this, other: this,
+                            __le__=Mock(return_value=False))),
+        (13, [13, 14, 15, 1], 4, 987, None),
+    ])
+    def test_receive_cf_packets_block__incorrect_sn(self, sequence_number, packet_sequence_numbers, block_size,
+                                                    remaining_data_length, timestamp_end):
+        self.mock_perf_counter.return_value = self.mock_can_transport_interface.n_cr_timeout = MagicMock(
+            __sub__=lambda this, other: this,
+            __add__=lambda this, other: this,
+            __mul__=lambda this, other: this,
+            __le__=Mock(return_value=False))
+        self.mock_can_packet_type_is_initial_packet_type.return_value = False
+        packet_sequence = [
+            Mock(spec=CanPacketRecord,
+                 packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                 sequence_number=packet_sequence_numbers[i],
+                 payload=[])
+            for i in range(block_size)
+        ]
+        self.mock_can_transport_interface.receive_packet.side_effect = packet_sequence[:]
+        with pytest.raises(CanUnexpectedSequenceNumber):
+            AbstractCanTransportInterface._receive_cf_packets_block(self.mock_can_transport_interface,
+                                                                    sequence_number=sequence_number,
+                                                                    block_size=block_size,
+                                                                    remaining_data_length=remaining_data_length,
+                                                                    timestamp_end=timestamp_end)
 
     @pytest.mark.parametrize("sequence_number, block_size, remaining_data_length, timestamp_end", [
         (1, 1, 1, MagicMock(__sub__=lambda this, other: this,
@@ -1036,6 +1067,38 @@ class TestAbstractCanTransportInterface:
             loop=mock_loop)
         self.mock_warn.assert_called_once()
 
+    @pytest.mark.parametrize("sequence_number, packet_sequence_numbers, block_size, remaining_data_length, timestamp_end", [
+            (1, [0], 1, 1, MagicMock(__sub__=lambda this, other: this,
+                                     __mul__=lambda this, other: this,
+                                     __le__=Mock(return_value=False))),
+            (13, [13, 14, 15, 1], 4, 987, None),
+        ])
+    @pytest.mark.asyncio
+    async def test_async_receive_cf_packets_block__incorrect_sn(self, sequence_number, packet_sequence_numbers,
+                                                                block_size, remaining_data_length, timestamp_end):
+        mock_loop = Mock()
+        self.mock_perf_counter.return_value = self.mock_can_transport_interface.n_cr_timeout = MagicMock(
+            __sub__=lambda this, other: this,
+            __add__=lambda this, other: this,
+            __mul__=lambda this, other: this,
+            __le__=Mock(return_value=False))
+        self.mock_can_packet_type_is_initial_packet_type.return_value = False
+        packet_sequence = [
+            Mock(spec=CanPacketRecord,
+                 packet_type=CanPacketType.CONSECUTIVE_FRAME,
+                 sequence_number=packet_sequence_numbers[i],
+                 payload=[])
+            for i in range(block_size)
+        ]
+        self.mock_can_transport_interface.async_receive_packet.side_effect = packet_sequence[:]
+        with pytest.raises(CanUnexpectedSequenceNumber):
+            await AbstractCanTransportInterface._async_receive_cf_packets_block(self.mock_can_transport_interface,
+                                                                                sequence_number=sequence_number,
+                                                                                block_size=block_size,
+                                                                                remaining_data_length=remaining_data_length,
+                                                                                timestamp_end=timestamp_end,
+                                                                                loop=mock_loop)
+
     @pytest.mark.parametrize("sequence_number, block_size, remaining_data_length, timestamp_end", [
         (1, 1, 1, MagicMock(__sub__=lambda this, other: this,
                             __mul__=lambda this, other: this,
@@ -1167,7 +1230,7 @@ class TestAbstractCanTransportInterface:
         self.mock_can_transport_interface.flow_control_parameters_generator = [(CanFlowStatus.Overflow, None, None)]
         self.mock_can_transport_interface.n_br = MagicMock(__sub__=lambda this, other: this,
                                                            __gt__=Mock(return_value=False))
-        with pytest.raises(OverflowError):
+        with pytest.raises(CanOverflowFlowStatus):
             AbstractCanTransportInterface._receive_consecutive_frames(self=self.mock_can_transport_interface,
                                                                     first_frame=mock_first_frame,
                                                                     timestamp_end=timestamp_end)
@@ -1328,7 +1391,7 @@ class TestAbstractCanTransportInterface:
         self.mock_can_transport_interface.flow_control_parameters_generator = [(CanFlowStatus.Overflow, None, None)]
         self.mock_can_transport_interface.n_br = MagicMock(__sub__=lambda this, other: this,
                                                            __gt__=Mock(return_value=False))
-        with pytest.raises(OverflowError):
+        with pytest.raises(CanOverflowFlowStatus):
             await AbstractCanTransportInterface._async_receive_consecutive_frames(self=self.mock_can_transport_interface,
                                                                                 first_frame=mock_first_frame,
                                                                                 timestamp_end=timestamp_end,
@@ -1699,7 +1762,7 @@ class TestAbstractCanTransportInterface:
                                                  flow_status=CanFlowStatus.Overflow)
         self.mock_can_transport_interface._wait_for_flow_control.return_value = mock_flow_control_record_overflow
         self.mock_can_transport_interface.n_bs_timeout = MagicMock(__div__=Mock())
-        with pytest.raises(OverflowError):
+        with pytest.raises(CanOverflowFlowStatus):
             AbstractCanTransportInterface.send_message(self.mock_can_transport_interface, message)
         self.mock_can_transport_interface.setup_sync.assert_called_once_with()
         self.mock_can_transport_interface.clear_flow_control_frame_buffers.assert_called_once_with()
@@ -1947,7 +2010,7 @@ class TestAbstractCanTransportInterface:
                                                  packet_type=CanPacketType.FLOW_CONTROL,
                                                  flow_status=CanFlowStatus.Overflow)
         self.mock_can_transport_interface._async_wait_for_flow_control.return_value = mock_flow_control_record_overflow
-        with pytest.raises(OverflowError):
+        with pytest.raises(CanOverflowFlowStatus):
             await AbstractCanTransportInterface.async_send_message(self.mock_can_transport_interface,
                                                                    message=message,
                                                                    loop=mock_loop)

--- a/uds/can/__init__.py
+++ b/uds/can/__init__.py
@@ -31,5 +31,5 @@ from .packet import (
     CanSTminTranslator,
     DefaultFlowControlParametersGenerator,
 )
-from .segmenter import CanSegmenter
+from .segmenter import CanSegmentationError, CanSegmenter
 from .transport_interface import PythonCanTransportInterface

--- a/uds/can/packet/__init__.py
+++ b/uds/can/packet/__init__.py
@@ -7,6 +7,7 @@ from .can_packet_type import CanPacketType
 from .consecutive_frame import (
     CONSECUTIVE_FRAME_N_PCI,
     SN_BYTES_USED,
+    CanUnexpectedSequenceNumber,
     create_consecutive_frame_data,
     encode_sequence_number,
     extract_consecutive_frame_payload,
@@ -42,6 +43,7 @@ from .flow_control import (
     ST_MIN_BYTE_POSITION,
     AbstractFlowControlParametersGenerator,
     CanFlowStatus,
+    CanOverflowFlowStatus,
     CanSTminTranslator,
     DefaultFlowControlParametersGenerator,
     FlowControlParametersAlias,

--- a/uds/can/packet/consecutive_frame.py
+++ b/uds/can/packet/consecutive_frame.py
@@ -1,6 +1,7 @@
 """Implementation of handlers for :ref:`Consecutive Frame <knowledge-base-can-consecutive-frame>` CAN packet."""
 
 __all__ = ["CONSECUTIVE_FRAME_N_PCI", "SN_BYTES_USED",
+           "CanUnexpectedSequenceNumber",
            "is_consecutive_frame", "validate_consecutive_frame_data",
            "create_consecutive_frame_data", "generate_consecutive_frame_data", "extract_consecutive_frame_payload",
            "get_consecutive_frame_min_dlc", "get_consecutive_frame_max_payload_size",
@@ -16,6 +17,10 @@ CONSECUTIVE_FRAME_N_PCI: int = 0x2
 
 SN_BYTES_USED: int = 1
 """Number of CAN Frame data bytes used to carry CAN Packet Type and Sequence Number (SN) in a Consecutive Frame."""
+
+
+class CanUnexpectedSequenceNumber(RuntimeError):
+    """Unexpected Sequence Number value in CAN Consecutive Frame received."""
 
 
 def is_consecutive_frame(addressing_format: CanAddressingFormat, raw_frame_data: RawBytesAlias) -> bool:

--- a/uds/can/packet/flow_control.py
+++ b/uds/can/packet/flow_control.py
@@ -8,7 +8,8 @@ This module contains implementation of :ref:`Flow Control CAN packet <knowledge-
 """
 
 __all__ = ["FLOW_CONTROL_N_PCI", "FS_BYTES_USED", "BS_BYTE_POSITION", "ST_MIN_BYTE_POSITION",
-           "CanFlowStatus", "CanSTminTranslator", "UnrecognizedSTminWarning",
+           "CanFlowStatus", "CanOverflowFlowStatus",
+           "CanSTminTranslator", "UnrecognizedSTminWarning",
            "AbstractFlowControlParametersGenerator", "DefaultFlowControlParametersGenerator",
            "FlowControlParametersAlias",
            "is_flow_control", "validate_flow_control_data",
@@ -46,6 +47,10 @@ BS_BYTE_POSITION: int = 1
 """Position of a data byte with :ref:`Block Size <knowledge-base-can-block-size>` parameter."""
 ST_MIN_BYTE_POSITION: int = 2
 """Position of a data byte with  :ref:`STmin <knowledge-base-can-st-min>` parameter."""
+
+
+class CanOverflowFlowStatus(OverflowError):
+    """Flow Control with Overflow Flow Status was either received or transmitted over CAN bus."""
 
 
 class UnrecognizedSTminWarning(Warning):

--- a/uds/can/segmenter.py
+++ b/uds/can/segmenter.py
@@ -1,6 +1,6 @@
 """Segmentation specific for CAN bus."""
 
-__all__ = ["CanSegmenter"]
+__all__ = ["CanSegmentationError", "CanSegmenter"]
 
 from warnings import warn
 
@@ -25,6 +25,10 @@ from .packet import (
     get_first_frame_payload_size,
     get_single_frame_min_dlc,
 )
+
+
+class CanSegmentationError(SegmentationError):
+    """Error during CAN bus specific segmentation or desegmentation."""
 
 
 class CanSegmenter(AbstractSegmenter):
@@ -168,15 +172,15 @@ class CanSegmenter(AbstractSegmenter):
 
         :param message: UDS message to divide into packets.
 
-        :raise SegmentationError: Provided diagnostic message cannot be segmented.
+        :raise CanSegmentationError: Provided diagnostic message cannot be segmented.
 
         :return: CAN packets that are an outcome of UDS message segmentation.
         """
         message_payload_size = len(message.payload)
         if message_payload_size > MAX_LONG_FF_DL_VALUE:
-            raise SegmentationError("Provided diagnostic message cannot be segmented to CAN Packet as it is too big "
-                                    "to transmit it over CAN bus. "
-                                    f"Maximal diagnostic message length: {MAX_LONG_FF_DL_VALUE}")
+            raise CanSegmentationError("Provided diagnostic message cannot be segmented to CAN Packet as it is too big "
+                                       "to transmit it over CAN bus. "
+                                       f"Maximal diagnostic message length: {MAX_LONG_FF_DL_VALUE}")
         try:
             min_sf_dlc = get_single_frame_min_dlc(addressing_format=self.addressing_format,
                                                   payload_length=message_payload_size)
@@ -231,7 +235,7 @@ class CanSegmenter(AbstractSegmenter):
 
         :param message: UDS message to divide into packets.
 
-        :raise SegmentationError: Provided diagnostic message cannot be segmented.
+        :raise CanSegmentationError: Provided diagnostic message cannot be segmented.
 
         :return: CAN packets that are an outcome of UDS message segmentation.
         """
@@ -242,8 +246,8 @@ class CanSegmenter(AbstractSegmenter):
         except ValueError:
             min_sf_dlc = CanDlcHandler.MAX_DLC_VALUE + 1
         if min_sf_dlc > self.dlc:
-            raise SegmentationError("Provided diagnostic message cannot be segmented using functional addressing "
-                                    "as it will not fit into a Single Frame.")
+            raise CanSegmentationError("Provided diagnostic message cannot be segmented using functional addressing "
+                                       "as it will not fit into a Single Frame.")
         if self.use_data_optimization:
             dlc = None if self.min_dlc is None else max(min_sf_dlc, self.min_dlc)
         else:
@@ -322,13 +326,14 @@ class CanSegmenter(AbstractSegmenter):
 
         :param packets: CAN packets to desegment into UDS message.
 
-        :raise SegmentationError: Provided packets are not a complete packets sequence that form a diagnostic message.
+        :raise CanSegmentationError: Provided packets are not a complete packets sequence that form
+            a diagnostic message.
         :raise NotImplementedError: There is missing implementation for the provided CAN Packets type.
 
         :return: A diagnostic message that is an outcome of CAN packets desegmentation.
         """
         if not self.is_desegmented_message(packets):
-            raise SegmentationError("Provided packets are not a complete packets sequence.")
+            raise CanSegmentationError("Provided packets are not a complete packets sequence.")
         if isinstance(packets[0], CanPacketRecord):
             return UdsMessageRecord(packets)  # type: ignore
         if isinstance(packets[0], CanPacket):
@@ -342,7 +347,7 @@ class CanSegmenter(AbstractSegmenter):
                         payload_bytes += bytearray(packet.payload)
                 return UdsMessage(payload=payload_bytes[:packets[0].data_length],
                                   addressing_type=packets[0].addressing_type)
-            raise SegmentationError("Unexpectedly, something went wrong...")
+            raise CanSegmentationError("Unexpectedly, something went wrong...")
         raise NotImplementedError("Missing implementation for the provided CAN Packet type.")
 
     def segmentation(self, message: UdsMessage) -> tuple[CanPacket, ...]:

--- a/uds/can/transport_interface/common.py
+++ b/uds/can/transport_interface/common.py
@@ -644,7 +644,7 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
 
         :raise TimeoutError: Timeout was reached. Either:
             - Consecutive Frame did not arrive before reaching N_Cr timeout
-            - Diagnostic message reception
+            - diagnostic message was not fully received on time
         :raise CanUnexpectedSequenceNumber: Consecutive Frame with unexpected Sequence Number value was received.
 
         :return: Either:
@@ -709,7 +709,7 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
 
         :raise TimeoutError: Timeout was reached. Either:
             - Consecutive Frame did not arrive before reaching N_Cr timeout
-            - Diagnostic message reception
+            - diagnostic message was not fully received on time
         :raise CanUnexpectedSequenceNumber: Consecutive Frame with unexpected Sequence Number value was received.
 
         :return: Either:
@@ -765,6 +765,7 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
         :param first_frame: :ref:`First Frame <knowledge-base-can-first-frame>` that was received.
         :param timestamp_end: The final timestamp till when the reception must be completed.
 
+        :raise TimeoutError: Message was not fully received on time.
         :raise CanOverflowFlowStatus: Flow Control packet with
             :ref:`Flow Status <knowledge-base-can-flow-status>` equal to OVERFLOW was sent.
 
@@ -830,10 +831,9 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
         :param timestamp_end: The final timestamp till when the reception must be completed.
         :param loop: An asyncio event loop used for observing messages.
 
-        :raise TimeoutError: :ref:`N_Cr <knowledge-base-can-n-cr>` timeout was reached.
+        :raise TimeoutError: Message was not fully received on time.
         :raise CanOverflowFlowStatus: Flow Control packet with :ref:`Flow Status <knowledge-base-can-flow-status>`
             equal to OVERFLOW was sent.
-        :raise NotImplementedError: Unhandled CAN packet starting a new CAN message transmission was received.
 
         :return: Record of UDS message that was formed provided First Frame and received Consecutive Frames.
         """
@@ -1124,7 +1124,6 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
             Leave None to wait forever.
 
         :raise MessageTransmissionNotStartedError: Timeout was exceeded before message reception started.
-        :raise TimeoutError: Timeout was exceeded during message receiving (before all packets received).
 
         :return: Record with historic information about received UDS message.
         """
@@ -1176,7 +1175,6 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
         :param loop: An asyncio event loop to use for scheduling this task.
 
         :raise MessageTransmissionNotStartedError: Timeout was exceeded before message reception started.
-        :raise TimeoutError: Timeout was exceeded during message receiving (before all packets received).
 
         :return: Record with historic information about received UDS message.
         """

--- a/uds/can/transport_interface/common.py
+++ b/uds/can/transport_interface/common.py
@@ -707,6 +707,11 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
         :param timestamp_end: The final timestamp till when the reception must be completed.
         :param loop: An asyncio event loop used for observing messages.
 
+        :raise TimeoutError: Timeout was reached. Either:
+            - Consecutive Frame did not arrive before reaching N_Cr timeout
+            - Diagnostic message reception
+        :raise CanUnexpectedSequenceNumber: Consecutive Frame with unexpected Sequence Number value was received.
+
         :return: Either:
             - Record of UDS message if reception was interrupted by a new UDS message transmission.
             - Tuple with records of received Consecutive Frames.

--- a/uds/can/transport_interface/common.py
+++ b/uds/can/transport_interface/common.py
@@ -29,10 +29,12 @@ from ..frame import CanVersion
 from ..packet import (
     AbstractFlowControlParametersGenerator,
     CanFlowStatus,
+    CanOverflowFlowStatus,
     CanPacket,
     CanPacketRecord,
     CanPacketType,
     CanSTminTranslator,
+    CanUnexpectedSequenceNumber,
     DefaultFlowControlParametersGenerator,
 )
 from ..segmenter import CanSegmenter
@@ -643,6 +645,7 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
         :raise TimeoutError: Timeout was reached. Either:
             - Consecutive Frame did not arrive before reaching N_Cr timeout
             - Diagnostic message reception
+        :raise CanUnexpectedSequenceNumber: Consecutive Frame with unexpected Sequence Number value was received.
 
         :return: Either:
             - Record of UDS message if reception was interrupted by a new UDS message transmission.
@@ -674,12 +677,16 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
                 return self._message_receive_start(initial_packet=received_packet,
                                                    timestamp_end=timestamp_end)
             # handle following Consecutive Frame
-            if (received_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-                    and received_packet.sequence_number == sequence_number):
-                timestamp_start = perf_counter()
-                received_cf.append(received_packet)
-                received_payload_size += len(received_packet.payload)  # type: ignore
-                sequence_number = (received_packet.sequence_number + 1) & 0xF
+            if received_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME:
+                if received_packet.sequence_number == sequence_number:
+                    timestamp_start = perf_counter()
+                    received_cf.append(received_packet)
+                    received_payload_size += len(received_packet.payload)  # type: ignore
+                    sequence_number = (received_packet.sequence_number + 1) & 0xF
+                else:
+                    raise CanUnexpectedSequenceNumber(f"Consecutive Frame with Sequence Number out of range received. "
+                                                      f"Expected: 0x{sequence_number:X}. "
+                                                      f"Received: 0x{received_packet.sequence_number:X}.")
         return tuple(received_cf)
 
     async def _async_receive_cf_packets_block(self,
@@ -732,12 +739,16 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
                                                                timestamp_end=timestamp_end,
                                                                loop=loop)
             # handle following Consecutive Frame
-            if (received_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME
-                    and received_packet.sequence_number == sequence_number):
-                timestamp_start = perf_counter()
-                received_cf.append(received_packet)
-                received_payload_size += len(received_packet.payload)  # type: ignore
-                sequence_number = (received_packet.sequence_number + 1) & 0xF
+            if received_packet.packet_type == CanPacketType.CONSECUTIVE_FRAME:
+                if received_packet.sequence_number == sequence_number:
+                    timestamp_start = perf_counter()
+                    received_cf.append(received_packet)
+                    received_payload_size += len(received_packet.payload)  # type: ignore
+                    sequence_number = (received_packet.sequence_number + 1) & 0xF
+                else:
+                    raise CanUnexpectedSequenceNumber(f"Consecutive Frame with Sequence Number out of range received. "
+                                                      f"Expected: 0x{sequence_number:X}. "
+                                                      f"Received: 0x{received_packet.sequence_number:X}.")
         return tuple(received_cf)
 
     def _receive_consecutive_frames(self,
@@ -749,8 +760,8 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
         :param first_frame: :ref:`First Frame <knowledge-base-can-first-frame>` that was received.
         :param timestamp_end: The final timestamp till when the reception must be completed.
 
-        :raise OverflowError: Flow Control packet with :ref:`Flow Status <knowledge-base-can-flow-status>` equal to
-            OVERFLOW was sent.
+        :raise CanOverflowFlowStatus: Flow Control packet with
+            :ref:`Flow Status <knowledge-base-can-flow-status>` equal to OVERFLOW was sent.
 
         :return: Record of UDS message that was formed provided First Frame and received Consecutive Frames.
         """
@@ -786,7 +797,7 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
                                                                st_min=st_min)
             packets_records.append(self.send_packet(fc_packet))
             if flow_status == CanFlowStatus.Overflow:
-                raise OverflowError("Flow Control with Flow Status `OVERFLOW` was transmitted.")
+                raise CanOverflowFlowStatus("Flow Control with Flow Status `OVERFLOW` was transmitted.")
             if flow_status == CanFlowStatus.ContinueToSend:
                 remaining_data_length = message_data_length - received_data_length
                 cf_block = self._receive_cf_packets_block(sequence_number=sequence_number,
@@ -815,8 +826,8 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
         :param loop: An asyncio event loop used for observing messages.
 
         :raise TimeoutError: :ref:`N_Cr <knowledge-base-can-n-cr>` timeout was reached.
-        :raise OverflowError: Flow Control packet with :ref:`Flow Status <knowledge-base-can-flow-status>` equal to
-            OVERFLOW was sent.
+        :raise CanOverflowFlowStatus: Flow Control packet with :ref:`Flow Status <knowledge-base-can-flow-status>`
+            equal to OVERFLOW was sent.
         :raise NotImplementedError: Unhandled CAN packet starting a new CAN message transmission was received.
 
         :return: Record of UDS message that was formed provided First Frame and received Consecutive Frames.
@@ -855,7 +866,7 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
                                                                st_min=st_min)
             packets_records.append(await self.async_send_packet(fc_packet, loop=loop))
             if flow_status == CanFlowStatus.Overflow:
-                raise OverflowError("Flow Control with Flow Status `OVERFLOW` was transmitted.")
+                raise CanOverflowFlowStatus("Flow Control with Flow Status `OVERFLOW` was transmitted.")
             if flow_status == CanFlowStatus.ContinueToSend:
                 remaining_data_length = message_data_length - received_data_length
                 cf_block = await self._async_receive_cf_packets_block(sequence_number=sequence_number,
@@ -1015,7 +1026,8 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
 
         :param message: A message to send.
 
-        :raise OverflowError: Flow Control packet with Flow Status equal to OVERFLOW was received.
+        :raise CanOverflowFlowStatus: Flow Control packet with
+            :ref:`Flow Status <knowledge-base-can-flow-status>` equal to OVERFLOW was received.
         :raise NotImplementedError: Flow Control CAN packet with unknown Flow Status was received.
 
         :return: Record with historic information about transmitted UDS message.
@@ -1042,7 +1054,7 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
             elif flow_control_record.flow_status == CanFlowStatus.Wait:
                 continue
             elif flow_control_record.flow_status == CanFlowStatus.Overflow:
-                raise OverflowError("Flow Control with Flow Status `OVERFLOW` was received.")
+                raise CanOverflowFlowStatus("Flow Control with Flow Status `OVERFLOW` was received.")
             else:
                 raise NotImplementedError(f"Unknown Flow Status received: {flow_control_record.flow_status}")
         message_records = UdsMessageRecord(packet_records)
@@ -1058,7 +1070,8 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
         :param message: A message to send.
         :param loop: An asyncio event loop to use for scheduling this task.
 
-        :raise OverflowError: Flow Control packet with Flow Status equal to OVERFLOW was received.
+        :raise CanOverflowFlowStatus: Flow Control packet with
+            :ref:`Flow Status <knowledge-base-can-flow-status>` equal to OVERFLOW was received.
         :raise NotImplementedError: Flow Control CAN packet with unknown Flow Status was received.
 
         :return: Record with historic information about transmitted UDS message.
@@ -1087,7 +1100,7 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
             elif flow_control_record.flow_status == CanFlowStatus.Wait:
                 continue
             elif flow_control_record.flow_status == CanFlowStatus.Overflow:
-                raise OverflowError("Flow Control with Flow Status `OVERFLOW` was received.")
+                raise CanOverflowFlowStatus("Flow Control with Flow Status `OVERFLOW` was received.")
             else:
                 raise NotImplementedError(f"Unknown Flow Status received: {flow_control_record.flow_status}")
         message_records = UdsMessageRecord(packet_records)

--- a/uds/can/transport_interface/common.py
+++ b/uds/can/transport_interface/common.py
@@ -684,7 +684,7 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
                     received_payload_size += len(received_packet.payload)  # type: ignore
                     sequence_number = (received_packet.sequence_number + 1) & 0xF
                 else:
-                    raise CanUnexpectedSequenceNumber(f"Consecutive Frame with Sequence Number out of range received. "
+                    raise CanUnexpectedSequenceNumber(f"Consecutive Frame with Sequence Number out of order received. "
                                                       f"Expected: 0x{sequence_number:X}. "
                                                       f"Received: 0x{received_packet.sequence_number:X}.")
         return tuple(received_cf)
@@ -746,7 +746,7 @@ class AbstractCanTransportInterface(AbstractTransportInterface, ABC):
                     received_payload_size += len(received_packet.payload)  # type: ignore
                     sequence_number = (received_packet.sequence_number + 1) & 0xF
                 else:
-                    raise CanUnexpectedSequenceNumber(f"Consecutive Frame with Sequence Number out of range received. "
+                    raise CanUnexpectedSequenceNumber(f"Consecutive Frame with Sequence Number out of order received. "
                                                       f"Expected: 0x{sequence_number:X}. "
                                                       f"Received: 0x{received_packet.sequence_number:X}.")
         return tuple(received_cf)


### PR DESCRIPTION
# Description
<!--- Describe your changes -->
- define CAN specific exceptions
- raise an exception when CAN Consecutive Frame with Sequence Number out of order is received


# How Has This Been Tested?
<!--- Please shortly describe how you tested your code. -->
- new unit tests defined


# Process
<!--- If you are familiar with the process, leave the line below. If not, please describe what you did, so we could help you deliver your changed according to our quality policies -->
I know the [process](https://github.com/mdabrowski1990/uds/wiki/Software-Development-Life-Cycle) and did my best to follow it
